### PR TITLE
Use a MultiFab to store the mass fluxes during a timestep

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -619,6 +619,17 @@ protected:
     amrex::Array<std::unique_ptr<amrex::MultiFab> > rad_fluxes;
 #endif
 
+    //
+    // Temporary fluxes that only live for the length of the timestep.
+    //
+    amrex::Array<std::unique_ptr<amrex::MultiFab> > current_fluxes;
+#if (BL_SPACEDIM <= 2)
+    amrex::MultiFab         current_P_radial;
+#endif
+#ifdef RADIATION
+    amrex::Array<std::unique_ptr<amrex::MultiFab> > current_rad_fluxes;
+#endif
+
     amrex::FluxRegister flux_reg;
 #if (BL_SPACEDIM <= 2)
     amrex::FluxRegister pres_reg;

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -619,6 +619,8 @@ protected:
     amrex::Array<std::unique_ptr<amrex::MultiFab> > rad_fluxes;
 #endif
 
+    amrex::Array<std::unique_ptr<amrex::MultiFab> > mass_fluxes;
+
     amrex::FluxRegister flux_reg;
 #if (BL_SPACEDIM <= 2)
     amrex::FluxRegister pres_reg;

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -619,17 +619,6 @@ protected:
     amrex::Array<std::unique_ptr<amrex::MultiFab> > rad_fluxes;
 #endif
 
-    //
-    // Temporary fluxes that only live for the length of the timestep.
-    //
-    amrex::Array<std::unique_ptr<amrex::MultiFab> > current_fluxes;
-#if (BL_SPACEDIM <= 2)
-    amrex::MultiFab         current_P_radial;
-#endif
-#ifdef RADIATION
-    amrex::Array<std::unique_ptr<amrex::MultiFab> > current_rad_fluxes;
-#endif
-
     amrex::FluxRegister flux_reg;
 #if (BL_SPACEDIM <= 2)
     amrex::FluxRegister pres_reg;

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -2241,22 +2241,6 @@ Castro::reflux(int crse_level, int fine_level)
 
 	    reg->Reflux(crse_lev.hydro_source, crse_lev.volume, 1.0, 0, 0, NUM_STATE, crse_lev.geom);
 
-#ifdef GRAVITY
-            // Store the updated mass_fluxes for use in the gravity source term.
-
-            crse_lev.mass_fluxes.resize(3);
-
-            for (int i = 0; i < BL_SPACEDIM; ++i) {
-                crse_lev.mass_fluxes[i].reset(new MultiFab(crse_lev.getEdgeBoxArray(i), crse_lev.dmap, 1, 0));
-                MultiFab::Copy(*crse_lev.mass_fluxes[i], *crse_lev.fluxes[i], Density, 0, 1, 0);
-            }
-
-            for (int i = BL_SPACEDIM; i < 3; ++i) {
-                crse_lev.mass_fluxes[i].reset(new MultiFab(crse_lev.get_new_data(State_Type).boxArray(), crse_lev.dmap, 1, 0));
-                crse_lev.mass_fluxes[i]->setVal(0.0);
-            }
-#endif
-
 	}
 
 	// We no longer need the flux register data, so clear it out.
