### PR TITLE
Use a standalone BC fill for sources StateData

### DIFF
--- a/Source/driver/Castro_F.H
+++ b/Source/driver/Castro_F.H
@@ -191,6 +191,18 @@ extern "C"
     (const int* lo, const int* hi, BL_FORT_FAB_ARG_3D(S_new),
      const int& verbose, const int* idx);
 
+  void ca_generic_single_fill
+    (BL_FORT_FAB_ARG_3D(state),
+     const int* dlo, const int* dhi,
+     const amrex::Real* dx, const amrex::Real* glo, 
+     const amrex::Real* time, const int* bc);
+
+  void ca_generic_multi_fill
+    (BL_FORT_FAB_ARG_3D(state),
+     const int* dlo, const int* dhi,
+     const amrex::Real* dx, const amrex::Real* glo, 
+     const amrex::Real* time, const int* bc);
+
 #ifdef DIMENSION_AGNOSTIC
 
   void ca_hypfill

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -520,7 +520,8 @@ Castro::variableSetUp ()
   for (int i = 0; i < NUM_STATE; i++)
     state_type_source_names[i] = name[i] + "_source";
 
-  desc_lst.setComponent(Source_Type,Density,state_type_source_names,bcs,BndryFunc(ca_denfill,ca_hypfill));
+  desc_lst.setComponent(Source_Type,Density,state_type_source_names,bcs,
+                        BndryFunc(ca_generic_single_fill,ca_generic_multi_fill));
 
 #ifdef REACTIONS
   std::string name_react;
@@ -537,13 +538,14 @@ Castro::variableSetUp ()
 #ifdef SDC
   for (int i = 0; i < NUM_STATE; ++i)
       state_type_source_names[i] = "sdc_sources_" + name[i];
-  desc_lst.setComponent(SDC_Source_Type,Density,state_type_source_names,bcs,BndryFunc(ca_denfill,ca_hypfill));
+  desc_lst.setComponent(SDC_Source_Type,Density,state_type_source_names,bcs,
+                        BndryFunc(ca_generic_single_fill,ca_generic_multi_fill));
 #ifdef REACTIONS
   for (int i = 0; i < QVAR; ++i) {
       char buf[64];
       sprintf(buf, "sdc_react_source_%d", i);
       set_scalar_bc(bc,phys_bc);
-      desc_lst.setComponent(SDC_React_Type,i,std::string(buf),bc,BndryFunc(ca_denfill));
+      desc_lst.setComponent(SDC_React_Type,i,std::string(buf),bc,BndryFunc(ca_generic_single_fill));
   }
 #endif
 #endif

--- a/Source/driver/Make.package
+++ b/Source/driver/Make.package
@@ -24,6 +24,8 @@ FEXE_headers += Castro_F.H
 FEXE_headers += Castro_error_F.H
 FEXE_headers += Derive_F.H
 
+ca_F90EXE_sources += generic_fill.F90
+
 ca_F90EXE_sources += castro_c_interfaces_nd.F90
 ifeq ($(USE_CUDA), TRUE)
   ca_F90EXE_sources += castro_cuda_interfaces_nd.F90

--- a/Source/driver/generic_fill.F90
+++ b/Source/driver/generic_fill.F90
@@ -1,0 +1,55 @@
+module generic_fill_module
+
+  implicit none
+
+contains
+
+  ! Used for a generic fill of any StateData.
+
+  subroutine ca_generic_single_fill(state, s_lo, s_hi, &
+                                    domlo, domhi, delta, xlo, time, bc) &
+                                    bind(C, name="ca_generic_single_fill")
+
+    use amrex_fort_module, only: rt => amrex_real
+    use prob_params_module, only: dim
+
+    implicit none
+
+    integer,  intent(in   ) :: s_lo(3), s_hi(3)
+    integer,  intent(in   ) :: bc(dim,2)
+    integer,  intent(in   ) :: domlo(3), domhi(3)
+    real(rt), intent(in   ) :: delta(dim), xlo(dim), time
+    real(rt), intent(inout) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3))
+
+    call filcc_nd(state,s_lo,s_hi,domlo,domhi,delta,xlo,bc)
+
+  end subroutine ca_generic_single_fill
+
+
+
+
+  subroutine ca_generic_multi_fill(state, s_lo, s_hi, &
+                                   domlo, domhi, delta, xlo, time, bc) &
+                                   bind(C, name="ca_generic_multi_fill")
+
+    use meth_params_module, only: NVAR
+    use amrex_fort_module, only: rt => amrex_real
+    use prob_params_module, only: dim
+
+    implicit none
+
+    integer,  intent(in   ) :: s_lo(3), s_hi(3)
+    integer,  intent(in   ) :: bc(dim,2,NVAR)
+    integer,  intent(in   ) :: domlo(3), domhi(3)
+    real(rt), intent(in   ) :: delta(dim), xlo(dim), time
+    real(rt), intent(inout) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),NVAR)
+
+    integer :: n
+
+    do n = 1, NVAR
+       call filcc_nd(state(:,:,:,n),s_lo,s_hi,domlo,domhi,delta,xlo,bc(:,:,n))
+    end do
+
+  end subroutine ca_generic_multi_fill
+
+end module generic_fill_module


### PR DESCRIPTION
This PR creates new functions, ca_generic_single_fill and ca_generic_multi_fill. All these do is call filcc. These are useful for any generic fill of data with NUM_STATE (NVAR) components.

This PR also applies them to Source_Type, SDC_Source_Type, and SDC_React_Type. These are all NUM_STATE sized, and use the same BCs as the State_Type (normal linear extrapolation for everything but the velocity components).

Fixes #154