### PR TITLE
Pass the state for the source terms as an argument to the source constructor

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 # changes since last release
 
+  -- Minor inconsistencies in how the external and diffusion source terms
+     were constructed when simultaneously using reactions (#268, #269)
+     have been fixed (#271).
 
 # 17.12
 

--- a/Source/diffusion/Castro_diffusion.cpp
+++ b/Source/diffusion/Castro_diffusion.cpp
@@ -9,23 +9,23 @@ using std::string;
 using namespace amrex;
 
 void
-Castro::construct_old_diff_source(MultiFab& source, Real time, Real dt)
+Castro::construct_old_diff_source(MultiFab& source, MultiFab& state, Real time, Real dt)
 {
     MultiFab TempDiffTerm(grids, dmap, 1, 1);
     MultiFab SpecDiffTerm(grids, dmap, NumSpec, 1);
     MultiFab ViscousTermforMomentum(grids, dmap, BL_SPACEDIM, 1);
     MultiFab ViscousTermforEnergy(grids, dmap, 1, 1);
 
-    add_temp_diffusion_to_source(source, TempDiffTerm, time, 1);
+    add_temp_diffusion_to_source(source, state, TempDiffTerm, time);
 
 #if (BL_SPACEDIM == 1)
-    add_spec_diffusion_to_source(source, SpecDiffTerm, time, 1);
-    add_viscous_term_to_source(source, ViscousTermforMomentum, ViscousTermforEnergy, time);
+    add_spec_diffusion_to_source(source, state, SpecDiffTerm, time);
+    add_viscous_term_to_source(source, state, ViscousTermforMomentum, ViscousTermforEnergy, time);
 #endif
 }
 
 void
-Castro::construct_new_diff_source(MultiFab& source, Real time, Real dt)
+Castro::construct_new_diff_source(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt)
 {
     MultiFab TempDiffTerm(grids, dmap, 1, 1);
     MultiFab SpecDiffTerm(grids, dmap, NumSpec, 1);
@@ -34,11 +34,11 @@ Castro::construct_new_diff_source(MultiFab& source, Real time, Real dt)
 
     Real mult_factor = 0.5;
 
-    add_temp_diffusion_to_source(source, TempDiffTerm, time, 0, mult_factor);
+    add_temp_diffusion_to_source(source, state_new, TempDiffTerm, time, mult_factor);
 
 #if (BL_SPACEDIM == 1)
-    add_spec_diffusion_to_source(source, SpecDiffTerm, time, 0, mult_factor);
-    add_viscous_term_to_source(source, ViscousTermforMomentum, ViscousTermforEnergy, time, mult_factor);
+    add_spec_diffusion_to_source(source, state_new, SpecDiffTerm, time, mult_factor);
+    add_viscous_term_to_source(source, state_new, ViscousTermforMomentum, ViscousTermforEnergy, time, mult_factor);
 #endif
 
     // Time center the source term.
@@ -46,11 +46,11 @@ Castro::construct_new_diff_source(MultiFab& source, Real time, Real dt)
     mult_factor = -0.5;
     Real old_time = time - dt;
 
-    add_temp_diffusion_to_source(source, TempDiffTerm, old_time, 1, mult_factor);
+    add_temp_diffusion_to_source(source, state_old, TempDiffTerm, old_time, mult_factor);
 
 #if (BL_SPACEDIM == 1)
-    add_spec_diffusion_to_source(source, SpecDiffTerm, old_time, 1, mult_factor);
-    add_viscous_term_to_source(source, ViscousTermforMomentum, ViscousTermforEnergy, old_time, mult_factor);
+    add_spec_diffusion_to_source(source, state_old, SpecDiffTerm, old_time, mult_factor);
+    add_viscous_term_to_source(source, state_old, ViscousTermforMomentum, ViscousTermforEnergy, old_time, mult_factor);
 #endif
 
 
@@ -59,14 +59,14 @@ Castro::construct_new_diff_source(MultiFab& source, Real time, Real dt)
 // **********************************************************************************************
 
 void
-Castro::add_temp_diffusion_to_source (MultiFab& ext_src, MultiFab& DiffTerm, Real t, int is_old, Real mult_factor)
+Castro::add_temp_diffusion_to_source (MultiFab& ext_src, MultiFab& state, MultiFab& DiffTerm, Real t, Real mult_factor)
 {
     // Define an explicit temperature update.
     DiffTerm.setVal(0.);
     if (diffuse_temp == 1) {
-       getTempDiffusionTerm(t, DiffTerm, is_old);
+        getTempDiffusionTerm(t, state, DiffTerm);
     } else if (diffuse_enth == 1) {
-       getEnthDiffusionTerm(t,DiffTerm, is_old);
+        getEnthDiffusionTerm(t, state, DiffTerm);
     }
 
     if (diffuse_temp == 1 or diffuse_enth == 1) {
@@ -79,12 +79,12 @@ Castro::add_temp_diffusion_to_source (MultiFab& ext_src, MultiFab& DiffTerm, Rea
 
 #if (BL_SPACEDIM == 1)
 void
-Castro::add_spec_diffusion_to_source (MultiFab& ext_src, MultiFab& SpecDiffTerm, Real t, int is_old, Real mult_factor)
+Castro::add_spec_diffusion_to_source (MultiFab& ext_src, MultiFab& state, MultiFab& SpecDiffTerm, Real t, Real mult_factor)
 {
     // Define an explicit species update.
     SpecDiffTerm.setVal(0.);
     if (diffuse_spec == 1) {
-       getSpecDiffusionTerm(t, SpecDiffTerm, is_old);
+       getSpecDiffusionTerm(t, state, SpecDiffTerm);
        MultiFab::Saxpy(ext_src,mult_factor,SpecDiffTerm,0,FirstSpec,NumSpec,0);
     }
 }
@@ -94,14 +94,14 @@ Castro::add_spec_diffusion_to_source (MultiFab& ext_src, MultiFab& SpecDiffTerm,
 
 #if (BL_SPACEDIM == 1)
 void
-Castro::add_viscous_term_to_source(MultiFab& ext_src, MultiFab& ViscousTermforMomentum, 
+Castro::add_viscous_term_to_source(MultiFab& ext_src, MultiFab& state, MultiFab& ViscousTermforMomentum, 
                                    MultiFab& ViscousTermforEnergy, Real t, Real mult_factor)
 {
     // Define an explicit viscous term
     ViscousTermforMomentum.setVal(0.);
     ViscousTermforEnergy.setVal(0.);
     if (diffuse_vel == 1) {
-       getViscousTerm(t,ViscousTermforMomentum,ViscousTermforEnergy);
+       getViscousTerm(t,state,ViscousTermforMomentum,ViscousTermforEnergy);
        MultiFab::Saxpy(ext_src,mult_factor,ViscousTermforMomentum,0,Xmom,1,0);
        MultiFab::Saxpy(ext_src,mult_factor,ViscousTermforEnergy  ,0,Eden,1,0);
     }
@@ -111,19 +111,9 @@ Castro::add_viscous_term_to_source(MultiFab& ext_src, MultiFab& ViscousTermforMo
 // **********************************************************************************************
 
 void
-Castro::getTempDiffusionTerm (Real time, MultiFab& TempDiffTerm, int is_old)
+Castro::getTempDiffusionTerm (Real time, MultiFab& state, MultiFab& TempDiffTerm)
 {
     BL_PROFILE("Castro::getTempDiffusionTerm()");
-
-    MultiFab *S;
-
-    if (is_old == 1) {
-      S = &get_old_data(State_Type);
-    } else if (is_old == 0) {
-      S = &get_new_data(State_Type);
-    } else {
-      amrex::Abort("invalid time level in getTempDiffusionTerm");
-    }
 
    if (verbose && ParallelDescriptor::IOProcessor())
       std::cout << "Calculating diffusion term at time " << time << std::endl;
@@ -144,17 +134,17 @@ Castro::getTempDiffusionTerm (Real time, MultiFab& TempDiffTerm, int is_old)
    MultiFab Temperature(grids,dmap,1,1);
 
    {
-       FillPatchIterator fpi(*this, *S, 1, time, State_Type, 0, NUM_STATE);
-       MultiFab& state = fpi.get_mf();
+       FillPatchIterator fpi(*this, state, 1, time, State_Type, 0, NUM_STATE);
+       MultiFab& grown_state = fpi.get_mf();
 
-       MultiFab::Copy(Temperature, state, Temp, 0, 1, 1);
+       MultiFab::Copy(Temperature, grown_state, Temp, 0, 1, 1);
 
-       for (MFIter mfi(state); mfi.isValid(); ++mfi)
+       for (MFIter mfi(grown_state); mfi.isValid(); ++mfi)
        {
 	   const Box& bx = grids[mfi.index()];
 
 	   ca_fill_temp_cond(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
-			     BL_TO_FORTRAN_3D(state[mfi]),
+			     BL_TO_FORTRAN_3D(grown_state[mfi]),
 			     BL_TO_FORTRAN_3D((*coeffs_temporary[0])[mfi]),
 			     BL_TO_FORTRAN_3D((*coeffs_temporary[1])[mfi]),
 			     BL_TO_FORTRAN_3D((*coeffs_temporary[2])[mfi]));
@@ -190,19 +180,9 @@ Castro::getTempDiffusionTerm (Real time, MultiFab& TempDiffTerm, int is_old)
 }
 
 void
-Castro::getEnthDiffusionTerm (Real time, MultiFab& DiffTerm, int is_old)
+Castro::getEnthDiffusionTerm (Real time, MultiFab& state, MultiFab& DiffTerm)
 {
     BL_PROFILE("Castro::getEnthDiffusionTerm()");
-
-    MultiFab *S;
-
-    if (is_old == 1) {
-      S = &get_old_data(State_Type);
-    } else if (is_old == 0) {
-      S = &get_new_data(State_Type);
-    } else {
-      amrex::Abort("invalid time level in getEnthDiffusionTerm");
-    }
 
    if (verbose && ParallelDescriptor::IOProcessor())
       std::cout << "Calculating diffusion term at time " << time << std::endl;
@@ -222,18 +202,18 @@ Castro::getEnthDiffusionTerm (Real time, MultiFab& DiffTerm, int is_old)
    // Define enthalpy at this level.
    MultiFab Enthalpy(grids,dmap,1,1);
    {
-       FillPatchIterator fpi(*this, *S, 1, time, State_Type, 0, NUM_STATE);
-       const MultiFab& state = fpi.get_mf();
+       FillPatchIterator fpi(*this, state, 1, time, State_Type, 0, NUM_STATE);
+       const MultiFab& grown_state = fpi.get_mf();
 
-       for (MFIter mfi(state); mfi.isValid(); ++mfi)
+       for (MFIter mfi(grown_state); mfi.isValid(); ++mfi)
        {
 	   const Box& bx = grids[mfi.index()];
 	   make_enthalpy(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
-	                 BL_TO_FORTRAN_3D(state[mfi]),
+	                 BL_TO_FORTRAN_3D(grown_state[mfi]),
 	                 BL_TO_FORTRAN_3D(Enthalpy[mfi]));
 
 	   ca_fill_enth_cond(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
-			     BL_TO_FORTRAN_3D(state[mfi]),
+			     BL_TO_FORTRAN_3D(grown_state[mfi]),
 			     BL_TO_FORTRAN_3D((*coeffs_temporary[0])[mfi]),
 			     BL_TO_FORTRAN_3D((*coeffs_temporary[1])[mfi]),
 			     BL_TO_FORTRAN_3D((*coeffs_temporary[2])[mfi]));
@@ -279,20 +259,10 @@ Castro::getEnthDiffusionTerm (Real time, MultiFab& DiffTerm, int is_old)
 
 #if (BL_SPACEDIM == 1)
 void
-Castro::getSpecDiffusionTerm (Real time, MultiFab& SpecDiffTerm, int is_old)
+Castro::getSpecDiffusionTerm (Real time, MultiFab& state, MultiFab& SpecDiffTerm)
 {
   BL_PROFILE("Castro::getSpecDiffusionTerm()");
 
-  MultiFab *S;
-
-  if (is_old == 1) {
-    S = &get_old_data(State_Type);
-  } else if (is_old == 0) {
-    S = &get_new_data(State_Type);
-  } else {
-    amrex::Abort("invalid time level in getSpecDiffusionTerm");
-  }
-  
   if (verbose && ParallelDescriptor::IOProcessor())
     std::cout << "Calculating species diffusion term at time " << time << std::endl;
 
@@ -308,15 +278,15 @@ Castro::getSpecDiffusionTerm (Real time, MultiFab& SpecDiffTerm, int is_old)
        }
    }
 
-   FillPatchIterator fpi(*this, *S, 1, time, State_Type, 0, NUM_STATE);
-   MultiFab& state = fpi.get_mf();
+   FillPatchIterator fpi(*this, state, 1, time, State_Type, 0, NUM_STATE);
+   MultiFab& grown_state = fpi.get_mf();
 
-   for (MFIter mfi(state); mfi.isValid(); ++mfi)
+   for (MFIter mfi(grown_state); mfi.isValid(); ++mfi)
    {
        const Box& bx = grids[mfi.index()];
 
        ca_fill_spec_coeff(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
-			  BL_TO_FORTRAN_3D(state[mfi]),
+			  BL_TO_FORTRAN_3D(grown_state[mfi]),
 			  BL_TO_FORTRAN_3D((*coeffs_temporary[0])[mfi]),
 			  BL_TO_FORTRAN_3D((*coeffs_temporary[1])[mfi]),
 			  BL_TO_FORTRAN_3D((*coeffs_temporary[2])[mfi]));
@@ -342,8 +312,8 @@ Castro::getSpecDiffusionTerm (Real time, MultiFab& SpecDiffTerm, int is_old)
    // Fill one species at a time at this level.
    for (int ispec = 0; ispec < NumSpec; ispec++)
    {
-       MultiFab::Copy  (Species, state, FirstSpec+ispec, 0, 1, 1);
-       MultiFab::Divide(Species, state, Density        , 0, 1, 1);
+       MultiFab::Copy  (Species, grown_state, FirstSpec+ispec, 0, 1, 1);
+       MultiFab::Divide(Species, grown_state, Density        , 0, 1, 1);
 
        // Fill temperature at next coarser level, if it exists.
        if (level > 0)
@@ -376,26 +346,25 @@ Castro::getSpecDiffusionTerm (Real time, MultiFab& SpecDiffTerm, int is_old)
 //       only part of the viscous term.  We assume that the coefficient that is filled is "2 mu"
 // **********************************************
 void
-Castro::getViscousTerm (Real time, MultiFab& ViscousTermforMomentum, MultiFab& ViscousTermforEnergy)
+Castro::getViscousTerm (Real time, MultiFab& state, MultiFab& ViscousTermforMomentum, MultiFab& ViscousTermforEnergy)
 {
     BL_PROFILE("Castro::getViscousTerm()");
 
    if (verbose && ParallelDescriptor::IOProcessor())
       std::cout << "Calculating viscous term at time " << time << std::endl;
 
-   getFirstViscousTerm(time,ViscousTermforMomentum);
+   getFirstViscousTerm(time,state,ViscousTermforMomentum);
 
    MultiFab SecndTerm(grids,dmap,ViscousTermforMomentum.nComp(),ViscousTermforMomentum.nGrow());
-   getSecndViscousTerm(time,SecndTerm);
+   getSecndViscousTerm(time,state,SecndTerm);
    MultiFab::Add(ViscousTermforMomentum, SecndTerm, 0, 0, ViscousTermforMomentum.nComp(), 0);
 
-   getViscousTermForEnergy(time,ViscousTermforEnergy);
+   getViscousTermForEnergy(time,state,ViscousTermforEnergy);
 }
 
 void
-Castro::getFirstViscousTerm (Real time, MultiFab& ViscousTerm)
+Castro::getFirstViscousTerm (Real time, MultiFab& state, MultiFab& ViscousTerm)
 {
-   MultiFab& S_old = get_old_data(State_Type);
 
    // Fill coefficients at this level.
    Vector<std::unique_ptr<MultiFab> > coeffs(BL_SPACEDIM);
@@ -412,19 +381,19 @@ Castro::getFirstViscousTerm (Real time, MultiFab& ViscousTerm)
    // Fill velocity at this level.
    MultiFab Vel(grids,dmap,1,1);
 
-   FillPatchIterator fpi(*this,S_old,1,time,State_Type,0,NUM_STATE);
-   MultiFab& state_old = fpi.get_mf();
+   FillPatchIterator fpi(*this, state, 1, time, State_Type, 0, NUM_STATE);
+   MultiFab& grown_state = fpi.get_mf();
 
    // Remember this is just 1-d
-   MultiFab::Copy  (Vel, state_old, Xmom   , 0, 1, 1);
-   MultiFab::Divide(Vel, state_old, Density, 0, 1, 1);
+   MultiFab::Copy  (Vel, grown_state, Xmom   , 0, 1, 1);
+   MultiFab::Divide(Vel, grown_state, Density, 0, 1, 1);
 
-   for (MFIter mfi(state_old); mfi.isValid(); ++mfi)
+   for (MFIter mfi(grown_state); mfi.isValid(); ++mfi)
    {
        const Box& bx = grids[mfi.index()];
 
        ca_fill_first_visc_coeff(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
-				BL_TO_FORTRAN_3D(state_old[mfi]),
+				BL_TO_FORTRAN_3D(grown_state[mfi]),
 				BL_TO_FORTRAN_3D((*coeffs_temporary[0])[mfi]),
 				BL_TO_FORTRAN_3D((*coeffs_temporary[1])[mfi]),
 				BL_TO_FORTRAN_3D((*coeffs_temporary[2])[mfi]));
@@ -460,9 +429,8 @@ Castro::getFirstViscousTerm (Real time, MultiFab& ViscousTerm)
 }
 
 void
-Castro::getSecndViscousTerm (Real time, MultiFab& ViscousTerm)
+Castro::getSecndViscousTerm (Real time, MultiFab& state, MultiFab& ViscousTerm)
 {
-   MultiFab& S_old = get_old_data(State_Type);
 
    // Fill coefficients at this level.
    Vector<std::unique_ptr<MultiFab> > coeffs(BL_SPACEDIM);
@@ -479,19 +447,19 @@ Castro::getSecndViscousTerm (Real time, MultiFab& ViscousTerm)
    // Fill velocity at this level.
    MultiFab Vel(grids,dmap,1,1);
 
-   FillPatchIterator fpi(*this,S_old,1,time,State_Type,0,NUM_STATE);
-   MultiFab& state_old = fpi.get_mf();
+   FillPatchIterator fpi(*this, state, 1, time, State_Type, 0, NUM_STATE);
+   MultiFab& grown_state = fpi.get_mf();
 
    // Remember this is just 1-d
-   MultiFab::Copy  (Vel, state_old, Xmom   , 0, 1, 1);
-   MultiFab::Divide(Vel, state_old, Density, 0, 1, 1);
+   MultiFab::Copy  (Vel, grown_state, Xmom   , 0, 1, 1);
+   MultiFab::Divide(Vel, grown_state, Density, 0, 1, 1);
 
-   for (MFIter mfi(state_old); mfi.isValid(); ++mfi)
+   for (MFIter mfi(grown_state); mfi.isValid(); ++mfi)
    {
        const Box& bx = grids[mfi.index()];
 
        ca_fill_secnd_visc_coeff(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
-				BL_TO_FORTRAN_3D(state_old[mfi]),
+				BL_TO_FORTRAN_3D(grown_state[mfi]),
 				BL_TO_FORTRAN_3D((*coeffs_temporary[0])[mfi]),
 				BL_TO_FORTRAN_3D((*coeffs_temporary[1])[mfi]),
 				BL_TO_FORTRAN_3D((*coeffs_temporary[2])[mfi]));
@@ -527,9 +495,8 @@ Castro::getSecndViscousTerm (Real time, MultiFab& ViscousTerm)
 }
 
 void
-Castro::getViscousTermForEnergy (Real time, MultiFab& ViscousTerm)
+Castro::getViscousTermForEnergy (Real time, MultiFab& state, MultiFab& ViscousTerm)
 {
-   MultiFab& S_old = get_old_data(State_Type);
 
    // Fill coefficients at this level.
    Vector<std::unique_ptr<MultiFab> > coeffs(BL_SPACEDIM);
@@ -543,21 +510,21 @@ Castro::getViscousTermForEnergy (Real time, MultiFab& ViscousTerm)
        }
    }
 
-   FillPatchIterator fpi(*this,S_old,2,time,State_Type,0,NUM_STATE);
-   MultiFab& state_old = fpi.get_mf();
+   FillPatchIterator fpi(*this, state, 2, time, State_Type, 0, NUM_STATE);
+   MultiFab& grown_state = fpi.get_mf();
 
    const Geometry& fine_geom = parent->Geom(parent->finestLevel());
    const Real*       dx_fine = fine_geom.CellSize();
 
    // Remember this is just 1-d
    int coord_type = Geometry::Coord();
-   for (MFIter mfi(state_old); mfi.isValid(); ++mfi)
+   for (MFIter mfi(grown_state); mfi.isValid(); ++mfi)
    {
        const Box& bx = grids[mfi.index()];
 
        ca_compute_div_tau_u(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
 			    BL_TO_FORTRAN_3D(ViscousTerm[mfi]),
-			    BL_TO_FORTRAN_3D(state_old[mfi]),
+			    BL_TO_FORTRAN_3D(grown_state[mfi]),
 			    ZFILL(dx_fine),&coord_type);
    }
 

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -264,15 +264,17 @@ public:
 
     bool source_flag(int src);
 
+    bool apply_sources();
+
     static int get_output_at_completion();
 
-    void do_old_sources(amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
+    void do_old_sources(amrex::MultiFab& source, amrex::MultiFab& state, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
 
-    void construct_old_source(int src, amrex::MultiFab& source, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
+    void construct_old_source(int src, amrex::MultiFab& source, amrex::MultiFab& state, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
 
-    void do_new_sources(amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
+    void do_new_sources(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
 
-    void construct_new_source(int src, amrex::MultiFab& source, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
+    void construct_new_source(int src, amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
 
     amrex::Vector<amrex::Real> evaluate_source_change(amrex::MultiFab& update, amrex::Real dt, bool local = false);
 
@@ -288,14 +290,14 @@ public:
 				   amrex::Real dt = 1.0);
 
 #ifdef SPONGE
-    void construct_old_sponge_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_old_sponge_source(amrex::MultiFab& source, amrex::MultiFab& state, amrex::Real time, amrex::Real dt);
 
-    void construct_new_sponge_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_new_sponge_source(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt);
 #endif
 
-    void construct_old_ext_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_old_ext_source(amrex::MultiFab& source, amrex::MultiFab& state, amrex::Real time, amrex::Real dt);
 
-    void construct_new_ext_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_new_ext_source(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt);
 
     void fill_ext_source(amrex::Real time, amrex::Real dt, amrex::MultiFab& S_old, amrex::MultiFab& S_new, amrex::MultiFab& ext_src);
 
@@ -307,9 +309,9 @@ public:
     void construct_new_gravity(int amr_iteration, int amr_ncycle,
 			       amrex::Real time);
 #endif
-    void construct_old_gravity_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_old_gravity_source(amrex::MultiFab& source, amrex::MultiFab& state, amrex::Real time, amrex::Real dt);
 
-    void construct_new_gravity_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_new_gravity_source(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt);
 #endif
 
     //
@@ -460,9 +462,9 @@ public:
 
     void construct_new_rotation(int amr_iteration, int amr_ncycle, amrex::Real time);
 
-    void construct_old_rotation_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_old_rotation_source(amrex::MultiFab& source, amrex::MultiFab& state, amrex::Real time, amrex::Real dt);
 
-    void construct_new_rotation_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_new_rotation_source(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt);
 
     void fill_rotation_field(amrex::MultiFab& phi, amrex::MultiFab& rot, amrex::MultiFab& state, amrex::Real time);
 #endif
@@ -482,26 +484,26 @@ public:
     void swap_state_time_levels (const amrex::Real dt);
 
 #ifdef DIFFUSION
-    void construct_old_diff_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
-    void construct_new_diff_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_old_diff_source(amrex::MultiFab& source, amrex::MultiFab& state, amrex::Real time, amrex::Real dt);
+    void construct_new_diff_source(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt);
 
-    void getTempDiffusionTerm (amrex::Real time, amrex::MultiFab& DiffTerm, int is_old);
-    void getEnthDiffusionTerm (amrex::Real time, amrex::MultiFab& DiffTerm, int is_old);
+    void getTempDiffusionTerm (amrex::Real time, amrex::MultiFab& state, amrex::MultiFab& DiffTerm);
+    void getEnthDiffusionTerm (amrex::Real time, amrex::MultiFab& state, amrex::MultiFab& DiffTerm);
 #if (BL_SPACEDIM == 1)
-    void getSpecDiffusionTerm (amrex::Real time, amrex::MultiFab& DiffTerm, int is_old);
+    void getSpecDiffusionTerm (amrex::Real time, amrex::MultiFab& state, amrex::MultiFab& DiffTerm);
 #endif
 #if (BL_SPACEDIM == 1)
-    void getViscousTerm (amrex::Real time, amrex::MultiFab& ViscousTermforMomentum, amrex::MultiFab& ViscousTermforEnergy);
-    void getFirstViscousTerm (amrex::Real time, amrex::MultiFab& ViscousTerm);
-    void getSecndViscousTerm (amrex::Real time, amrex::MultiFab& ViscousTerm);
-    void getViscousTermForEnergy (amrex::Real time, amrex::MultiFab& ViscousTermforEnergy);
+    void getViscousTerm (amrex::Real time, amrex::MultiFab& state, amrex::MultiFab& ViscousTermforMomentum, amrex::MultiFab& ViscousTermforEnergy);
+    void getFirstViscousTerm (amrex::Real time, amrex::MultiFab& state, amrex::MultiFab& ViscousTerm);
+    void getSecndViscousTerm (amrex::Real time, amrex::MultiFab& state, amrex::MultiFab& ViscousTerm);
+    void getViscousTermForEnergy (amrex::Real time, amrex::MultiFab& state, amrex::MultiFab& ViscousTermforEnergy);
 #endif
-    void add_temp_diffusion_to_source (amrex::MultiFab& ext_src, amrex::MultiFab& DiffTerm, amrex::Real t, int is_old, amrex::Real mult_factor = 1.0);
+    void add_temp_diffusion_to_source (amrex::MultiFab& ext_src, amrex::MultiFab& source, amrex::MultiFab& DiffTerm, amrex::Real t, amrex::Real mult_factor = 1.0);
 #if (BL_SPACEDIM == 1)
-    void add_spec_diffusion_to_source (amrex::MultiFab& ext_src, amrex::MultiFab& DiffTerm, amrex::Real t, int is_old, amrex::Real mult_factor = 1.0);
+    void add_spec_diffusion_to_source (amrex::MultiFab& ext_src, amrex::MultiFab& source, amrex::MultiFab& DiffTerm, amrex::Real t, amrex::Real mult_factor = 1.0);
 #endif
 #if (BL_SPACEDIM == 1)
-    void add_viscous_term_to_source   (amrex::MultiFab& ext_src, amrex::MultiFab& ViscousTermforMomentum, 
+    void add_viscous_term_to_source   (amrex::MultiFab& ext_src, amrex::MultiFab& state, amrex::MultiFab& ViscousTermforMomentum, 
                                        amrex::MultiFab& ViscousTermforEnergy, amrex::Real t, amrex::Real mult_factor = 1.0);
 #endif
 #endif
@@ -532,9 +534,9 @@ public:
     amrex::Real get_point_mass ();
 
 #ifdef HYBRID_MOMENTUM
-    void construct_old_hybrid_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_old_hybrid_source(amrex::MultiFab& source, amrex::MultiFab& state, amrex::Real time, amrex::Real dt);
 
-    void construct_new_hybrid_source(amrex::MultiFab& source, amrex::Real time, amrex::Real dt);
+    void construct_new_hybrid_source(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt);
 
     void fill_hybrid_hydro_source(amrex::MultiFab& state, amrex::MultiFab& source, const amrex::Real mult_factor);
 

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -222,13 +222,13 @@ Castro::do_advance (Real time,
       construct_old_gravity(amr_iteration, amr_ncycle, prev_time);
 #endif
 
+      MultiFab& old_source = get_old_data(Source_Type);
+
       if (apply_sources()) {
 
-          MultiFab& source = get_old_data(Source_Type);
+          do_old_sources(old_source, Sborder, prev_time, dt, amr_iteration, amr_ncycle);
 
-          do_old_sources(source, Sborder, prev_time, dt, amr_iteration, amr_ncycle);
-
-          apply_source_to_state(S_new, source, dt, S_new.nGrow());
+          apply_source_to_state(S_new, old_source, dt, S_new.nGrow());
 
           // Apply the old sources to the sources for the hydro.
           // Note that we are doing an add here, not a copy,
@@ -236,6 +236,10 @@ Castro::do_advance (Real time,
           // terms (e.g. the source term predictor, or the SDC source).
 
           AmrLevel::FillPatchAdd(*this, sources_for_hydro, NUM_GROW, time, Source_Type, 0, NUM_STATE);
+
+      } else {
+
+          old_source.setVal(0.0, NUM_GROW);
 
       }
 
@@ -341,13 +345,17 @@ Castro::do_advance (Real time,
       construct_new_gravity(amr_iteration, amr_ncycle, cur_time);
 #endif
 
+      MultiFab& new_source = get_new_data(Source_Type);
+
       if (apply_sources()) {
 
-          MultiFab& source = get_new_data(Source_Type);
+          do_new_sources(new_source, Sborder, S_new, cur_time, dt, amr_iteration, amr_ncycle);
 
-          do_new_sources(source, Sborder, S_new, cur_time, dt, amr_iteration, amr_ncycle);
+          apply_source_to_state(S_new, new_source, dt, S_new.nGrow());
 
-          apply_source_to_state(S_new, source, dt, S_new.nGrow());
+      } else {
+
+          new_source.setVal(0.0, NUM_GROW);
 
       }
 

--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -223,7 +223,7 @@ Castro::construct_new_gravity(int amr_iteration, int amr_ncycle, Real time)
 }
 #endif
 
-void Castro::construct_old_gravity_source(MultiFab& source, Real time, Real dt)
+void Castro::construct_old_gravity_source(MultiFab& source, MultiFab& state, Real time, Real dt)
 {
 
 #ifdef SELF_GRAVITY
@@ -242,13 +242,13 @@ void Castro::construct_old_gravity_source(MultiFab& source, Real time, Real dt)
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    for (MFIter mfi(Sborder,true); mfi.isValid(); ++mfi)
+    for (MFIter mfi(state, true); mfi.isValid(); ++mfi)
     {
 	const Box& bx = mfi.tilebox();
 
 	ca_gsrc(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
 		ARLIM_3D(domlo), ARLIM_3D(domhi),
-		BL_TO_FORTRAN_3D(Sborder[mfi]),
+		BL_TO_FORTRAN_3D(state[mfi]),
 #ifdef SELF_GRAVITY
 		BL_TO_FORTRAN_3D(phi_old[mfi]),
 		BL_TO_FORTRAN_3D(grav_old[mfi]),
@@ -260,10 +260,8 @@ void Castro::construct_old_gravity_source(MultiFab& source, Real time, Real dt)
 
 }
 
-void Castro::construct_new_gravity_source(MultiFab& source, Real time, Real dt)
+void Castro::construct_new_gravity_source(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt)
 {
-    MultiFab& S_old = get_old_data(State_Type);
-    MultiFab& S_new = get_new_data(State_Type);
 
 #ifdef SELF_GRAVITY
     MultiFab& phi_old = get_old_data(PhiGrav_Type);
@@ -283,14 +281,14 @@ void Castro::construct_new_gravity_source(MultiFab& source, Real time, Real dt)
 #pragma omp parallel
 #endif
     {
-	for (MFIter mfi(S_new,true); mfi.isValid(); ++mfi)
+	for (MFIter mfi(state_new, true); mfi.isValid(); ++mfi)
 	{
 	    const Box& bx = mfi.tilebox();
 
 	    ca_corrgsrc(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
 			ARLIM_3D(domlo), ARLIM_3D(domhi),
-			BL_TO_FORTRAN_3D(S_old[mfi]),
-			BL_TO_FORTRAN_3D(S_new[mfi]),
+			BL_TO_FORTRAN_3D(state_old[mfi]),
+			BL_TO_FORTRAN_3D(state_new[mfi]),
 #ifdef SELF_GRAVITY
 			BL_TO_FORTRAN_3D(phi_old[mfi]),
 			BL_TO_FORTRAN_3D(phi_new[mfi]),

--- a/Source/hydro/Castro_hybrid.cpp
+++ b/Source/hydro/Castro_hybrid.cpp
@@ -4,33 +4,29 @@
 using namespace amrex;
 
 void
-Castro::construct_old_hybrid_source(MultiFab& source, Real time, Real dt)
+Castro::construct_old_hybrid_source(MultiFab& source, MultiFab& state, Real time, Real dt)
 {
     Real mult_factor = 1.0;
 
-    fill_hybrid_hydro_source(source, Sborder, mult_factor);
+    fill_hybrid_hydro_source(source, state, mult_factor);
 }
 
 
 
 void
-Castro::construct_new_hybrid_source(MultiFab& source, Real time, Real dt)
+Castro::construct_new_hybrid_source(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt)
 {
-    MultiFab& S_old = get_old_data(State_Type);
-    MultiFab& S_new = get_new_data(State_Type);
-
     // Start by subtracting off the old-time data.
 
     Real mult_factor = -0.5;
 
-    fill_hybrid_hydro_source(source, S_old, mult_factor);
+    fill_hybrid_hydro_source(source, state_old, mult_factor);
 
     // Time center with the new data.
 
     mult_factor = 0.5;
 
-    fill_hybrid_hydro_source(source, S_new, mult_factor);
-
+    fill_hybrid_hydro_source(source, state_new, mult_factor);
 }
 
 

--- a/Source/sources/Castro_external.cpp
+++ b/Source/sources/Castro_external.cpp
@@ -4,7 +4,7 @@
 using namespace amrex;
 
 void
-Castro::construct_old_ext_source(MultiFab& source, Real time, Real dt)
+Castro::construct_old_ext_source(MultiFab& source, MultiFab& state, Real time, Real dt)
 {
     if (!add_ext_src) return;
 
@@ -12,7 +12,7 @@ Castro::construct_old_ext_source(MultiFab& source, Real time, Real dt)
 
     ext_src.setVal(0.0);
 
-    fill_ext_source(time, dt, Sborder, Sborder, ext_src);
+    fill_ext_source(time, dt, state, state, ext_src);
 
     Real mult_factor = 1.0;
 
@@ -22,11 +22,8 @@ Castro::construct_old_ext_source(MultiFab& source, Real time, Real dt)
 
 
 void
-Castro::construct_new_ext_source(MultiFab& source, Real time, Real dt)
+Castro::construct_new_ext_source(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt)
 {
-    MultiFab& S_old = get_old_data(State_Type);
-    MultiFab& S_new = get_new_data(State_Type);
-
     if (!add_ext_src) return;
 
     MultiFab ext_src(grids, dmap, NUM_STATE, 0);
@@ -38,7 +35,7 @@ Castro::construct_new_ext_source(MultiFab& source, Real time, Real dt)
     Real old_time = time - dt;
     Real mult_factor = -0.5;
 
-    fill_ext_source(old_time, dt, S_old, S_old, ext_src);
+    fill_ext_source(old_time, dt, state_old, state_old, ext_src);
 
     MultiFab::Saxpy(source, mult_factor, ext_src, 0, 0, NUM_STATE, 0);
 
@@ -48,7 +45,7 @@ Castro::construct_new_ext_source(MultiFab& source, Real time, Real dt)
 
     mult_factor = 0.5;
 
-    fill_ext_source(time, dt, S_old, S_new, ext_src);
+    fill_ext_source(time, dt, state_old, state_new, ext_src);
 
     MultiFab::Saxpy(source, mult_factor, ext_src, 0, 0, NUM_STATE, 0);
 

--- a/Source/sources/Castro_sponge.cpp
+++ b/Source/sources/Castro_sponge.cpp
@@ -5,7 +5,7 @@
 using namespace amrex;
 
 void
-Castro::construct_old_sponge_source(MultiFab& source, Real time, Real dt)
+Castro::construct_old_sponge_source(MultiFab& source, MultiFab& state, Real time, Real dt)
 {
 
     if (!do_sponge) return;
@@ -19,12 +19,12 @@ Castro::construct_old_sponge_source(MultiFab& source, Real time, Real dt)
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    for (MFIter mfi(Sborder,true); mfi.isValid(); ++mfi)
+    for (MFIter mfi(state, true); mfi.isValid(); ++mfi)
     {
 	const Box& bx = mfi.tilebox();
 
 	ca_sponge(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
-		  BL_TO_FORTRAN_3D(Sborder[mfi]),
+		  BL_TO_FORTRAN_3D(state[mfi]),
 		  BL_TO_FORTRAN_3D(source[mfi]),
 		  BL_TO_FORTRAN_3D(volume[mfi]),
 		  ZFILL(dx), dt, time, mult_factor);
@@ -34,10 +34,8 @@ Castro::construct_old_sponge_source(MultiFab& source, Real time, Real dt)
 }
 
 void
-Castro::construct_new_sponge_source(MultiFab& source, Real time, Real dt)
+Castro::construct_new_sponge_source(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt)
 {
-    MultiFab& S_old = get_old_data(State_Type);
-    MultiFab& S_new = get_new_data(State_Type);
 
     if (!do_sponge) return;
 
@@ -53,12 +51,12 @@ Castro::construct_new_sponge_source(MultiFab& source, Real time, Real dt)
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    for (MFIter mfi(S_old,true); mfi.isValid(); ++mfi)
+    for (MFIter mfi(state_old, true); mfi.isValid(); ++mfi)
     {
         const Box& bx = mfi.tilebox();
 
         ca_sponge(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
-                  BL_TO_FORTRAN_3D(S_old[mfi]),
+                  BL_TO_FORTRAN_3D(state_old[mfi]),
                   BL_TO_FORTRAN_3D(source[mfi]),
                   BL_TO_FORTRAN_3D(volume[mfi]),
                   ZFILL(dx), dt, time, mult_factor_old);
@@ -73,12 +71,12 @@ Castro::construct_new_sponge_source(MultiFab& source, Real time, Real dt)
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    for (MFIter mfi(S_new,true); mfi.isValid(); ++mfi)
+    for (MFIter mfi(state_new, true); mfi.isValid(); ++mfi)
     {
 	const Box& bx = mfi.tilebox();
 
 	ca_sponge(ARLIM_3D(bx.loVect()), ARLIM_3D(bx.hiVect()),
-                  BL_TO_FORTRAN_3D(S_new[mfi]),
+                  BL_TO_FORTRAN_3D(state_new[mfi]),
 		  BL_TO_FORTRAN_3D(source[mfi]),
 		  BL_TO_FORTRAN_3D(volume[mfi]),
 		  ZFILL(dx), dt, time, mult_factor_new);


### PR DESCRIPTION
This generalizes the algorithm so that one can choose which state MultiFab to send in for calculating the source terms. This is a step in the direction of enabling source term calculations at arbitrary times, which is useful for MOL, and also allows the old source terms to be either calculated with either S_old or Sborder (which can be useful if trying to reconstruct the source terms at a later time when Sborder is no longer available).

This changes results for diffusion if reactions are also enabled, since diffusion was previously using the unreacted S_old state, not Sborder.

Fixes #269 
Fixes #268 
Closes #168