### PR TITLE
Remove SDC_Source_Type from StateData

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,14 @@
 # changes since last release
 
+  -- The SDC_Source_Type StateData was removed, as its purpose is now supplanted
+     by the change to always keep the source terms in StateData (see below), and
+     it was thus redundant. This does not change code output but does mean that
+     old checkpoints generated while using SDC are no longer compatible with the
+     current code. Normally we strive to maintain forward compatibility of
+     checkpoints, but this change was considered justified because SDC is still
+     considered an experimental feature under development and to our knowledge
+     no production science runs have yet been done using SDC.
+
   -- The parameter gravity.max_solve_level was removed. This was added to work
      around convergence issues in the multigrid solve, but those convergence
      issues have since been fixed, so the parameter is no longer used.

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -40,7 +40,6 @@ enum StateType { State_Type = 0,
                  Reactions_Type,
 #endif
 #ifdef SDC
-		 SDC_Source_Type,
 #ifdef REACTIONS
 		 SDC_React_Type
 #endif

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -509,14 +509,9 @@ Castro::Castro (Amr&            papa,
 #endif
 
 #ifdef SDC
-   // Initialize old and new source terms to zero.
-
-   MultiFab& sdc_sources_new = get_new_data(SDC_Source_Type);
-   sdc_sources_new.setVal(0.0, NUM_GROW);
-
+#ifdef REACTIONS
    // Initialize reactions source term to zero.
 
-#ifdef REACTIONS
    MultiFab& react_src_new = get_new_data(SDC_React_Type);
    react_src_new.setVal(0.0, NUM_GROW);
 #endif
@@ -861,8 +856,6 @@ Castro::initData ()
 #endif
 
 #ifdef SDC
-   MultiFab& sources_new = get_new_data(SDC_Source_Type);
-   sources_new.setVal(0.0, NUM_GROW);
 #ifdef REACTIONS
    MultiFab& react_src_new = get_new_data(SDC_React_Type);
    react_src_new.setVal(0.0, NUM_GROW);
@@ -2550,7 +2543,6 @@ Castro::avgDown ()
 #endif
 
 #ifdef SDC
-  avgDown(SDC_Source_Type);
 #ifdef REACTIONS
   avgDown(SDC_React_Type);
 #endif

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -424,17 +424,6 @@ void
 Castro::finalize_do_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
 {
 
-#ifdef SDC
-    // The new sources are broken into types (ext, diff, hybrid, grav,
-    // ...) via an enum.  For SDC, store the sum of the new_sources
-    // over these different physics types in the state data -- that's
-    // what hydro really cares about.
-
-    MultiFab& SDC_source_new = get_new_data(SDC_Source_Type);
-    MultiFab& sources_new = get_new_data(Source_Type);
-    MultiFab::Copy(SDC_source_new, sources_new, 0, 0, NUM_STATE, sources_new.nGrow());
-#endif
-
 #ifdef RADIATION
     if (!do_hydro && Radiation::rad_hydro_combined) {
 	MultiFab& Er_old = get_old_data(Rad_Type);
@@ -578,7 +567,7 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
     // value of the "new-time" sources to the old-time sources to get a
     // time-centered value.
 
-    AmrLevel::FillPatch(*this, sources_for_hydro, NUM_GROW, time, SDC_Source_Type, 0, NUM_STATE);
+    AmrLevel::FillPatch(*this, sources_for_hydro, NUM_GROW, time, Source_Type, 0, NUM_STATE);
 
 #endif
 
@@ -595,8 +584,6 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
 	// don't want to allocate memory for it.
 
 #ifdef SDC
-	if (k == SDC_Source_Type)
-	    state[k].swapTimeLevels(0.0);
 #ifdef REACTIONS
 	if (k == SDC_React_Type)
 	    state[k].swapTimeLevels(0.0);
@@ -933,8 +920,6 @@ Castro::subcycle_advance(const Real time, const Real dt, int amr_iteration, int 
             for (int k = 0; k < num_state_type; k++) {
 
 #ifdef SDC
-                if (k == SDC_Source_Type)
-                    state[k].swapTimeLevels(0.0);
 #ifdef REACTIONS
                 if (k == SDC_React_Type)
                     state[k].swapTimeLevels(0.0);

--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -48,11 +48,12 @@ using namespace amrex;
 // 3: A ReactHeader file was generated and the maximum de/dt was stored there
 // 4: Reactions_Type added to checkpoint; ReactHeader functionality deprecated
 // 5: SDC_Source_Type and SDC_React_Type added to checkpoint
+// 6: SDC_Source_Type removed from Castro
 
 namespace
 {
     int input_version = -1;
-    int current_version = 5;
+    int current_version = 6;
 }
 
 // I/O routines for Castro
@@ -130,8 +131,8 @@ Castro::restart (Amr&     papa,
 #endif
 
 #ifdef SDC
-    if (input_version < 5) { // old checkpoint without SDC_Source_Type
-      state[SDC_Source_Type].restart(desc_lst[SDC_Source_Type], state[State_Type]);
+    if (input_version < 6) { // old checkpoint with SDC_Source_Type
+        amrex::Abort("Cannot restart from this checkpoint when using SDC.");
     }
 #ifdef REACTIONS
     if (input_version < 5) { // old checkpoint without SDC_React_Type
@@ -483,10 +484,6 @@ Castro::set_state_in_checkpoint (Vector<int>& state_in_checkpoint)
     }
 #endif
 #ifdef SDC
-    if (input_version < 5 && i == SDC_Source_Type) {
-      // We are reading an old checkpoint with no SDC_Source_Type
-      state_in_checkpoint[i] = 0;
-    }
 #ifdef REACTIONS
     if (input_version < 5 && i == SDC_React_Type) {
       // We are reading an old checkpoint with no SDC_React_Type
@@ -626,8 +623,6 @@ Castro::setPlotVariables ()
       parent->deleteStatePlotVar(desc_lst[Source_Type].name(i));
 
 #ifdef SDC
-  for (int i = 0; i < desc_lst[SDC_Source_Type].nComp(); i++)
-      parent->deleteStatePlotVar(desc_lst[SDC_Source_Type].name(i));
 #ifdef REACTIONS
   for (int i = 0; i < desc_lst[SDC_React_Type].nComp(); i++)
       parent->deleteStatePlotVar(desc_lst[SDC_React_Type].name(i));

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -379,16 +379,9 @@ Castro::variableSetUp ()
 #endif
 
 #ifdef SDC
-  // For SDC we want to store the source terms.
-
-  store_in_checkpoint = true;
-  desc_lst.addDescriptor(SDC_Source_Type, IndexType::TheCellType(),
-			 StateDescriptor::Point,NUM_GROW,NUM_STATE,
-			 &cell_cons_interp,state_data_extrap,store_in_checkpoint);
-
-  // We also want to store the reactions source.
-
 #ifdef REACTIONS
+  // For SDC, we want to store the reactions source.
+
   store_in_checkpoint = true;
   desc_lst.addDescriptor(SDC_React_Type, IndexType::TheCellType(),
 			 StateDescriptor::Point,NUM_GROW,QVAR,
@@ -549,10 +542,6 @@ Castro::variableSetUp ()
 #endif
 
 #ifdef SDC
-  for (int i = 0; i < NUM_STATE; ++i)
-      state_type_source_names[i] = "sdc_sources_" + name[i];
-  desc_lst.setComponent(SDC_Source_Type,Density,state_type_source_names,source_bcs,
-                        BndryFunc(ca_generic_single_fill,ca_generic_multi_fill));
 #ifdef REACTIONS
   for (int i = 0; i < QVAR; ++i) {
       char buf[64];


### PR DESCRIPTION
A separate SDC_Source_Type is no longer needed, because now the standard Source_Type StateData holds the new-time source terms, which is exactly what SDC needed (the SDC in the name was something of a misnomer). SDC now draws from the Source_Type.

This breaks checkpoint forward compatibility for previous runs using SDC.

The Castro checkpoint version number is incremented to 6.