### PR TITLE
Shorten the lifetime of hydro_source

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -710,14 +710,6 @@ Castro::initMFs()
 
     }
 
-    if (do_reflux && update_sources_after_reflux) {
-
-	// This array holds the hydrodynamics update.
-
-	hydro_source.define(grids,dmap,NUM_STATE,0);
-
-    }
-
     post_step_regrid = 0;
 
 }
@@ -2323,10 +2315,6 @@ Castro::reflux(int crse_level, int fine_level)
 		temp_fluxes[i].reset();
 	    }
 
-	    // Reflux into the hydro_source array so that we have the most up-to-date version of it.
-
-	    reg->Reflux(crse_lev.hydro_source, crse_lev.volume, 1.0, 0, 0, NUM_STATE, crse_lev.geom);
-
 	}
 
 	// We no longer need the flux register data, so clear it out.
@@ -2363,8 +2351,6 @@ Castro::reflux(int crse_level, int fine_level)
 
 		MultiFab::Add(crse_lev.P_radial, *temp_fluxes[0], 0, 0, crse_lev.P_radial.nComp(), 0);
 		temp_fluxes[0].reset();
-
-                reg->Reflux(crse_lev.hydro_source, dr, 1.0, 0, Xmom, 1, crse_lev.geom);
 
 	    }
 

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -623,13 +623,9 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
 
     }
 
-    if (!(do_reflux && update_sources_after_reflux)) {
+    // This array holds the hydrodynamics update.
 
-      // This array holds the hydrodynamics update.
-
-      hydro_source.define(grids,dmap,NUM_STATE,0);
-
-    }
+    hydro_source.define(grids,dmap,NUM_STATE,0);
 
 
 
@@ -700,11 +696,7 @@ Castro::finalize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
 
     Real cur_time = state[State_Type].curTime();
 
-    if (!(do_reflux && update_sources_after_reflux)) {
-
-	hydro_source.clear();
-
-    }
+    hydro_source.clear();
 
     sources_for_hydro.clear();
 


### PR DESCRIPTION
Now hydro_source only exists for the duration of the timestep, not permanently. The indefinite lifetime of hydro_source was for an old wdmerger feature that no longer exists.