### PR TITLE
Use the correct (negative) scaling for the coarse pressure

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,12 @@
 # changes since the last release:
 
+  -- A bug was fixed in non-Cartesian simulations with AMR
+     (1D spherical and 2D cylindrical). The bug was introduced
+     around version 17.02 and resulted in incorrect synchronization
+     of the pressure term in the momentum equations. The effect
+     would have manifested as non-conservation of momentum or
+     strange effects at coarse-fine interfaces.
+
   -- The sponge is now always time centered. The option to
      do otherwise was introduced in 17.02, and has now been
      removed. Additionally, the form of the energy source

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -705,10 +705,10 @@ Castro::initMFs()
 	// over the full set of fine timesteps to equal P_radial.
 
 #if (BL_SPACEDIM == 1)
-	pres_crse_scale = 1.0;
+	pres_crse_scale = -1.0;
 	pres_fine_scale = 1.0;
 #elif (BL_SPACEDIM == 2)
-	pres_crse_scale = 1.0;
+	pres_crse_scale = -1.0;
 	pres_fine_scale = 1.0 / crse_ratio[1];
 #endif
 


### PR DESCRIPTION
This error was introduced sometime around 17.02 when the reflux was rewritten. It only matters for 2D and 1D.

Thanks to @WeiqunZhang for finding this.