### PR TITLE
Fix the source term predictor when doing a retry

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -473,6 +473,8 @@ public:
 
     void computeTemp (amrex::MultiFab& State);
 
+    void apply_source_term_predictor(const Real time, const Real dt);
+
 #ifdef DIFFUSION
     void construct_old_diff_source(amrex::Real time, amrex::Real dt);
     void construct_new_diff_source(amrex::Real time, amrex::Real dt);

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -921,7 +921,8 @@ Castro::subcycle_advance(const Real time, const Real dt, int amr_iteration, int 
             sources_for_hydro.setVal(0.0, NUM_GROW);
 
 #ifndef SDC
-            apply_source_term_predictor(subcycle_time, dt_advance);
+            if (source_term_predictor == 1)
+                apply_source_term_predictor(subcycle_time, dt_advance);
 #endif
 
         }

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -783,6 +783,16 @@ Castro::retry_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
 
 	}
 
+        // Reset the source term predictor.
+
+        sources_for_hydro.setVal(0.0, NUM_GROW);
+
+#ifndef SDC
+        if (source_term_predictor == 1)
+            apply_source_term_predictor(time, dt_subcycle);
+#endif
+
+
 	if (track_grid_losses)
 	  for (int i = 0; i < n_lost; i++)
 	    material_lost_through_boundary_temp[i] = 0.0;
@@ -897,6 +907,16 @@ Castro::subcycle_advance(const Real time, const Real dt, int amr_iteration, int 
 
         if (sub_iteration > 1) {
 
+            // Reset the source term predictor.
+            // This must come before the swap.
+
+            sources_for_hydro.setVal(0.0, NUM_GROW);
+
+#ifndef SDC
+            if (source_term_predictor == 1)
+                apply_source_term_predictor(subcycle_time, dt_advance);
+#endif
+
             for (int k = 0; k < num_state_type; k++) {
 
 #ifdef SDC
@@ -914,15 +934,6 @@ Castro::subcycle_advance(const Real time, const Real dt, int amr_iteration, int 
             if (do_grav) {
                 gravity->swapTimeLevels(level);
             }
-#endif
-
-            // Reset the source term predictor.
-
-            sources_for_hydro.setVal(0.0, NUM_GROW);
-
-#ifndef SDC
-            if (source_term_predictor == 1)
-                apply_source_term_predictor(subcycle_time, dt_advance);
 #endif
 
         }


### PR DESCRIPTION
This fixes an issue where the sources going into the hydro were not updated correctly during a retry. If we were using the source term predictor, we wouldn't update to account for the smaller timesteps (or the most recent data from the previous subcycled timestep).