@@ -2389,6 +2373,22 @@ Castro::reflux(int crse_level, int fine_level)
     if (update_sources_after_reflux) {
 
 	for (int lev = fine_level; lev >= crse_level; --lev) {
+
+#ifdef GRAVITY
+            // Store the updated mass_fluxes for use in the gravity source term.
+
+            getLevel(lev).mass_fluxes.resize(3);
+
+            for (int i = 0; i < BL_SPACEDIM; ++i) {
+                getLevel(lev).mass_fluxes[i].reset(new MultiFab(getLevel(lev).getEdgeBoxArray(i), getLevel(lev).dmap, 1, 0));
+                MultiFab::Copy(*getLevel(lev).mass_fluxes[i], *getLevel(lev).fluxes[i], Density, 0, 1, 0);
+            }
+
+            for (int i = BL_SPACEDIM; i < 3; ++i) {
+                getLevel(lev).mass_fluxes[i].reset(new MultiFab(getLevel(lev).get_new_data(State_Type).boxArray(), getLevel(lev).dmap, 1, 0));
+                getLevel(lev).mass_fluxes[i]->setVal(0.0);
+            }
+#endif
 
 	    MultiFab& S_new = getLevel(lev).get_new_data(State_Type);
 	    Real time = getLevel(lev).state[State_Type].curTime();

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -606,6 +606,18 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
 	    rad_fluxes[dir]->setVal(0.0);
 #endif
 
+    mass_fluxes.resize(3);
+
+    for (int dir = 0; dir < BL_SPACEDIM; ++dir) {
+	mass_fluxes[dir].reset(new MultiFab(getEdgeBoxArray(dir), dmap, 1, 0));
+        mass_fluxes[dir]->setVal(0.0);
+    }
+
+    for (int dir = BL_SPACEDIM; dir < 3; ++dir) {
+	mass_fluxes[dir].reset(new MultiFab(get_new_data(State_Type).boxArray(), dmap, 1, 0));
+        mass_fluxes[dir]->setVal(0.0);
+    }
+
 }
 
 
@@ -649,6 +661,9 @@ Castro::finalize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
       k_mol.clear();
       Sburn.clear();
     }
+
+    for (int dir = 0; dir < 3; ++dir)
+	mass_fluxes[dir].reset();
 
 }
 
@@ -793,6 +808,11 @@ Castro::retry_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
 	  state[k].setTimeLevel(time, 0.0, 0.0);
 
 	}
+
+#ifdef SELF_GRAVITY
+        if (do_grav)
+            gravity->swapTimeLevels(level);
+#endif
 
 	if (track_grid_losses)
 	  for (int i = 0; i < n_lost; i++)

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -590,7 +590,7 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
       Sburn.define(grids, dmap, NUM_STATE, 0);
     }
 
-    // Zero out the current fluxes.
+    // Zero out the stored and current fluxes.
 
     for (int dir = 0; dir < 3; ++dir)
 	fluxes[dir]->setVal(0.0);
@@ -604,6 +604,42 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
     if (Radiation::rad_hydro_combined)
 	for (int dir = 0; dir < BL_SPACEDIM; ++dir)
 	    rad_fluxes[dir]->setVal(0.0);
+#endif
+
+    current_fluxes.resize(3);
+
+    for (int dir = 0; dir < BL_SPACEDIM; ++dir)
+	current_fluxes[dir].reset(new MultiFab(getEdgeBoxArray(dir), dmap, NUM_STATE, 0));
+
+    for (int dir = BL_SPACEDIM; dir < 3; ++dir)
+	current_fluxes[dir].reset(new MultiFab(get_new_data(State_Type).boxArray(), dmap, NUM_STATE, 0));
+
+#if (BL_SPACEDIM <= 2)
+    if (!Geometry::IsCartesian())
+	current_P_radial.define(getEdgeBoxArray(0), dmap, 1, 0);
+#endif
+
+#ifdef RADIATION
+    if (Radiation::rad_hydro_combined) {
+	current_rad_fluxes.resize(BL_SPACEDIM);
+        for (int dir = 0; dir < BL_SPACEDIM; ++dir) {
+	    current_rad_fluxes[dir].reset(new MultiFab(getEdgeBoxArray(dir), dmap, Radiation::nGroups, 0));
+	}
+    }
+#endif
+
+    for (int dir = 0; dir < 3; ++dir)
+	current_fluxes[dir]->setVal(0.0);
+
+#if (BL_SPACEDIM <= 2)
+    if (!Geometry::IsCartesian())
+	current_P_radial.setVal(0.0);
+#endif
+
+#ifdef RADIATION
+    if (Radiation::rad_hydro_combined)
+	for (int dir = 0; dir < BL_SPACEDIM; ++dir)
+	    current_rad_fluxes[dir]->setVal(0.0);
 #endif
 
 }
@@ -649,6 +685,22 @@ Castro::finalize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
       k_mol.clear();
       Sburn.clear();
     }
