### PR TITLE
Remove the parameter castro.keep_sources_until_end

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 # changes since last release
 
+  -- The parameter castro.keep_sources_until_end has been removed.
+
   -- Source terms (gravity, rotation, etc.) have now been all coalesced into
      a single MultiFab. This reduces the memory footprint of the code. This
      negates the need for the code parameters update_state_between_sources and

--- a/Docs/runtime_parameters/runtime_parameters.tex
+++ b/Docs/runtime_parameters/runtime_parameters.tex
@@ -325,46 +325,45 @@
 \runparamNS{hybrid\_hydro}{castro} &  whether to use the hybrid advection scheme that updates z-angular momentum, cylindrical momentum, and azimuthal momentum (3D only) & 0 \\
 \runparamNS{hybrid\_riemann}{castro} &  do we drop from our regular Riemann solver to HLL when we are in shocks to avoid the odd-even decoupling instability? & 0 \\
 \rowcolor{tableShade}
-\runparamNS{keep\_sources\_until\_end}{castro} &  retain source terms until end of timestep & 0 \\
 \runparamNS{limit\_fluxes\_on\_small\_dens}{castro} &  Should we limit the density fluxes so that we do not create small densities? & 0 \\
-\rowcolor{tableShade}
 \runparamNS{plm\_iorder}{castro} &  for piecewise linear, reconstruction order to use & 2 \\
+\rowcolor{tableShade}
 \runparamNS{ppm\_predict\_gammae}{castro} &  do we construct $\gamma_e = p/(\rho e) + 1$ and bring it to the interfaces for additional thermodynamic information (this is the Colella \& Glaz technique) or do we use $(\rho e)$ (the classic \castro\ behavior).  Note this also uses $\tau = 1/\rho$ instead of $\rho$. & 0 \\
-\rowcolor{tableShade}
 \runparamNS{ppm\_reference\_eigenvectors}{castro} &  do we use the reference state in evaluating the eigenvectors? & 0 \\
+\rowcolor{tableShade}
 \runparamNS{ppm\_temp\_fix}{castro} &  various methods of giving temperature a larger role in the reconstruction---see Zingale \& Katz 2015 & 0 \\
-\rowcolor{tableShade}
 \runparamNS{ppm\_trace\_sources}{castro} &  to we reconstruct and trace under the parabolas of the source terms to the velocity (gravity and rotation) & 1 \\
+\rowcolor{tableShade}
 \runparamNS{ppm\_type}{castro} &  reconstruction type: 0: piecewise linear; 1: classic Colella \& Woodward ppm; 2: extrema-preserving ppm & 1 \\
-\rowcolor{tableShade}
 \runparamNS{riemann\_solver}{castro} &  which Riemann solver do we use: 0: Colella, Glaz, \& Ferguson (a two-shock solver); 1: Colella \& Glaz (a two-shock solver) 2: HLLC & 0 \\
+\rowcolor{tableShade}
 \runparamNS{small\_dens}{castro} &  the small density cutoff.  Densities below this value will be reset & -1.e200 \\
-\rowcolor{tableShade}
 \runparamNS{small\_ener}{castro} &  the small specific internal energy cutoff.  Internal energies below this value will be reset & -1.e200 \\
+\rowcolor{tableShade}
 \runparamNS{small\_pres}{castro} &  the small pressure cutoff.  Pressures below this value will be reset & -1.e200 \\
-\rowcolor{tableShade}
 \runparamNS{small\_temp}{castro} &  the small temperature cutoff.  Temperatures below this value will be reset & -1.e200 \\
+\rowcolor{tableShade}
 \runparamNS{source\_term\_predictor}{castro} &  extrapolate the source terms (gravity and rotation) to $n+1/2$ timelevel for use in the interface state prediction & 0 \\
-\rowcolor{tableShade}
 \runparamNS{sponge\_implicit}{castro} &  if we are using the sponge, whether to use the implicit solve for it & 1 \\
+\rowcolor{tableShade}
 \runparamNS{transverse\_reset\_density}{castro} &  if the transverse interface state correction, if the new density is negative, then replace all of the interface quantities with their values without the transverse correction. & 1 \\
-\rowcolor{tableShade}
 \runparamNS{transverse\_reset\_rhoe}{castro} &  if the interface state for $(\rho e)$ is negative after we add the transverse terms, then replace the interface value of $(\rho e)$ with a value constructed from the $(\rho e)$ evolution equation & 0 \\
+\rowcolor{tableShade}
 \runparamNS{transverse\_use\_eos}{castro} &  after we add the transverse correction to the interface states, replace the predicted pressure with an EOS call (using $e$ and $\rho$). & 0 \\
-\rowcolor{tableShade}
 \runparamNS{use\_colglaz}{castro} &  this is deprecated---use {\tt riemann\_solver} instead & -1 \\
+\rowcolor{tableShade}
 \runparamNS{use\_eos\_in\_riemann}{castro} &  should we use the EOS in the Riemann solver to ensure thermodynamic consistency? & 0 \\
-\rowcolor{tableShade}
 \runparamNS{use\_flattening}{castro} &  flatten the reconstructed profiles around shocks to prevent them from becoming too thin & 1 \\
+\rowcolor{tableShade}
 \runparamNS{use\_pslope}{castro} &  for the piecewise linear reconstruction, do we subtract off $(\rho g)$ from the pressure before limiting? & 1 \\
