### PR TITLE
Set a floor for timestep limiting due to changes in X

### DIFF
--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -302,6 +302,11 @@ dtnuc_e                      Real          1.e200             y
 # {\tt dtnuc}  $\cdot\,(X / \dot{X})$.
 dtnuc_X                      Real          1.e200             y
 
+# If we are using the timestep limiter based on changes in $X$, set a threshold
+# on the species abundance below which the limiter is not applied. This helps
+# prevent the timestep from becoming very small due to changes in trace species.
+dtnuc_X_threshold            Real          1.e-3              y
+
 # If we are doing burning timestep limiting, choose the method for
 # estimating $\dot{e}$ and $\dot{X}$.
 # 1 == call the burner's RHS for an instantaneous calculation

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -147,6 +147,7 @@ module meth_params_module
   real(rt), save :: cfl
   real(rt), save :: dtnuc_e
   real(rt), save :: dtnuc_X
+  real(rt), save :: dtnuc_X_threshold
   integer         , save :: dtnuc_mode
   real(rt), save :: dxnuc
   integer         , save :: do_react
@@ -192,16 +193,17 @@ module meth_params_module
   !$acc create(allow_small_energy, do_sponge, sponge_implicit) &
   !$acc create(first_order_hydro, hse_zero_vels, hse_interp_temp) &
   !$acc create(hse_reflect_vels, cfl, dtnuc_e) &
-  !$acc create(dtnuc_X, dtnuc_mode, dxnuc) &
-  !$acc create(do_react, react_T_min, react_T_max) &
-  !$acc create(react_rho_min, react_rho_max, disable_shock_burning) &
-  !$acc create(diffuse_cutoff_density, diffuse_cond_scale_fac, do_grav) &
-  !$acc create(grav_source_type, do_rotation, rot_period) &
-  !$acc create(rot_period_dot, rotation_include_centrifugal, rotation_include_coriolis) &
-  !$acc create(rotation_include_domegadt, state_in_rotating_frame, rot_source_type) &
-  !$acc create(implicit_rotation_update, rot_axis, point_mass) &
-  !$acc create(point_mass_fix_solution, do_acc, grown_factor) &
-  !$acc create(track_grid_losses, const_grav, get_g_from_phi)
+  !$acc create(dtnuc_X, dtnuc_X_threshold, dtnuc_mode) &
+  !$acc create(dxnuc, do_react, react_T_min) &
+  !$acc create(react_T_max, react_rho_min, react_rho_max) &
+  !$acc create(disable_shock_burning, diffuse_cutoff_density, diffuse_cond_scale_fac) &
+  !$acc create(do_grav, grav_source_type, do_rotation) &
+  !$acc create(rot_period, rot_period_dot, rotation_include_centrifugal) &
+  !$acc create(rotation_include_coriolis, rotation_include_domegadt, state_in_rotating_frame) &
+  !$acc create(rot_source_type, implicit_rotation_update, rot_axis) &
+  !$acc create(point_mass, point_mass_fix_solution, do_acc) &
+  !$acc create(grown_factor, track_grid_losses, const_grav) &
+  !$acc create(get_g_from_phi)
 
   ! End the declarations of the ParmParse parameters
 
@@ -283,6 +285,7 @@ contains
     cfl = 0.8d0;
     dtnuc_e = 1.d200;
     dtnuc_X = 1.d200;
+    dtnuc_X_threshold = 1.d-3;
     dtnuc_mode = 1;
     dxnuc = 1.d200;
     do_react = -1;
@@ -361,6 +364,7 @@ contains
     call pp%query("cfl", cfl)
     call pp%query("dtnuc_e", dtnuc_e)
     call pp%query("dtnuc_X", dtnuc_X)
+    call pp%query("dtnuc_X_threshold", dtnuc_X_threshold)
     call pp%query("dtnuc_mode", dtnuc_mode)
     call pp%query("dxnuc", dxnuc)
     call pp%query("do_react", do_react)
@@ -433,16 +437,17 @@ contains
     !$acc device(allow_small_energy, do_sponge, sponge_implicit) &
     !$acc device(first_order_hydro, hse_zero_vels, hse_interp_temp) &
     !$acc device(hse_reflect_vels, cfl, dtnuc_e) &
-    !$acc device(dtnuc_X, dtnuc_mode, dxnuc) &
-    !$acc device(do_react, react_T_min, react_T_max) &
-    !$acc device(react_rho_min, react_rho_max, disable_shock_burning) &
-    !$acc device(diffuse_cutoff_density, diffuse_cond_scale_fac, do_grav) &
-    !$acc device(grav_source_type, do_rotation, rot_period) &
-    !$acc device(rot_period_dot, rotation_include_centrifugal, rotation_include_coriolis) &
-    !$acc device(rotation_include_domegadt, state_in_rotating_frame, rot_source_type) &
-    !$acc device(implicit_rotation_update, rot_axis, point_mass) &
-    !$acc device(point_mass_fix_solution, do_acc, grown_factor) &
-    !$acc device(track_grid_losses, const_grav, get_g_from_phi)
+    !$acc device(dtnuc_X, dtnuc_X_threshold, dtnuc_mode) &
+    !$acc device(dxnuc, do_react, react_T_min) &
+    !$acc device(react_T_max, react_rho_min, react_rho_max) &
+    !$acc device(disable_shock_burning, diffuse_cutoff_density, diffuse_cond_scale_fac) &
+    !$acc device(do_grav, grav_source_type, do_rotation) &
+    !$acc device(rot_period, rot_period_dot, rotation_include_centrifugal) &
+    !$acc device(rotation_include_coriolis, rotation_include_domegadt, state_in_rotating_frame) &
+    !$acc device(rot_source_type, implicit_rotation_update, rot_axis) &
+    !$acc device(point_mass, point_mass_fix_solution, do_acc) &
+    !$acc device(grown_factor, track_grid_losses, const_grav) &
+    !$acc device(get_g_from_phi)
 
 
     ! now set the external BC flags

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -75,6 +75,7 @@ amrex::Real Castro::retry_neg_dens_factor = 1.e-1;
 int         Castro::sdc_iters = 2;
 amrex::Real Castro::dtnuc_e = 1.e200;
 amrex::Real Castro::dtnuc_X = 1.e200;
+amrex::Real Castro::dtnuc_X_threshold = 1.e-3;
 int         Castro::dtnuc_mode = 1;
 amrex::Real Castro::dxnuc = 1.e200;
 int         Castro::do_react = -1;

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -75,6 +75,7 @@ static amrex::Real retry_neg_dens_factor;
 static int sdc_iters;
 static amrex::Real dtnuc_e;
 static amrex::Real dtnuc_X;
+static amrex::Real dtnuc_X_threshold;
 static int dtnuc_mode;
 static amrex::Real dxnuc;
 static int do_react;

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -75,6 +75,7 @@ pp.query("retry_neg_dens_factor", retry_neg_dens_factor);
 pp.query("sdc_iters", sdc_iters);
 pp.query("dtnuc_e", dtnuc_e);
 pp.query("dtnuc_X", dtnuc_X);
+pp.query("dtnuc_X_threshold", dtnuc_X_threshold);
 pp.query("dtnuc_mode", dtnuc_mode);
 pp.query("dxnuc", dxnuc);
 pp.query("do_react", do_react);


### PR DESCRIPTION
The current implementation has the problem that it can drag the timestep
down to very small values due to changes in trace isotopes. Usually for
burning simulations we do not care about changes to abundances that are
very small in absolute terms. This limiter (which defaults to 1.e-3) is
the abundance below which the timestep limiter is not applied.