### PR TITLE
remove enuc from Reactions_Type

### DIFF
--- a/Source/Castro_react.cpp
+++ b/Source/Castro_react.cpp
@@ -256,7 +256,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, const iMultiFab& mask, MultiFab& w
 
     if (verbose) {
 
-	Real e_added = r.sum(NumSpec + 1);
+	Real e_added = r.sum(NumSpec);
 
 	if (ParallelDescriptor::IOProcessor() && e_added != 0.0)
 	    std::cout << "... (rho e) added from burning: " << e_added << std::endl;

--- a/Source/Castro_setup.cpp
+++ b/Source/Castro_setup.cpp
@@ -374,11 +374,10 @@ Castro::variableSetUp ()
 
 #ifdef REACTIONS
   // Components 0:Numspec-1         are      omegadot_i
-  // Component    NumSpec            is      enuc =      (eout-ein)
-  // Component    NumSpec+1          is  rho_enuc= rho * (eout-ein)
+  // Component    NumSpec            is      rho_enuc = rho * (eout-ein)
   store_in_checkpoint = true;
   desc_lst.addDescriptor(Reactions_Type,IndexType::TheCellType(),
-			 StateDescriptor::Point,0,NumSpec+2,
+			 StateDescriptor::Point,0,NumSpec+1,
 			 &cell_cons_interp,state_data_extrap,store_in_checkpoint);
 #endif
 
@@ -534,8 +533,7 @@ Castro::variableSetUp ()
       name_react = "omegadot_" + spec_names[i];
       desc_lst.setComponent(Reactions_Type, i, name_react, bc,BndryFunc(ca_reactfill));
     }
-  desc_lst.setComponent(Reactions_Type, NumSpec  , "enuc", bc, BndryFunc(ca_reactfill));
-  desc_lst.setComponent(Reactions_Type, NumSpec+1, "rho_enuc", bc, BndryFunc(ca_reactfill));
+  desc_lst.setComponent(Reactions_Type, NumSpec  , "rho_enuc", bc, BndryFunc(ca_reactfill));
 #endif
 
 #ifdef SDC

--- a/Source/Src_nd/React_nd.F90
+++ b/Source/Src_nd/React_nd.F90
@@ -43,7 +43,7 @@ contains
     integer          :: w_lo(3), w_hi(3)
     integer          :: m_lo(3), m_hi(3)
     real(rt)         :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
-    real(rt)         :: reactions(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec+2)
+    real(rt)         :: reactions(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec+1)
     real(rt)         :: weights(w_lo(1):w_hi(1),w_lo(2):w_hi(2),w_lo(3):w_hi(3))
     integer          :: mask(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3))
     real(rt)         :: time, dt_react
@@ -178,8 +178,7 @@ contains
                 do n = 1, nspec
                    reactions(i,j,k,n) = (burn_state_out % xn(n) - burn_state_in % xn(n)) / dt_react
                 enddo
-                reactions(i,j,k,nspec+1) = delta_e / dt_react
-                reactions(i,j,k,nspec+2) = delta_rho_e / dt_react
+                reactions(i,j,k,nspec+1) = delta_rho_e / dt_react
 
              endif
 
@@ -238,7 +237,7 @@ contains
     real(rt)         :: uold(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),NVAR)
     real(rt)         :: unew(un_lo(1):un_hi(1),un_lo(2):un_hi(2),un_lo(3):un_hi(3),NVAR)
     real(rt)         :: asrc(as_lo(1):as_hi(1),as_lo(2):as_hi(2),as_lo(3):as_hi(3),NVAR)
-    real(rt)         :: reactions(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec+2)
+    real(rt)         :: reactions(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec+1)
     integer          :: mask(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3))
     real(rt)         :: time, dt_react
 
@@ -334,8 +333,7 @@ contains
                 do n = 1, nspec
                    reactions(i,j,k,n) = (unew(i,j,k,UFS+n-1) * rhoninv - uold(i,j,k,UFS+n-1) * rhooinv) / dt_react
                 enddo
-                reactions(i,j,k,nspec+1) = (unew(i,j,k,UEINT) * rhonInv - uold(i,j,k,UEINT) * rhooInv) / dt_react
-                reactions(i,j,k,nspec+2) = (unew(i,j,k,UEINT) - uold(i,j,k,UEINT)) / dt_react
+                reactions(i,j,k,nspec+1) = (unew(i,j,k,UEINT) - uold(i,j,k,UEINT)) / dt_react
 
              endif
 

--- a/Source/Src_nd/timestep.F90
+++ b/Source/Src_nd/timestep.F90
@@ -126,8 +126,8 @@ contains
     integer          :: lo(3), hi(3)
     real(rt)         :: sold(so_lo(1):so_hi(1),so_lo(2):so_hi(2),so_lo(3):so_hi(3),NVAR)
     real(rt)         :: snew(sn_lo(1):sn_hi(1),sn_lo(2):sn_hi(2),sn_lo(3):sn_hi(3),NVAR)
-    real(rt)         :: rold(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),nspec+2)
-    real(rt)         :: rnew(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),nspec+2)
+    real(rt)         :: rold(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),nspec+1)
+    real(rt)         :: rnew(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),nspec+1)
     real(rt)         :: dx(3), dt, dt_old
 
     real(rt)         :: e, X(nspec), dedt, dXdt(nspec)
@@ -429,8 +429,8 @@ contains
     real(rt)         :: s_old(so_lo(1):so_hi(1),so_lo(2):so_hi(2),so_lo(3):so_hi(3),NVAR)
     real(rt)         :: s_new(sn_lo(1):sn_hi(1),sn_lo(2):sn_hi(2),sn_lo(3):sn_hi(3),NVAR)
 #ifdef REACTIONS
-    real(rt)         :: r_old(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),nspec+2)
-    real(rt)         :: r_new(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),nspec+2)
+    real(rt)         :: r_old(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),nspec+1)
+    real(rt)         :: r_new(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),nspec+1)
 #endif
     real(rt)         :: dx(3), dt_old, dt_new
 


### PR DESCRIPTION
this addresses #35 -- we had both rho_enuc and enuc in the Reactions_Type statedata -- seems redundant, so we remove enuc.