-\rowcolor{tableShade}
 \runparamNS{xl\_ext\_bc\_type}{castro} &  if we are doing an external -x boundary condition, who do we interpret it? & "" \\
+\rowcolor{tableShade}
 \runparamNS{xr\_ext\_bc\_type}{castro} &  if we are doing an external +x boundary condition, who do we interpret it? & "" \\
-\rowcolor{tableShade}
 \runparamNS{yl\_ext\_bc\_type}{castro} &  if we are doing an external -y boundary condition, who do we interpret it? & "" \\
-\runparamNS{yr\_ext\_bc\_type}{castro} &  if we are doing an external +y boundary condition, who do we interpret it? & "" \\
 \rowcolor{tableShade}
+\runparamNS{yr\_ext\_bc\_type}{castro} &  if we are doing an external +y boundary condition, who do we interpret it? & "" \\
 \runparamNS{zl\_ext\_bc\_type}{castro} &  if we are doing an external -z boundary condition, who do we interpret it? & "" \\
+\rowcolor{tableShade}
 \runparamNS{zr\_ext\_bc\_type}{castro} &  if we are doing an external +z boundary condition, who do we interpret it? & "" \\
 
 

--- a/Exec/science/wdmerger/Prob.cpp
+++ b/Exec/science/wdmerger/Prob.cpp
@@ -630,11 +630,6 @@ void Castro::problem_post_init() {
   if (problem == 3 && !relaxation_is_done && parent->subCycle())
     amrex::Abort("Error: cannot perform relaxation step if we are sub-cycling in the AMR.");
 
-  // If we're doing an initial relaxation step, ensure that we retain source terms.
-
-  if (problem == 3 && !relaxation_is_done && !keep_sources_until_end)
-    amrex::Abort("Error: cannot perform relaxation step if we are not retaining source terms.");
-
   // Update the rotational period; some problems change this from what's in the inputs parameters.
 
   get_period(&rotational_period);

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -710,7 +710,7 @@ Castro::initMFs()
 
     }
 
-    if (keep_sources_until_end || (do_reflux && update_sources_after_reflux)) {
+    if (do_reflux && update_sources_after_reflux) {
 
 	// These arrays hold all source terms that update the state.
 

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -591,14 +591,13 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
 
     }
 
-    if (!(keep_sources_until_end || (do_reflux && update_sources_after_reflux))) {
+    if (!(do_reflux && update_sources_after_reflux)) {
 
-      // These arrays hold all source terms that update the state.  We
-      // create and destroy them in the advance to save memory outside
-      // of the advance, unless we keep_sources_until_end (for
-      // diagnostics) or update the sources after reflux.  In those
-      // cases, we initialize these sources in Castro::initMFs and
-      // keep them for the life of the simulation.
+      // These arrays hold all source terms that update the state.
+      // Normally these are allocated at initialization because
+      // of the source term update after a reflux, but if the user
+      // chooses not to do that, we can save memory by only allocating
+      // the data temporarily for the duration of the advance.
 
       old_sources.define(grids, dmap, NUM_STATE, NUM_GROW);
       new_sources.define(grids, dmap, NUM_STATE, get_new_data(State_Type).nGrow());
@@ -685,7 +684,7 @@ Castro::finalize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
 
     Real cur_time = state[State_Type].curTime();
 
-    if (!(keep_sources_until_end || (do_reflux && update_sources_after_reflux))) {
+    if (!(do_reflux && update_sources_after_reflux)) {
 
 	old_sources.clear();
 	new_sources.clear();

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -191,9 +191,6 @@ do_sponge                    int           0                  y
 # if we are using the sponge, whether to use the implicit solve for it
 sponge_implicit              int           1                  y
 
-# retain source terms until end of timestep
-keep_sources_until_end       int           0
-
 # extrapolate the source terms (gravity and rotation) to $n+1/2$
 # timelevel for use in the interface state prediction
 source_term_predictor        int           0

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -47,7 +47,6 @@ int         Castro::allow_negative_energy = 0;
 int         Castro::allow_small_energy = 1;
 int         Castro::do_sponge = 0;
 int         Castro::sponge_implicit = 1;
-int         Castro::keep_sources_until_end = 0;
 int         Castro::source_term_predictor = 0;
 int         Castro::first_order_hydro = 0;
 std::string Castro::xl_ext_bc_type = "";

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -47,7 +47,6 @@ static int allow_negative_energy;
 static int allow_small_energy;
 static int do_sponge;
 static int sponge_implicit;
-static int keep_sources_until_end;
 static int source_term_predictor;
 static int first_order_hydro;
 static std::string xl_ext_bc_type;

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -47,7 +47,6 @@ pp.query("allow_negative_energy", allow_negative_energy);
 pp.query("allow_small_energy", allow_small_energy);
 pp.query("do_sponge", do_sponge);
 pp.query("sponge_implicit", sponge_implicit);
-pp.query("keep_sources_until_end", keep_sources_until_end);
 pp.query("source_term_predictor", source_term_predictor);
 pp.query("first_order_hydro", first_order_hydro);
 pp.query("xl_ext_bc_type", xl_ext_bc_type);


### PR DESCRIPTION
This was added to assist with wdmerger due to the strategy of using the source term data to calculate a relaxation step. This strategy has been reworked and no longer needs the source term data, so this parameter has been removed. Note that by default, the source term data will be kept indefinitely anyway -- this is disabled only if castro.update_sources_after_reflux = 0.