### PR TITLE
Update the wdmerger_retry test to have a guaranteed retry

### DIFF
--- a/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
@@ -170,9 +170,6 @@ castro.density_reset_method = 2
 # Explicitly limit fluxes to avoid hitting a negative density
 castro.limit_fluxes_on_small_dens = 0
 
-# Time center the sponge source
-castro.time_center_sponge = 1
-
 ############################################################################################
 # Thermodynamics
 ############################################################################################
@@ -269,9 +266,6 @@ DistributionMapping.efficiency = 0.9
 # Calculate and print the center of mass at each time step
 castro.show_center_of_mass = 1
 
-# Diagnostics on mass/momentum/energy added during a hydro update
-castro.print_energy_diagnostics = 1
-
 # Diagnostics on mass/momentum/energy lost through physical ground boundaries
 castro.track_grid_losses = 1
 
@@ -349,3 +343,9 @@ amr.data_log = grid_diag.out star_diag.out species_diag.out amr_diag.out bndy_di
 
 # Write out plotfile data in single precision
 fab.format = NATIVE_32
+
+# Used a forced fixed dt that is known to be larger
+# than the safe hydrodynamic timestep given the above
+# CFL value. This guarantees that we will retry on
+# all levels, at least in the first timestep.
+castro.fixed_dt = 0.08


### PR DESCRIPTION
The previous approach to this test was unreliable because a change in how we did the hydro update could make the retry go away. This test now guarantees a retry by using a fixed dt which is larger than the CFL timestep.