### PR TITLE
Apply the sources to the state's ghost zones

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -538,7 +538,7 @@ public:
 
     void apply_source_to_state (amrex::MultiFab& state, amrex::MultiFab& source, amrex::Real dt);
 
-    void expand_state(amrex::MultiFab& S, amrex::Real time, int ng);
+    void expand_state(amrex::MultiFab& S, amrex::Real time, int ng, bool do_clean = true);
 
 #ifdef SELF_GRAVITY
     void make_radial_data (int is_new);

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -538,7 +538,7 @@ public:
 
     void apply_source_to_state (amrex::MultiFab& state, amrex::MultiFab& source, amrex::Real dt);
 
-    void expand_state(amrex::MultiFab& S, amrex::Real time, int ng, bool do_clean = true);
+    void expand_state(amrex::MultiFab& S, amrex::Real time, int ng);
 
 #ifdef SELF_GRAVITY
     void make_radial_data (int is_new);

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3356,15 +3356,13 @@ Castro::build_interior_boundary_mask (int ng)
 // Fill a version of the state with ng ghost zones from the state data.
 
 void
-Castro::expand_state(MultiFab& S, Real time, int ng, bool do_clean)
+Castro::expand_state(MultiFab& S, Real time, int ng)
 {
     BL_ASSERT(S.nGrow() >= ng);
 
     AmrLevel::FillPatch(*this,S,ng,time,State_Type,0,NUM_STATE);
 
-    if (do_clean)
-        clean_state(S);
-
+    clean_state(S);
 }
 
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3356,13 +3356,14 @@ Castro::build_interior_boundary_mask (int ng)
 // Fill a version of the state with ng ghost zones from the state data.
 
 void
-Castro::expand_state(MultiFab& S, Real time, int ng)
+Castro::expand_state(MultiFab& S, Real time, int ng, bool do_clean)
 {
     BL_ASSERT(S.nGrow() >= ng);
 
     AmrLevel::FillPatch(*this,S,ng,time,State_Type,0,NUM_STATE);
 
-    clean_state(S);
+    if (do_clean)
+        clean_state(S);
 
 }
 

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -251,11 +251,27 @@ Castro::do_advance (Real time,
       // define the temperature now
       clean_state(S_new);
 
+      // If the state has ghost zones, sync them up now
+      // since the hydro source only works on the valid zones.
+
+      if (S_new.nGrow() > 0) {
+          bool do_clean = false;
+          expand_state(S_new, cur_time, S_new.nGrow(), do_clean);
+      }
+
     } else if (do_ctu) {
 
       // Sync up state after old sources and hydro source.
 
       frac_change = clean_state(S_new, Sborder);
+
+      // If the state has ghost zones, sync them up now
+      // since the hydro source only works on the valid zones.
+
+      if (S_new.nGrow() > 0) {
+          bool do_clean = false;
+          expand_state(S_new, cur_time, S_new.nGrow(), do_clean);
+      }
 
       // Check for NaN's.
 

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -255,8 +255,7 @@ Castro::do_advance (Real time,
       // since the hydro source only works on the valid zones.
 
       if (S_new.nGrow() > 0) {
-          bool do_clean = false;
-          expand_state(S_new, cur_time, S_new.nGrow(), do_clean);
+          expand_state(S_new, cur_time, S_new.nGrow());
       }
 
     } else if (do_ctu) {
@@ -269,8 +268,7 @@ Castro::do_advance (Real time,
       // since the hydro source only works on the valid zones.
 
       if (S_new.nGrow() > 0) {
-          bool do_clean = false;
-          expand_state(S_new, cur_time, S_new.nGrow(), do_clean);
+          expand_state(S_new, cur_time, S_new.nGrow());
       }
 
       // Check for NaN's.

--- a/Source/sources/Castro_sources.cpp
+++ b/Source/sources/Castro_sources.cpp
@@ -10,9 +10,9 @@ using namespace amrex;
 void
 Castro::apply_source_to_state(MultiFab& state, MultiFab& source, Real dt)
 {
+    AMREX_ASSERT(source.nGrow() >= state.nGrow());
 
-  MultiFab::Saxpy(state, dt, source, 0, 0, NUM_STATE, 0);
-
+    MultiFab::Saxpy(state, dt, source, 0, 0, NUM_STATE, state.nGrow());
 }
 
 void


### PR DESCRIPTION
This fixes #213 -- it ensures the advances give a valid update for the ghost zones in the State_Type.