+
+    for (int dir = 0; dir < 3; ++dir)
+	current_fluxes[dir].reset();
+
+#if (BL_SPACEDIM <= 2)
+    if (!Geometry::IsCartesian())
+	current_P_radial.clear();
+#endif
+
+#ifdef RADIATION
+    if (Radiation::rad_hydro_combined) {
+        for (int dir = 0; dir < BL_SPACEDIM; ++dir) {
+	    current_rad_fluxes[dir].reset();
+	}
+    }
+#endif
 
 }
 
@@ -793,6 +845,11 @@ Castro::retry_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
 	  state[k].setTimeLevel(time, 0.0, 0.0);
 
 	}
+
+#ifdef SELF_GRAVITY
+        if (do_grav)
+            gravity->swapTimeLevels(level);
+#endif
 
 	if (track_grid_losses)
 	  for (int i = 0; i < n_lost; i++)

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -590,7 +590,7 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
       Sburn.define(grids, dmap, NUM_STATE, 0);
     }
 
-    // Zero out the stored and current fluxes.
+    // Zero out the current fluxes.
 
     for (int dir = 0; dir < 3; ++dir)
 	fluxes[dir]->setVal(0.0);
@@ -604,42 +604,6 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
     if (Radiation::rad_hydro_combined)
 	for (int dir = 0; dir < BL_SPACEDIM; ++dir)
 	    rad_fluxes[dir]->setVal(0.0);
-#endif
-
-    current_fluxes.resize(3);
-
-    for (int dir = 0; dir < BL_SPACEDIM; ++dir)
-	current_fluxes[dir].reset(new MultiFab(getEdgeBoxArray(dir), dmap, NUM_STATE, 0));
-
-    for (int dir = BL_SPACEDIM; dir < 3; ++dir)
-	current_fluxes[dir].reset(new MultiFab(get_new_data(State_Type).boxArray(), dmap, NUM_STATE, 0));
-
-#if (BL_SPACEDIM <= 2)
-    if (!Geometry::IsCartesian())
-	current_P_radial.define(getEdgeBoxArray(0), dmap, 1, 0);
-#endif
-
-#ifdef RADIATION
-    if (Radiation::rad_hydro_combined) {
-	current_rad_fluxes.resize(BL_SPACEDIM);
-        for (int dir = 0; dir < BL_SPACEDIM; ++dir) {
-	    current_rad_fluxes[dir].reset(new MultiFab(getEdgeBoxArray(dir), dmap, Radiation::nGroups, 0));
-	}
-    }
-#endif
-
-    for (int dir = 0; dir < 3; ++dir)
-	current_fluxes[dir]->setVal(0.0);
-
-#if (BL_SPACEDIM <= 2)
-    if (!Geometry::IsCartesian())
-	current_P_radial.setVal(0.0);
-#endif
-
-#ifdef RADIATION
-    if (Radiation::rad_hydro_combined)
-	for (int dir = 0; dir < BL_SPACEDIM; ++dir)
-	    current_rad_fluxes[dir]->setVal(0.0);
 #endif
 
 }
@@ -685,22 +649,6 @@ Castro::finalize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
       k_mol.clear();
       Sburn.clear();
     }
-
-    for (int dir = 0; dir < 3; ++dir)
-	current_fluxes[dir].reset();
-
-#if (BL_SPACEDIM <= 2)
-    if (!Geometry::IsCartesian())
-	current_P_radial.clear();
-#endif
-
-#ifdef RADIATION
-    if (Radiation::rad_hydro_combined) {
-        for (int dir = 0; dir < BL_SPACEDIM; ++dir) {
-	    current_rad_fluxes[dir].reset();
-	}
-    }
-#endif
 
 }
 
@@ -845,11 +793,6 @@ Castro::retry_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
 	  state[k].setTimeLevel(time, 0.0, 0.0);
 
 	}
-
-#ifdef SELF_GRAVITY
-        if (do_grav)
-            gravity->swapTimeLevels(level);
-#endif
 
 	if (track_grid_losses)
 	  for (int i = 0; i < n_lost; i++)

