### PR TITLE
Take correct post-restart timestep if step was limited to hit plot interval

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 # changes since last release
 
+  -- As of 17.10, there is a new option castro.plot_per_is_exact. If this
+     is set to 1, timesteps will be shortened to exactly hit the time interval
+     specified by amr.plot_per. An issue with this was fixed where an incorrect
+     timestep would be taken after a restart if the previous step had been
+     shortened.
+
   -- We can now use the new multigrid solver from AMReX (implemented
      in C++) instead of the older Fortran solver.  This is enabled
      with gravity.use_mlmg_solver=1.  Note, this only works in 3-d
@@ -23,6 +29,10 @@
      Numerical experiments have show this scales better than the old
      solver.
 
+# 17.11.1
+
+  -- Minor bug fixes from the 17.11 release. There is a corresponding
+     17.11.1 release of AMReX.
 
 # 17.11
 


### PR DESCRIPTION
If a timestep was limited to hit a plot interval, a restart would see this shortened dt when calculating the next dt, and would limit the timestep to change_max * dt. This situation was worked around during normal evolution because we do not want to have to catch back up to the longer timestep every time we stop to hit a plot interval. This commit also ensures this behavior if we're restarting after a shortened timestep.

A new file is added to the checkpoint directory that stores the previous, longer timestep in this situation. On a restart, we check if this file exists, and if so, read in that longer timestep. This fixes the problem.

Fixes #242