### PR TITLE
Fix a typo in the Microphysics repo urls

### DIFF
--- a/Docs/GettingStarted/CastroGettingStarted.tex
+++ b/Docs/GettingStarted/CastroGettingStarted.tex
@@ -78,11 +78,11 @@ export CASTRO_HOME="/path/to/Castro/"
     solver was distributed separately as {\tt CastroRadiation.git},
     but this has been merged into the main \castro\ respository}:
 \begin{verbatim}
-git clone https//github.com/starkiler-astro/Microphysics.git
+git clone https://github.com/starkiller-astro/Microphysics.git
 \end{verbatim}
 or via SSH as
 \begin{verbatim}
-git clone ssh://git@github.com:/starkiler-astro/Microphysics.git
+git clone ssh://git@github.com:/starkiller-astro/Microphysics.git
 \end{verbatim}
 
 To access the \microphysics\ routines, set the {\tt MICROPHYSICS\_HOME}


### PR DESCRIPTION
Hi,

I saw a typo in the Getting Started chapter, so this fixes the Microphysics repo urls.