--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -302,9 +302,9 @@ void Castro::construct_new_gravity_source(Real time, Real dt)
 			BL_TO_FORTRAN_3D(grav_new[mfi]),
 #endif
 			BL_TO_FORTRAN_3D(volume[mfi]),
-			BL_TO_FORTRAN_3D((*current_fluxes[0])[mfi]),
-			BL_TO_FORTRAN_3D((*current_fluxes[1])[mfi]),
-			BL_TO_FORTRAN_3D((*current_fluxes[2])[mfi]),
+			BL_TO_FORTRAN_3D((*fluxes[0])[mfi]),
+			BL_TO_FORTRAN_3D((*fluxes[1])[mfi]),
+			BL_TO_FORTRAN_3D((*fluxes[2])[mfi]),
 			BL_TO_FORTRAN_3D((*new_sources[grav_src])[mfi]),
 			ZFILL(dx),dt,&time);
 

--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -302,9 +302,9 @@ void Castro::construct_new_gravity_source(Real time, Real dt)
 			BL_TO_FORTRAN_3D(grav_new[mfi]),
 #endif
 			BL_TO_FORTRAN_3D(volume[mfi]),
-			BL_TO_FORTRAN_3D((*fluxes[0])[mfi]),
-			BL_TO_FORTRAN_3D((*fluxes[1])[mfi]),
-			BL_TO_FORTRAN_3D((*fluxes[2])[mfi]),
+			BL_TO_FORTRAN_3D((*current_fluxes[0])[mfi]),
+			BL_TO_FORTRAN_3D((*current_fluxes[1])[mfi]),
+			BL_TO_FORTRAN_3D((*current_fluxes[2])[mfi]),
 			BL_TO_FORTRAN_3D((*new_sources[grav_src])[mfi]),
 			ZFILL(dx),dt,&time);
 

--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -302,9 +302,9 @@ void Castro::construct_new_gravity_source(Real time, Real dt)
 			BL_TO_FORTRAN_3D(grav_new[mfi]),
 #endif
 			BL_TO_FORTRAN_3D(volume[mfi]),
-			BL_TO_FORTRAN_3D((*fluxes[0])[mfi]),
-			BL_TO_FORTRAN_3D((*fluxes[1])[mfi]),
-			BL_TO_FORTRAN_3D((*fluxes[2])[mfi]),
+			BL_TO_FORTRAN_3D((*mass_fluxes[0])[mfi]),
+			BL_TO_FORTRAN_3D((*mass_fluxes[1])[mfi]),
+			BL_TO_FORTRAN_3D((*mass_fluxes[2])[mfi]),
 			BL_TO_FORTRAN_3D((*new_sources[grav_src])[mfi]),
 			ZFILL(dx),dt,&time);
 

--- a/Source/gravity/gravity_sources_nd.F90
+++ b/Source/gravity/gravity_sources_nd.F90
@@ -235,11 +235,11 @@ contains
 
     real(rt), intent(in)    :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
 
-    ! Hydrodynamics fluxes
+    ! Hydrodynamical mass fluxes
 
-    real(rt), intent(in)    :: flux1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3),NVAR)
-    real(rt), intent(in)    :: flux2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3),NVAR)
-    real(rt), intent(in)    :: flux3(f3_lo(1):f3_hi(1),f3_lo(2):f3_hi(2),f3_lo(3):f3_hi(3),NVAR)
+    real(rt), intent(in)    :: flux1(f1_lo(1):f1_hi(1),f1_lo(2):f1_hi(2),f1_lo(3):f1_hi(3))
+    real(rt), intent(in)    :: flux2(f2_lo(1):f2_hi(1),f2_lo(2):f2_hi(2),f2_lo(3):f2_hi(3))
+    real(rt), intent(in)    :: flux3(f3_lo(1):f3_hi(1),f3_lo(2):f3_hi(2),f3_lo(3):f3_hi(3))
 
     ! The source term to send back
 
@@ -482,12 +482,12 @@ contains
 #ifdef SELF_GRAVITY
                 if (gravity_type == "PoissonGrav" .or. (gravity_type == "MonopoleGrav" .and. get_g_from_phi == 1) ) then
 
-                   SrEcorr = SrEcorr + (ONE / dt) * ((flux1(i        ,j,k,URHO) * HALF * (phi(i-1,j,k) + phi(i,j,k)) - &
-                                                      flux1(i+1*dg(1),j,k,URHO) * HALF * (phi(i+1,j,k) + phi(i,j,k)) + &
-                                                      flux2(i,j        ,k,URHO) * HALF * (phi(i,j-1,k) + phi(i,j,k)) - &
-                                                      flux2(i,j+1*dg(2),k,URHO) * HALF * (phi(i,j+1,k) + phi(i,j,k)) + &
-                                                      flux3(i,j,k        ,URHO) * HALF * (phi(i,j,k-1) + phi(i,j,k)) - &
-                                                      flux3(i,j,k+1*dg(3),URHO) * HALF * (phi(i,j,k+1) + phi(i,j,k))) / vol(i,j,k) - &
+                   SrEcorr = SrEcorr + (ONE / dt) * ((flux1(i        ,j,k) * HALF * (phi(i-1,j,k) + phi(i,j,k)) - &
+                                                      flux1(i+1*dg(1),j,k) * HALF * (phi(i+1,j,k) + phi(i,j,k)) + &
+                                                      flux2(i,j        ,k) * HALF * (phi(i,j-1,k) + phi(i,j,k)) - &
+                                                      flux2(i,j+1*dg(2),k) * HALF * (phi(i,j+1,k) + phi(i,j,k)) + &
+                                                      flux3(i,j,k        ) * HALF * (phi(i,j,k-1) + phi(i,j,k)) - &
+                                                      flux3(i,j,k+1*dg(3)) * HALF * (phi(i,j,k+1) + phi(i,j,k))) / vol(i,j,k) - &
                                                       (rhon - rhoo) * phi(i,j,k))
 
                 else
@@ -497,26 +497,26 @@ contains
                    ! gravitational acceleration. It relies on the concept that, to second order,
                    ! g_{i+1/2} = -( phi_{i+1} - phi_{i} ) / dx.
 
-                   SrEcorr = SrEcorr + hdtInv * ( flux1(i        ,j,k,URHO) * gravx(i  ,j,k) * dx(1) + &
-                                                  flux1(i+1*dg(1),j,k,URHO) * gravx(i+1,j,k) * dx(1) + &
-                                                  flux2(i,j        ,k,URHO) * gravy(i,j  ,k) * dx(2) + &
-                                                  flux2(i,j+1*dg(2),k,URHO) * gravy(i,j+1,k) * dx(2) + &
-                                                  flux3(i,j,k        ,URHO) * gravz(i,j,k  ) * dx(3) + &
-                                                  flux3(i,j,k+1*dg(3),URHO) * gravz(i,j,k+1) * dx(3) ) / vol(i,j,k)
+                   SrEcorr = SrEcorr + hdtInv * ( flux1(i        ,j,k) * gravx(i  ,j,k) * dx(1) + &
+                                                  flux1(i+1*dg(1),j,k) * gravx(i+1,j,k) * dx(1) + &
+                                                  flux2(i,j        ,k) * gravy(i,j  ,k) * dx(2) + &
+                                                  flux2(i,j+1*dg(2),k) * gravy(i,j+1,k) * dx(2) + &
+                                                  flux3(i,j,k        ) * gravz(i,j,k  ) * dx(3) + &
+                                                  flux3(i,j,k+1*dg(3)) * gravz(i,j,k+1) * dx(3) ) / vol(i,j,k)
 
                 endif
 #else
                 ! For constant gravity, the only contribution is from the dimension that the gravity points in.
 
                 if (dim .eq. 1) then
-                   SrEcorr = SrEcorr + (HALF / dt) * ( flux1(i        ,j,k,URHO) * const_grav * dx(1) + &
-                                                       flux1(i+1*dg(1),j,k,URHO) * const_grav * dx(1) ) / vol(i,j,k)
+                   SrEcorr = SrEcorr + (HALF / dt) * ( flux1(i        ,j,k) * const_grav * dx(1) + &
+                                                       flux1(i+1*dg(1),j,k) * const_grav * dx(1) ) / vol(i,j,k)
                 else if (dim .eq. 2) then
-                   SrEcorr = SrEcorr + (HALF / dt) * ( flux2(i,j        ,k,URHO) * const_grav * dx(2) + &
-                                                       flux2(i,j+1*dg(2),k,URHO) * const_grav * dx(2) ) / vol(i,j,k) 
+                   SrEcorr = SrEcorr + (HALF / dt) * ( flux2(i,j        ,k) * const_grav * dx(2) + &
+                                                       flux2(i,j+1*dg(2),k) * const_grav * dx(2) ) / vol(i,j,k)
                 else if (dim .eq. 3) then
-                   SrEcorr = SrEcorr + (HALF / dt) * ( flux3(i,j,k        ,URHO) * const_grav * dx(3) + &
-                                                       flux3(i,j,k+1*dg(3),URHO) * const_grav * dx(3) ) / vol(i,j,k)
+                   SrEcorr = SrEcorr + (HALF / dt) * ( flux3(i,j,k        ) * const_grav * dx(3) + &
+                                                       flux3(i,j,k+1*dg(3)) * const_grav * dx(3) ) / vol(i,j,k)
                 end if
 #endif
 

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -112,13 +112,6 @@ Castro::construct_hydro_source(Real time, Real dt)
 #endif
     {
 
-      FArrayBox flux[BL_SPACEDIM];
-#if (BL_SPACEDIM <= 2)
-      FArrayBox pradial(Box::TheUnitBox(),1);
-#endif
-#ifdef RADIATION
-      FArrayBox rad_flux[BL_SPACEDIM];
-#endif
       FArrayBox q, qaux, src_q;
 
       int priv_nstep_fsp = -1;
@@ -188,20 +181,6 @@ Castro::construct_hydro_source(Real time, Real dt)
 #endif
 #endif
 #endif
-	  // Allocate fabs for fluxes
-	  for (int i = 0; i < BL_SPACEDIM ; i++)  {
-	    const Box& bxtmp = amrex::surroundingNodes(bx,i);
-	    flux[i].resize(bxtmp,NUM_STATE);
-#ifdef RADIATION
-	    rad_flux[i].resize(bxtmp,Radiation::nGroups);
-#endif
-	  }
-
-#if (BL_SPACEDIM <= 2)
-	  if (!Geometry::IsCartesian()) {
-	    pradial.resize(amrex::surroundingNodes(bx,0),1);
-	  }
-#endif
 
 	  ca_ctu_update
 	    (&is_finest_level, &time,
@@ -217,16 +196,16 @@ Castro::construct_hydro_source(Real time, Real dt)
 	     BL_TO_FORTRAN_3D(src_q),
 	     BL_TO_FORTRAN_3D(source_out),
 	     dx, &dt,
-	     D_DECL(BL_TO_FORTRAN_3D(flux[0]),
-		    BL_TO_FORTRAN_3D(flux[1]),
-		    BL_TO_FORTRAN_3D(flux[2])),
+	     D_DECL(BL_TO_FORTRAN_3D((*current_fluxes[0])[mfi]),
+		    BL_TO_FORTRAN_3D((*current_fluxes[1])[mfi]),
+		    BL_TO_FORTRAN_3D((*current_fluxes[2])[mfi])),
 #ifdef RADIATION
-	     D_DECL(BL_TO_FORTRAN_3D(rad_flux[0]),
-		    BL_TO_FORTRAN_3D(rad_flux[1]),
-		    BL_TO_FORTRAN_3D(rad_flux[2])),
+	     D_DECL(BL_TO_FORTRAN_3D((*current_rad_fluxes[0])[mfi]),
+		    BL_TO_FORTRAN_3D((*current_rad_fluxes[1])[mfi]),
+		    BL_TO_FORTRAN_3D((*current_rad_fluxes[2])[mfi])),
 #endif
 #if (BL_SPACEDIM < 3)
-	     BL_TO_FORTRAN_3D(pradial),
+	     BL_TO_FORTRAN_3D(current_P_radial[mfi]),
 #endif
 	     D_DECL(BL_TO_FORTRAN_3D(area[0][mfi]),
 		    BL_TO_FORTRAN_3D(area[1][mfi]),
@@ -250,14 +229,14 @@ Castro::construct_hydro_source(Real time, Real dt)
 
 	  for (int i = 0; i < BL_SPACEDIM ; i++) {
 #ifndef SDC
-	    (*fluxes    [i])[mfi].plus(    flux[i],mfi.nodaltilebox(i),0,0,NUM_STATE);
+	    (*fluxes    [i])[mfi].plus((*    current_fluxes[i])[mfi],mfi.nodaltilebox(i),0,0,NUM_STATE);
 #ifdef RADIATION
-	    (*rad_fluxes[i])[mfi].plus(rad_flux[i],mfi.nodaltilebox(i),0,0,Radiation::nGroups);
+	    (*rad_fluxes[i])[mfi].plus((*current_rad_fluxes[i])[mfi],mfi.nodaltilebox(i),0,0,Radiation::nGroups);
 #endif
 #else
-	    (*fluxes    [i])[mfi].copy(    flux[i],mfi.nodaltilebox(i),0,mfi.nodaltilebox(i),0,NUM_STATE);
+	    (*fluxes    [i])[mfi].copy((*    current_fluxes[i])[mfi],mfi.nodaltilebox(i),0,mfi.nodaltilebox(i),0,NUM_STATE);
 #ifdef RADIATION
-	    (*rad_fluxes[i])[mfi].copy(rad_flux[i],mfi.nodaltilebox(i),0,mfi.nodaltilebox(i),0,Radiation::nGroups);
+	    (*rad_fluxes[i])[mfi].copy((*current_rad_fluxes[i])[mfi],mfi.nodaltilebox(i),0,mfi.nodaltilebox(i),0,Radiation::nGroups);
 #endif	    
 #endif
 	  }
@@ -265,9 +244,9 @@ Castro::construct_hydro_source(Real time, Real dt)
 #if (BL_SPACEDIM <= 2)
 	  if (!Geometry::IsCartesian()) {
 #ifndef SDC
-	    P_radial[mfi].plus(pradial,mfi.nodaltilebox(0),0,0,1);
+	    P_radial[mfi].plus(current_P_radial[mfi],mfi.nodaltilebox(0),0,0,1);
 #else
-	    P_radial[mfi].copy(pradial,mfi.nodaltilebox(0),0,mfi.nodaltilebox(0),0,1);
+	    P_radial[mfi].copy(current_P_radial[mfi],mfi.nodaltilebox(0),0,mfi.nodaltilebox(0),0,1);
 #endif
 	  }
 #endif

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -260,6 +260,7 @@ Castro::construct_hydro_source(Real time, Real dt)
 	    (*rad_fluxes[i])[mfi].copy(rad_flux[i],mfi.nodaltilebox(i),0,mfi.nodaltilebox(i),0,Radiation::nGroups);
 #endif	    
 #endif
+            (*mass_fluxes[i])[mfi].copy(flux[i],mfi.nodaltilebox(i),Density,mfi.nodaltilebox(i),0,1);
 	  }
 
 #if (BL_SPACEDIM <= 2)


### PR DESCRIPTION
The fluxes MultiFab holds this data normally when no subcycles occur.
But when subcycles occur, the fluxes MultiFab is intended to hold the
sum of the fluxes over all of the subcycles -- this is important for
getting refluxing right with AMR. But this introduces a problem because
the gravity source term references the fluxes MultiFab. A new MultiFab,
mass_fluxes, has been introduced and it stores the density hydro flux only
for a single timestep or subcycle.

Fixes #178