### PR TITLE
change how we set variables to index state arrays

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -566,7 +566,6 @@ public:
     static int       Shock;
 #endif
     static int       QVAR;
-    static int       QRADVAR;
     static int       NQAUX;
     static int       NQ;
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -90,7 +90,6 @@ int          Castro::Shock         = -1;
 #endif
 
 int          Castro::QVAR          = -1;
-int          Castro::QRADVAR       = 0;
 int          Castro::NQAUX         = -1;
 int          Castro::NQ            = -1;
 
@@ -539,25 +538,6 @@ Castro::Castro (Amr&            papa,
       radiation->regrid(level, grids, dmap);
     }
 #endif
-
-
-    // initialize the Godunov state array used in hydro -- we wait
-    // until here so that ngroups is defined (if needed) in
-    // rad_params_module
-#ifdef RADIATION
-    ca_init_godunov_indices_rad();
-    ca_get_qradvar(&QRADVAR);
-
-    // NQAUX depends on radiation groups, so get it fresh here
-    ca_get_nqaux(&NQAUX);
-#else
-    ca_init_godunov_indices();
-#endif
-
-    // NQ will be used to dimension the primitive variable state
-    // vector it will include the "pure" hydrodynamical variables +
-    // any radiation variables
-    NQ = QVAR + QRADVAR;
 
 }
 
@@ -1731,25 +1711,6 @@ Castro::post_restart ()
                                      cs_level.Volume(),cs_level.Area());
          }
 #endif
-
-
-    // initialize the Godunov state array used in hydro -- we wait
-    // until here so that ngroups is defined (if needed) in
-    // rad_params_module
-#ifdef RADIATION
-    ca_init_godunov_indices_rad();
-    ca_get_qradvar(&QRADVAR);
-
-    // NQAUX depends on radiation groups, so get it fresh here
-    ca_get_nqaux(&NQAUX);
-#else
-    ca_init_godunov_indices();
-#endif
-
-    // NQ will be used to dimension the primitive variable state
-    // vector it will include the "pure" hydrodynamical variables +
-    // any radiation variables
-    NQ = QVAR + QRADVAR;
 
 #ifdef DO_PROBLEM_POST_RESTART
     problem_post_restart();

--- a/Source/driver/Castro_F.H
+++ b/Source/driver/Castro_F.H
@@ -28,9 +28,7 @@ extern "C"
 
   void ca_get_qvar(int* qvar);
 
-#ifdef RADIATION
-  void ca_get_qradvar(int* qradvar);
-#endif
+  void ca_get_nq(int* nq);
 
   void ca_get_nqaux(int* nqaux);
 

--- a/Source/driver/Castro_F.H
+++ b/Source/driver/Castro_F.H
@@ -62,6 +62,9 @@ extern "C"
 #ifdef SHOCK_VAR
      const int& Shock,
 #endif
+#ifdef RADIATION
+     const int& ngroups,
+#endif
      const int* gravity_type, const int& gravity_type_len);
 
   void ca_finalize_meth_params();

--- a/Source/driver/Castro_F.H
+++ b/Source/driver/Castro_F.H
@@ -53,6 +53,9 @@ extern "C"
   void ca_set_method_params
     (const int& dm,
      const int& Density, const int& Xmom, 
+#ifdef HYBRID_MOMENTUM
+     const int& Rmom,
+#endif
      const int& Eden,    const int& Eint, 
      const int& Temp     , const int& FirstAdv, 
      const int& FirstSpec, const int& FirstAux, 

--- a/Source/driver/Castro_F.H
+++ b/Source/driver/Castro_F.H
@@ -69,11 +69,7 @@ extern "C"
 
   void ca_set_castro_method_params();
 
-#ifdef RADIATION
-  void ca_init_godunov_indices_rad();
-#else
   void ca_init_godunov_indices();
-#endif
 
   void ca_set_problem_params
     (const int& dm,

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -670,17 +670,9 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
 
     // Allocate space for the primitive variables.
 
-#ifdef RADIATION
-    q.define(grids, dmap, QRADVAR, NUM_GROW);
-#else
-    q.define(grids, dmap, QVAR, NUM_GROW);
-#endif
-
+    q.define(grids, dmap, NQ, NUM_GROW);
     qaux.define(grids, dmap, NQAUX, NUM_GROW);
-
     src_q.define(grids, dmap, QVAR, NUM_GROW);
-
-
 
     if (!do_ctu) {
       // if we are not doing CTU advection, then we are doing a method

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -476,7 +476,7 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   ! primitive state components
   !---------------------------------------------------------------------
 
-  ! QTHERM: number of primitive variables: rho, p, (rho e), T + 3 velocity components 
+  ! QTHERM: number of primitive variables: rho, p, (rho e), T + 3 velocity components
   ! QVAR  : number of total variables in primitive form
 
   QTHERM = NTHERM + 1 ! the + 1 is for QGAME which is always defined in primitive mode
@@ -490,7 +490,7 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 #endif
 
   QVAR = QTHERM + nspec + naux + numadv
-  
+
   ! NQ will be the number of hydro + radiation variables in the primitive
   ! state.  Initialize it just for hydro here
   NQ = QVAR
@@ -529,18 +529,28 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 
   end if
 
+#ifdef RADIATION
+  QPTOT  = QVAR+1
+  QREITOT = QVAR+2
+  QRAD = QVAR+3
+  QRADHI = qrad+ngroups-1
+
+  QRADVAR = QVAR + 2 + ngroups
+
+  ! update NQ -- it was already initialized above
+  NQ = QRADVAR
+#endif
+
   ! The NQAUX here are auxiliary quantities (game, gamc, c, csml, dpdr, dpde)
   ! that we create in the primitive variable call but that do not need to
   ! participate in tracing.
-  ! Note: radiation adds cg, gamcg, lambda (ngroups components), but we don't
-  ! yet know the number of radiation groups, so we'll add that lambda count
-  ! to it later
-   
+  ! Note: radiation adds cg, gamcg, lambda (ngroups components)
+
 #ifdef RADIATION
-  NQAUX = 6 !+ ngroups to be added later
+  NQAUX = 6 + ngroups
 #else
   NQAUX = 4
-#endif        
+#endif
 
   QGAMC   = 1
   QC      = 2

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -525,10 +525,8 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   QRAD = QVAR+3
   QRADHI = qrad+ngroups-1
 
-  QRADVAR = QVAR + 2 + ngroups
-
   ! update NQ -- it was already initialized above
-  NQ = QRADVAR
+  NQ = QVAR + 2 + ngroups
 #endif
 
   ! The NQAUX here are auxiliary quantities (game, gamc, c, csml, dpdr, dpde)

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -665,18 +665,33 @@ end subroutine ca_set_method_params
 subroutine ca_init_godunov_indices() bind(C, name="ca_init_godunov_indices")
 
   use meth_params_module, only: GDRHO, GDU, GDV, GDW, GDPRES, GDGAME, NGDNV, &
+#ifdef RADIATION
+                                GDLAMS, GDERADS, &
+#endif
                                 QU, QV, QW
+
   use amrex_fort_module, only: rt => amrex_real
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
 
   implicit none
 
   NGDNV = 6
+#if RADIATION
+  NGDNV = NGDNV + 2*ngroups
+#endif
+
   GDRHO = 1
   GDU = 2
   GDV = 3
   GDW = 4
   GDPRES = 5
   GDGAME = 6
+#ifdef RADIATION
+  GDLAMS = GDGAME+1            ! starting index for rad lambda
+  GDERADS = GDLAMS + ngroups   ! starting index for rad energy
+#endif
 
   ! sanity check
   if ((QU /= GDU) .or. (QV /= GDV) .or. (QW /= GDW)) then

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -376,6 +376,9 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 #ifdef SHOCK_VAR
                                 Shock, &
 #endif
+#ifdef RADIATION
+                                ngroups_in, &
+#endif
                                 gravity_type_in, gravity_type_len) &
                                 bind(C, name="ca_set_method_params")
 
@@ -384,10 +387,10 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   use eos_module, only: eos_init
   use eos_type_module, only: eos_get_small_dens, eos_get_small_temp
   use bl_constants_module, only : ZERO, ONE
+  use amrex_fort_module, only: rt => amrex_real
 #ifdef RADIATION
   use rad_params_module, only: ngroups
 #endif
-  use amrex_fort_module, only: rt => amrex_real
 
   implicit none
 
@@ -400,6 +403,10 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 #endif
   integer, intent(in) :: gravity_type_len
   integer, intent(in) :: gravity_type_in(gravity_type_len)
+#ifdef RADIATION
+  integer, intent(in) :: ngroups_in
+#endif
+
   integer :: iadv, ispec
 
   integer :: QLAST
@@ -407,6 +414,10 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 
   integer :: i
   integer :: ioproc
+
+#ifdef RADIATION
+  ngroups = ngroups_in
+#endif
 
   !---------------------------------------------------------------------
   ! conserved state components

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -155,7 +155,6 @@ end subroutine ca_get_aux_names
 subroutine ca_get_qvar(qvar_in) bind(C, name="ca_get_qvar")
 
   use meth_params_module, only: QVAR
-  use amrex_fort_module, only: rt => amrex_real
 
   implicit none
 
@@ -165,30 +164,21 @@ subroutine ca_get_qvar(qvar_in) bind(C, name="ca_get_qvar")
 
 end subroutine ca_get_qvar
 
-#ifdef RADIATION
-subroutine ca_get_qradvar(qradvar_in) bind(C, name="ca_get_qradvar")
+subroutine ca_get_nq(nq_in) bind(C, name="ca_get_nq")
 
-  use meth_params_module, only: QRADVAR
-  use amrex_fort_module, only: rt => amrex_real
+  use meth_params_module, only: NQ
 
   implicit none
 
-  integer, intent(inout) :: qradvar_in
+  integer, intent(inout) :: nq_in
 
-  qradvar_in = QRADVAR
+  nq_in = NQ
 
-end subroutine ca_get_qradvar
-#endif
-
-
-! :::
-! ::: ----------------------------------------------------------------
-! :::
+end subroutine ca_get_nq
 
 subroutine ca_get_nqaux(nqaux_in) bind(C, name="ca_get_nqaux")
 
   use meth_params_module, only: NQAUX
-  use amrex_fort_module, only: rt => amrex_real
 
   implicit none
 

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -361,8 +361,12 @@ end subroutine swap_outflow_data
 ! ::: ----------------------------------------------------------------
 ! :::
 
-subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
-                                FirstAdv,FirstSpec,FirstAux,numadv, &
+subroutine ca_set_method_params(dm, Density, Xmom, &
+#ifdef HYBRID_MOMENTUM
+                                Rmom, &
+#endif
+                                Eden, Eint, Temp, &
+                                FirstAdv, FirstSpec, FirstAux, numadv, &
 #ifdef SHOCK_VAR
                                 Shock, &
 #endif
@@ -414,8 +418,17 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
   !---------------------------------------------------------------------
   call ca_set_godunov_indices()
 
-  call ca_set_conserved_indices(Xmom+1, Xmom+2, Eint, 0, Density, &
-       FirstSpec, FirstAdv, FirstAux, Xmom, Temp, Eden)
+  call ca_set_conserved_indices( &
+#ifdef HYBRID_ADVECTION
+                                Rmom, Rmom+1, Rmom+2, &
+#endif
+#ifdef SHOCK
+                                Shock, &
+#endif
+                                Density ,Xmom, Xmom+1, Xmom+2, &
+                                Eden, Eint, Temp, &
+                                FirstSpec, FirstAdv, FirstAux &
+                                )
 
   call ca_set_auxillary_indices()
 

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -390,7 +390,7 @@ subroutine ca_set_method_params(dm, Density, Xmom, &
 
   integer, intent(in) :: dm
   integer, intent(in) :: Density, Xmom, Eden, Eint, Temp, &
-       FirstAdv, FirstSpec, FirstAux
+                         FirstAdv, FirstSpec, FirstAux
   integer, intent(in) :: numadv
 #ifdef SHOCK_VAR
   integer, intent(in) :: Shock
@@ -399,6 +399,9 @@ subroutine ca_set_method_params(dm, Density, Xmom, &
   integer, intent(in) :: gravity_type_in(gravity_type_len)
 #ifdef RADIATION
   integer, intent(in) :: ngroups_in
+#endif
+#ifdef ROTATION
+  integer, intent(in) :: Rmom
 #endif
 
   integer :: iadv, ispec

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -421,27 +421,11 @@ subroutine ca_set_method_params(dm, Density, Xmom, &
   !---------------------------------------------------------------------
   call ca_set_godunov_indices()
 
-  print *, "about to call"
-  print *, "Rmom = ", Rmom
-  print *, "Lmom = ", Rmom+1
-  print *, "Pmom = ", Rmom+2
-  print *, "Density = ", Density
-  print *, "Xmom = ", Xmom
-  print *, "Ymom = ", Xmom+1
-  print *, "Zmom = ", Xmom+2
-  print *, "Eden = ", Eden
-  print *, "Eint = ", Eint
-  print *, "Temp = ", Temp
-  print *, "FirstAdv = ", FirstAdv
-  print *, "FirstSpec = ", FirstSpec
-  print *, "FirstAux = ", FirstAux
-
-
   call ca_set_conserved_indices( &
-#ifdef HYBRID_ADVECTION
+#ifdef HYBRID_MOMENTUM
                                 Rmom, Rmom+1, Rmom+2, &
 #endif
-#ifdef SHOCK
+#ifdef SHOCK_VAR
                                 Shock, &
 #endif
                                 Density ,Xmom, Xmom+1, Xmom+2, &

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -421,6 +421,22 @@ subroutine ca_set_method_params(dm, Density, Xmom, &
   !---------------------------------------------------------------------
   call ca_set_godunov_indices()
 
+  print *, "about to call"
+  print *, "Rmom = ", Rmom
+  print *, "Lmom = ", Rmom+1
+  print *, "Pmom = ", Rmom+2
+  print *, "Density = ", Density
+  print *, "Xmom = ", Xmom
+  print *, "Ymom = ", Xmom+1
+  print *, "Zmom = ", Xmom+2
+  print *, "Eden = ", Eden
+  print *, "Eint = ", Eint
+  print *, "Temp = ", Temp
+  print *, "FirstAdv = ", FirstAdv
+  print *, "FirstSpec = ", FirstSpec
+  print *, "FirstAux = ", FirstAux
+
+
   call ca_set_conserved_indices( &
 #ifdef HYBRID_ADVECTION
                                 Rmom, Rmom+1, Rmom+2, &

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -427,7 +427,7 @@ subroutine ca_set_method_params(dm, Density, Xmom, &
 #endif
                                 Density ,Xmom, Xmom+1, Xmom+2, &
                                 Eden, Eint, Temp, &
-                                FirstSpec, FirstAdv, FirstAux &
+                                FirstAdv, FirstSpec, FirstAux &
                                 )
 
   call ca_set_auxillary_indices()

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -410,145 +410,16 @@ subroutine ca_set_method_params(dm,Density,Xmom,Eden,Eint,Temp, &
 #endif
 
   !---------------------------------------------------------------------
-  ! conserved state components
+  ! set integer keys to index states
   !---------------------------------------------------------------------
+  call ca_set_godunov_indices()
 
-  ! NTHERM: number of thermodynamic variables (rho, 3 momenta, rho*e, rho*E, T)
-  ! NVAR  : number of total variables in initial system
-  NTHERM = 7
+  call ca_set_conserved_indices(Xmom+1, Xmom+2, Eint, 0, Density, &
+       FirstSpec, FirstAdv, FirstAux, Xmom, Temp, Eden)
 
-#ifdef HYBRID_MOMENTUM
-  ! Include the hybrid momenta in here as well if we're using them.
+  call ca_set_auxillary_indices()
 
-  NTHERM = NTHERM + 3
-#endif
-
-  NVAR = NTHERM + nspec + naux + numadv
-
-  nadv = numadv
-
-  ! We use these to index into the state "U"
-  URHO  = Density   + 1
-  UMX   = Xmom      + 1
-  UMY   = Xmom      + 2
-  UMZ   = Xmom      + 3
-#ifdef HYBRID_MOMENTUM
-  UMR   = Xmom      + 4
-  UML   = Xmom      + 5
-  UMP   = Xmom      + 6
-#endif
-  UEDEN = Eden      + 1
-  UEINT = Eint      + 1
-  UTEMP = Temp      + 1
-
-  if (numadv .ge. 1) then
-     UFA   = FirstAdv  + 1
-  else
-     UFA = 1
-  end if
-
-  UFS   = FirstSpec + 1
-
-  if (naux .ge. 1) then
-     UFX = FirstAux  + 1
-  else
-     UFX = 1
-  end if
-
-#ifdef SHOCK_VAR
-  USHK  = Shock + 1
-  NVAR  = NVAR + 1
-#else
-  USHK  = -1
-#endif
-
-  !---------------------------------------------------------------------
-  ! primitive state components
-  !---------------------------------------------------------------------
-
-  ! QTHERM: number of primitive variables: rho, p, (rho e), T + 3 velocity components
-  ! QVAR  : number of total variables in primitive form
-
-  QTHERM = NTHERM + 1 ! the + 1 is for QGAME which is always defined in primitive mode
-
-#ifdef HYBRID_MOMENTUM
-  ! There is no primitive variable analogue of the hybrid momenta;
-  ! all of the hydro reconstructions are done using the linear momenta,
-  ! which are always intended to be in sync with the hybrid momenta.
-
-  QTHERM = QTHERM - 3
-#endif
-
-  QVAR = QTHERM + nspec + naux + numadv
-
-  ! NQ will be the number of hydro + radiation variables in the primitive
-  ! state.  Initialize it just for hydro here
-  NQ = QVAR
-
-  ! We use these to index into the state "Q"
-  QRHO  = 1
-
-  QU    = 2
-  QV    = 3
-  QW    = 4
-
-  QGAME = 5
-
-  QLAST   = QGAME
-
-  QPRES   = QLAST + 1
-  QREINT  = QLAST + 2
-
-  QTEMP   = QTHERM ! = QLAST + 3
-
-  if (numadv >= 1) then
-     QFA = QTHERM + 1
-     QFS = QFA + numadv
-
-  else
-     QFA = 1   ! density
-     QFS = QTHERM + 1
-
-  end if
-
-  if (naux >= 1) then
-     QFX = QFS + nspec
-
-  else
-     QFX = 1
-
-  end if
-
-#ifdef RADIATION
-  QPTOT  = QVAR+1
-  QREITOT = QVAR+2
-  QRAD = QVAR+3
-  QRADHI = qrad+ngroups-1
-
-  ! update NQ -- it was already initialized above
-  NQ = QVAR + 2 + ngroups
-#endif
-
-  ! The NQAUX here are auxiliary quantities (game, gamc, c, csml, dpdr, dpde)
-  ! that we create in the primitive variable call but that do not need to
-  ! participate in tracing.
-  ! Note: radiation adds cg, gamcg, lambda (ngroups components)
-
-#ifdef RADIATION
-  NQAUX = 6 + ngroups
-#else
-  NQAUX = 4
-#endif
-
-  QGAMC   = 1
-  QC      = 2
-  QDPDR   = 3
-  QDPDE   = 4
-#ifdef RADIATION
-  QGAMCG  = 5
-  QCG     = 6
-  QLAMS   = 7
-#endif
+  call ca_set_primitive_indices()
 
   ! easy indexing for the passively advected quantities.  This
   ! lets us loop over all groups (advected, species, aux)

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -203,6 +203,8 @@ Castro::variableSetUp ()
   // Read in the input values to Fortran.
   ca_set_castro_method_params();
 
+  std::cout << "C++ " << Rmom << " " << Xmom << std::endl;
+
   ca_set_method_params(dm, Density, Xmom, 
 #ifdef HYBRID_MOMENTUM
                        Rmom,

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -239,13 +239,15 @@ Castro::variableSetUp ()
 
 
   // Read in the input values to Fortran.
-
   ca_set_castro_method_params();
 
   ca_set_method_params(dm, Density, Xmom, Eden, Eint, Temp, FirstAdv, FirstSpec, FirstAux,
 		       NumAdv,
 #ifdef SHOCK_VAR
 		       Shock,
+#endif
+#ifdef RADIATION
+                       Radiation::nGroups,
 #endif
 		       gravity_type_name.dataPtr(), gravity_type_length);
 

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -252,9 +252,19 @@ Castro::variableSetUp ()
 		       gravity_type_name.dataPtr(), gravity_type_length);
 
   // Get the number of primitive variables from Fortran.
-
   ca_get_qvar(&QVAR);
+
+  // and the auxillary variables
   ca_get_nqaux(&NQAUX);
+
+  // initialize the Godunov state array used in hydro 
+  ca_init_godunov_indices();
+
+  // NQ will be used to dimension the primitive variable state
+  // vector it will include the "pure" hydrodynamical variables +
+  // any radiation variables
+  ca_get_nq(&NQ);
+
 
   Real run_stop = ParallelDescriptor::second() - run_strt;
 

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -203,8 +203,6 @@ Castro::variableSetUp ()
   // Read in the input values to Fortran.
   ca_set_castro_method_params();
 
-  std::cout << "C++ " << Rmom << " " << Xmom << std::endl;
-
   ca_set_method_params(dm, Density, Xmom, 
 #ifdef HYBRID_MOMENTUM
                        Rmom,

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -161,9 +161,19 @@ Castro::variableSetUp ()
   burner_init();
 #endif
 
+  const int dm = BL_SPACEDIM;
+
+
   //
   // Set number of state variables and pointers to components
   //
+
+  // Get the number of species from the network model.
+  ca_get_num_spec(&NumSpec);
+
+  // Get the number of auxiliary quantities from the network model.
+  ca_get_num_aux(&NumAux);
+
 
   int cnt = 0;
   Density = cnt++;
@@ -191,10 +201,6 @@ Castro::variableSetUp ()
       cnt += NumAdv;
     }
 
-  const int dm = BL_SPACEDIM;
-
-  // Get the number of species from the network model.
-  ca_get_num_spec(&NumSpec);
 
   if (NumSpec > 0)
     {
@@ -202,8 +208,6 @@ Castro::variableSetUp ()
       cnt += NumSpec;
     }
 
-  // Get the number of auxiliary quantities from the network model.
-  ca_get_num_aux(&NumAux);
 
   if (NumAux > 0)
     {
@@ -241,7 +245,11 @@ Castro::variableSetUp ()
   // Read in the input values to Fortran.
   ca_set_castro_method_params();
 
-  ca_set_method_params(dm, Density, Xmom, Eden, Eint, Temp, FirstAdv, FirstSpec, FirstAux,
+  ca_set_method_params(dm, Density, Xmom, 
+#ifdef HYBRID_MOMENTUM
+                       Rmom,
+#endif
+                       Eden, Eint, Temp, FirstAdv, FirstSpec, FirstAux,
 		       NumAdv,
 #ifdef SHOCK_VAR
 		       Shock,

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -175,49 +175,7 @@ Castro::variableSetUp ()
   ca_get_num_aux(&NumAux);
 
 
-  int cnt = 0;
-  Density = cnt++;
-  Xmom = cnt++;
-  Ymom = cnt++;
-  Zmom = cnt++;
-#ifdef HYBRID_MOMENTUM
-  Rmom = cnt++;
-  Lmom = cnt++;
-  Pmom = cnt++;
-#endif
-  Eden = cnt++;
-  Eint = cnt++;
-  Temp = cnt++;
-
-#ifdef NUM_ADV
-  NumAdv = NUM_ADV;
-#else
-  NumAdv = 0;
-#endif
-
-  if (NumAdv > 0)
-    {
-      FirstAdv = cnt;
-      cnt += NumAdv;
-    }
-
-
-  if (NumSpec > 0)
-    {
-      FirstSpec = cnt;
-      cnt += NumSpec;
-    }
-
-
-  if (NumAux > 0)
-    {
-      FirstAux = cnt;
-      cnt += NumAux;
-    }
-
-#ifdef SHOCK_VAR
-  Shock = cnt++;
-#endif
+#include "set_conserved.H"
 
   NUM_STATE = cnt;
 

--- a/Source/driver/Make.package
+++ b/Source/driver/Make.package
@@ -13,6 +13,7 @@ CEXE_sources += main.cpp
 
 CEXE_headers += Castro.H
 CEXE_headers += Castro_io.H
+CEXE_headers += set_conserved.H
 
 CEXE_sources += sum_utils.cpp
 CEXE_sources += sum_integrated_quantities.cpp

--- a/Source/driver/Make.package
+++ b/Source/driver/Make.package
@@ -35,6 +35,7 @@ ca_f90EXE_sources += interpolate.f90
 ca_f90EXE_sources += io.f90
 ca_f90EXE_sources += math.f90
 ca_F90EXE_sources += meth_params.F90
+ca_F90EXE_sources += set_indices.F90
 
 NEED_MGUTIL =
 

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -49,7 +49,7 @@
    sound-speed           None          QC        None            1        None
    dpdr                  None          QDPDR     None            1        None
    dpde                  None          QDPDE     None            1        None
-   gamma_c-gas           None          QGAMCC    None            1        RADIATION
+   gamma_c-gas           None          QGAMCG    None            1        RADIATION
    sound-speed-gas       None          QCG       None            1        RADIATION
    flux-limiter          None          QLAMS     None          ngroups    RADIATION
 

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -12,7 +12,7 @@
    energy-density         Eden         UEDEN     None             1      None
    internal-energy        Eint         UEINT     None             1      None
    temperature            Temp         UTEMP     None             1      None
-   advected               FirstAdv     UFA       None           numadv   None
+   advected               FirstAdv     UFA       None           nadv     None
    species                FirstSpec    UFS       None           nspec    None
    auxillary              FirstAux     UFX       None           naux     None
    shock                  Shock        USHK      None             1      None
@@ -31,7 +31,7 @@
    B-y                    None         QMAGY     QVAR             1      MHD
    B-z                    None         QMAGZ     QVAR             1      MHD
    temperature            None         QTEMP     QVAR             1      None
-   advected               None         QFA       QVAR           numadv   None
+   advected               None         QFA       QVAR           nadv     None
    species                None         QFS       QVAR           nspec    None
    auxillary              None         QFX       QVAR           naux     None
    total-pressure         None         QPTOT     None             1      RADIATION

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -1,60 +1,64 @@
-#  descriptive-name     C++-name   Fortran-name   adds-to        count   if-def
+#  descriptive-name     C++-name   Fortran-name  also-adds-to    count   if-def
 
 # the conserved variable state
-   density                Density      URHO      NVAR              1      None
-   x-momentum             Xmom         UMX       NVAR              1      None
-   y-momentum             Ymom         UMY       NVAR              1      None
-   z-momentum             Zmom         UMZ       NVAR              1      None
-   radial-momentum        None         UMR       NVAR              1      HYBRID_MOMENTUM
-   angular-momentum       None         UML       NVAR              1      HYBRID_MOMENTUM
-   polar-momentum         None         UMP       NVAR              1      HYBRID_MOMENTUM
-   energy-density         Eden         UEDEN     NVAR              1      None
-   internal-energy        Eint         UEINT     NVAR              1      None
-   temperature            Temp         UTEMP     NVAR              1      None
-   advected               FirstAdv     UFA       NVAR            numadv   None
-   species                FirstSpec    UFS       NVAR            nspec    None
-   auxillary              FirstAux     UFX       NVAR            naux     None
-   shock                  Shock        USHK      NVAR              1      None
+@set: conserved NVAR
+   density                Density      URHO      None             1      None
+   x-momentum             Xmom         UMX       None             1      None
+   y-momentum             Ymom         UMY       None             1      None
+   z-momentum             Zmom         UMZ       None             1      None
+   radial-momentum        None         UMR       None             1      HYBRID_MOMENTUM
+   angular-momentum       None         UML       None             1      HYBRID_MOMENTUM
+   perpendicular-momentum None         UMP       None             1      HYBRID_MOMENTUM
+   energy-density         Eden         UEDEN     None             1      None
+   internal-energy        Eint         UEINT     None             1      None
+   temperature            Temp         UTEMP     None             1      None
+   advected               FirstAdv     UFA       None           numadv   None
+   species                FirstSpec    UFS       None           nspec    None
+   auxillary              FirstAux     UFX       None           naux     None
+   shock                  Shock        USHK      None             1      None
 
 
 # the primitive variable state
-   density                None         QRHO      (QVAR, NQ)        1      None
-   x-velocity             None         QU        (QVAR, NQ)        1      None
-   y-velocity             None         QV        (QVAR, NQ)        1      None
-   z-velocity             None         QW        (QVAR, NQ)        1      None
-   gamma_e                None         QGAME     (QVAR, NQ)        1      None
-   pressure               None         QPRES     (QVAR, NQ)        1      None
-   rho-e                  None         QREINT    (QVAR, NQ)        1      None
-   B-x                    None         QMAGX     (QVAR, NQ)        1      MHD
-   B-y                    None         QMAGY     (QVAR, NQ)        1      MHD
-   B-z                    None         QMAGZ     (QVAR, NQ)        1      MHD
-   temperature            None         QTEMP     (QVAR, NQ)        1      None
-   advected               None         QFA       (QVAR, NQ)      numadv   None
-   species                None         QFS       (QVAR, NQ)      nspec    None
-   auxillary              None         QFX       (QVAR, NQ)      naux     None
-   total-pressure         None         QPTOT     NQ                1      RADIATION
-   total-reint            None         QREITOT   NQ                1      RADIATION
-   radiation              None         QRAD      NQ              ngroups  RADIATION
+@set: primitive NQ
+   density                None         QRHO      QVAR             1      None
+   x-velocity             None         QU        QVAR             1      None
+   y-velocity             None         QV        QVAR             1      None
+   z-velocity             None         QW        QVAR             1      None
+   gamma_e                None         QGAME     QVAR             1      None
+   pressure               None         QPRES     QVAR             1      None
+   rho-e                  None         QREINT    QVAR             1      None
+   B-x                    None         QMAGX     QVAR             1      MHD
+   B-y                    None         QMAGY     QVAR             1      MHD
+   B-z                    None         QMAGZ     QVAR             1      MHD
+   temperature            None         QTEMP     QVAR             1      None
+   advected               None         QFA       QVAR           numadv   None
+   species                None         QFS       QVAR           nspec    None
+   auxillary              None         QFX       QVAR           naux     None
+   total-pressure         None         QPTOT     None             1      RADIATION
+   total-reint            None         QREITOT   None             1      RADIATION
+   radiation              None         QRAD      None           ngroups  RADIATION
 
 
 # the auxillary quantities
-   gamma_c               None          QGAMC     NQAUX           1        None
-   sound-speed           None          QC        NQAUX           1        None
-   dp/dr                 None          QDPDR     NQAUX           1        None
-   dpde                  None          QDPDE     NQAUX           1        None
-   gamma_c-gas           None          QGAMCC    NQAUX           1        RADIATION
-   sound-speed-gas       None          QCG       NQAUX           1        RADIATION
-   flux-limiter          None          QLAMS     NQAUX         ngroups    RADIATION
+@set: auxillary NQAUX
+   gamma_c               None          QGAMC     None            1        None
+   sound-speed           None          QC        None            1        None
+   dp/dr                 None          QDPDR     None            1        None
+   dpde                  None          QDPDE     None            1        None
+   gamma_c-gas           None          QGAMCC    None            1        RADIATION
+   sound-speed-gas       None          QCG       None            1        RADIATION
+   flux-limiter          None          QLAMS     None          ngroups    RADIATION
 
 
-# interface states
-   density               None          GDRHO     NGDNV           1        None
-   x-velocity            None          GDU       NGDNV           1        None
-   y-velocity            None          GDV       NGDNV           1        None
-   z-velocity            None          GDW       NGDNV           1        None
-   pressure              None          GDPRES    NGDNV           1        None
-   gamma_e               None          GDGAME    NGDNV           1        None
-   flux-limiter          None          GDLAMS    NGDNV         ngroups    RADIATION
-   radiation             None          GDERADS   NGDNV         ngroups    RADIATION
+# godunov interface states
+@set: godunov NGDNV
+   density               None          GDRHO     None            1        None
+   x-velocity            None          GDU       None            1        None
+   y-velocity            None          GDV       None            1        None
+   z-velocity            None          GDW       None            1        None
+   pressure              None          GDPRES    None            1        None
+   gamma_e               None          GDGAME    None            1        None
+   flux-limiter          None          GDLAMS    None          ngroups    RADIATION
+   radiation             None          GDERADS   None          ngroups    RADIATION
 
 

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -1,21 +1,25 @@
+# this is the list of variables indices that Castro will use for
+# accessing various state arrays.  We will keep them in the order that
+# they are specified here.
+
 #  descriptive-name     C++-name   Fortran-name  also-adds-to    count   if-def
 
 # the conserved variable state
 @set: conserved NVAR
-   density                Density      URHO      None             1      None
-   x-momentum             Xmom         UMX       None             1      None
-   y-momentum             Ymom         UMY       None             1      None
-   z-momentum             Zmom         UMZ       None             1      None
-   radial-momentum        None         UMR       None             1      HYBRID_MOMENTUM
-   angular-momentum       None         UML       None             1      HYBRID_MOMENTUM
-   perpendicular-momentum None         UMP       None             1      HYBRID_MOMENTUM
-   energy-density         Eden         UEDEN     None             1      None
-   internal-energy        Eint         UEINT     None             1      None
-   temperature            Temp         UTEMP     None             1      None
-   advected               FirstAdv     UFA       None           nadv     None
-   species                FirstSpec    UFS       None           nspec    None
-   auxillary              FirstAux     UFX       None           naux     None
-   shock                  Shock        USHK      None             1      SHOCK_VAR
+   density                Density      URHO      None             1                None
+   x-momentum             Xmom         UMX       None             1                None
+   y-momentum             Ymom         UMY       None             1                None
+   z-momentum             Zmom         UMZ       None             1                None
+   radial-momentum        Rmom         UMR       None             1                HYBRID_MOMENTUM
+   angular-momentum       Lmom         UML       None             1                HYBRID_MOMENTUM
+   perpendicular-momentum Pmom         UMP       None             1                HYBRID_MOMENTUM
+   energy-density         Eden         UEDEN     None             1                None
+   internal-energy        Eint         UEINT     None             1                None
+   temperature            Temp         UTEMP     None             1                None
+   advected               FirstAdv     UFA       None           (nadv, NumAdv)     None
+   species                FirstSpec    UFS       None           (nspec, NumSpec)   None
+   auxillary              FirstAux     UFX       None           (naux, NumAux)     None
+   shock                  Shock        USHK      None             1                SHOCK_VAR
 
 
 # the primitive variable state
@@ -43,7 +47,7 @@
 @set: auxillary NQAUX
    gamma_c               None          QGAMC     None            1        None
    sound-speed           None          QC        None            1        None
-   dp/dr                 None          QDPDR     None            1        None
+   dpdr                  None          QDPDR     None            1        None
    dpde                  None          QDPDE     None            1        None
    gamma_c-gas           None          QGAMCC    None            1        RADIATION
    sound-speed-gas       None          QCG       None            1        RADIATION

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -54,7 +54,7 @@
    z-velocity            None          GDW       NGDNV           1        None
    pressure              None          GDPRES    NGDNV           1        None
    gamma_e               None          GDGAME    NGDNV           1        None
-   flux-limiter          None          GDLAMS    NGDNV           1        RADIATION
-   radiation             None          GDERADS   NGDNV           1        RADIATION
+   flux-limiter          None          GDLAMS    NGDNV         ngroups    RADIATION
+   radiation             None          GDERADS   NGDNV         ngroups    RADIATION
 
 

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -24,6 +24,7 @@
    z-velocity             None         QW        (QVAR, NQ)        1      None
    gamma_e                None         QGAME     (QVAR, NQ)        1      None
    pressure               None         QPRES     (QVAR, NQ)        1      None
+   rho-e                  None         QREINT    (QVAR, NQ)        1      None
    B-x                    None         QMAGX     (QVAR, NQ)        1      MHD
    B-y                    None         QMAGY     (QVAR, NQ)        1      MHD
    B-z                    None         QMAGZ     (QVAR, NQ)        1      MHD
@@ -31,6 +32,9 @@
    advected               None         QFA       (QVAR, NQ)      numadv   None
    species                None         QFS       (QVAR, NQ)      nspec    None
    auxillary              None         QFX       (QVAR, NQ)      naux     None
+   total-pressure         None         QPTOT     (QRADVAR, NQ)     1      RADIATION
+   total-reint            None         QREITOT   (QRADVAR, NQ)     1      RADIATION
+   radiation              None         QRAD      (QRADVAR, NQ)   ngroups  RADIATION
 
 
 # the auxillary quantities

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -1,0 +1,54 @@
+#  descriptive-name     C++-name   Fortran-name   adds-to        count   if-def
+
+# the conserved variable state
+   density                Density      URHO      NVAR              1      None
+   x-momentum             Xmom         UMX       NVAR              1      None
+   y-momentum             Ymom         UMY       NVAR              1      None
+   z-momentum             Zmom         UMZ       NVAR              1      None
+   radial-momentum        None         UMR       NVAR              1      HYBRID_MOMENTUM
+   angular-momentum       None         UML       NVAR              1      HYBRID_MOMENTUM
+   polar-momentum         None         UMP       NVAR              1      HYBRID_MOMENTUM
+   energy-density         Eden         UEDEN     NVAR              1      None
+   internal-energy        Eint         UEINT     NVAR              1      None
+   temperature            Temp         UTEMP     NVAR              1      None
+   advected               FirstAdv     UFA       NVAR            numadv   None
+   species                FirstSpec    UFS       NVAR            nspec    None
+   auxillary              FirstAux     UFX       NVAR            naux     None
+   shock                  Shock        USHK      NVAR              1      None
+
+
+# the primitive variable state
+   density                None         QRHO      (QVAR, NQ)        1      None
+   x-velocity             None         QU        (QVAR, NQ)        1      None
+   y-velocity             None         QV        (QVAR, NQ)        1      None
+   z-velocity             None         QW        (QVAR, NQ)        1      None
+   gamma_e                None         QGAME     (QVAR, NQ)        1      None
+   pressure               None         QPRES     (QVAR, NQ)        1      None
+   B-x                    None         QMAGX     (QVAR, NQ)        1      MHD
+   B-y                    None         QMAGY     (QVAR, NQ)        1      MHD
+   B-z                    None         QMAGZ     (QVAR, NQ)        1      MHD
+   temperature            None         QTEMP     (QVAR, NQ)        1      None
+   advected               None         QFA       (QVAR, NQ)      numadv   None
+   species                None         QFS       (QVAR, NQ)      nspec    None
+   auxillary              None         QFX       (QVAR, NQ)      naux     None
+
+
+# the auxillary quantities
+   gamma_c               None          QGAMC     NQAUX           1        None
+   sound-speed           None          QC        NQAUX           1        None
+   dp/dr                 None          QDPDR     NQAUX           1        None
+   dpde                  None          QDPDE     NQAUX           1        None
+   gamma_c-gas           None          QGAMCC    NQAUX           1        RADIATION
+   sound-speed-gas       None          QCG       NQAUX           1        RADIATION
+   flux-limiter          None          QLAMS     NQAUX         ngroups    RADIATION
+
+
+# interface states
+   density               None          GDRHO     NGDNV           1        None
+   x-velocity            None          GDU       NGDNV           1        None
+   y-velocity            None          GDV       NGDNV           1        None
+   z-velocity            None          GDW       NGDNV           1        None
+   pressure              None          GDPRES    NGDNV           1        None
+   gamma_e               None          GDGAME    NGDNV           1        None
+
+

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -32,9 +32,9 @@
    advected               None         QFA       (QVAR, NQ)      numadv   None
    species                None         QFS       (QVAR, NQ)      nspec    None
    auxillary              None         QFX       (QVAR, NQ)      naux     None
-   total-pressure         None         QPTOT     (QRADVAR, NQ)     1      RADIATION
-   total-reint            None         QREITOT   (QRADVAR, NQ)     1      RADIATION
-   radiation              None         QRAD      (QRADVAR, NQ)   ngroups  RADIATION
+   total-pressure         None         QPTOT     NQ                1      RADIATION
+   total-reint            None         QREITOT   NQ                1      RADIATION
+   radiation              None         QRAD      NQ              ngroups  RADIATION
 
 
 # the auxillary quantities

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -54,5 +54,7 @@
    z-velocity            None          GDW       NGDNV           1        None
    pressure              None          GDPRES    NGDNV           1        None
    gamma_e               None          GDGAME    NGDNV           1        None
+   flux-limiter          None          GDLAMS    NGDNV           1        RADIATION
+   radiation             None          GDERADS   NGDNV           1        RADIATION
 
 

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -15,7 +15,7 @@
    advected               FirstAdv     UFA       None           nadv     None
    species                FirstSpec    UFS       None           nspec    None
    auxillary              FirstAux     UFX       None           naux     None
-   shock                  Shock        USHK      None             1      None
+   shock                  Shock        USHK      None             1      SHOCK_VAR
 
 
 # the primitive variable state

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -537,19 +537,6 @@ contains
     integer, intent(in) :: fsp_type_in, do_is_in, com_in
     real(rt)        , intent(in) :: fppt
 
-    QPTOT  = QVAR+1
-    QREITOT = QVAR+2
-    QRAD = QVAR+3
-    QRADHI = qrad+ngroups-1
-  
-    QRADVAR = QVAR + 2 + ngroups
-  
-    ! update NQ -- it was already initialized in the hydro
-    NQ = QRADVAR
-
-    ! NQAUX already knows about the hydro and the non-group-dependent
-    ! rad variables, update it here
-    NQAUX = NQAUX + ngroups
 
     if (ngroups .eq. 1) then
        fspace_type = 1

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -230,6 +230,25 @@ contains
     call amrex_parmparse_destroy(pp)
 
 
+#ifdef DIFFUSION
+    diffuse_cutoff_density = -1.d200;
+    diffuse_cond_scale_fac = 1.0d0;
+#endif
+#ifdef ROTATION
+    rot_period = -1.d200;
+    rot_period_dot = 0.0d0;
+    rotation_include_centrifugal = 1;
+    rotation_include_coriolis = 1;
+    rotation_include_domegadt = 1;
+    state_in_rotating_frame = 1;
+    rot_source_type = 4;
+    implicit_rotation_update = 1;
+    rot_axis = 3;
+#endif
+#ifdef POINTMASS
+    point_mass = 0.0d0;
+    point_mass_fix_solution = 0;
+#endif
     difmag = 0.1d0;
     small_dens = -1.d200;
     small_temp = -1.d200;
@@ -294,27 +313,33 @@ contains
     react_rho_min = 0.0d0;
     react_rho_max = 1.d200;
     disable_shock_burning = 0;
-    diffuse_cutoff_density = -1.d200;
-    diffuse_cond_scale_fac = 1.0d0;
     do_grav = -1;
     grav_source_type = 4;
     do_rotation = -1;
-    rot_period = -1.d200;
-    rot_period_dot = 0.0d0;
-    rotation_include_centrifugal = 1;
-    rotation_include_coriolis = 1;
-    rotation_include_domegadt = 1;
-    state_in_rotating_frame = 1;
-    rot_source_type = 4;
-    implicit_rotation_update = 1;
-    rot_axis = 3;
-    point_mass = 0.0d0;
-    point_mass_fix_solution = 0;
     do_acc = -1;
     grown_factor = 1;
     track_grid_losses = 0;
 
     call amrex_parmparse_build(pp, "castro")
+#ifdef DIFFUSION
+    call pp%query("diffuse_cutoff_density", diffuse_cutoff_density)
+    call pp%query("diffuse_cond_scale_fac", diffuse_cond_scale_fac)
+#endif
+#ifdef ROTATION
+    call pp%query("rotational_period", rot_period)
+    call pp%query("rotational_dPdt", rot_period_dot)
+    call pp%query("rotation_include_centrifugal", rotation_include_centrifugal)
+    call pp%query("rotation_include_coriolis", rotation_include_coriolis)
+    call pp%query("rotation_include_domegadt", rotation_include_domegadt)
+    call pp%query("state_in_rotating_frame", state_in_rotating_frame)
+    call pp%query("rot_source_type", rot_source_type)
+    call pp%query("implicit_rotation_update", implicit_rotation_update)
+    call pp%query("rot_axis", rot_axis)
+#endif
+#ifdef POINTMASS
+    call pp%query("point_mass", point_mass)
+    call pp%query("point_mass_fix_solution", point_mass_fix_solution)
+#endif
     call pp%query("difmag", difmag)
     call pp%query("small_dens", small_dens)
     call pp%query("small_temp", small_temp)
@@ -373,48 +398,9 @@ contains
     call pp%query("react_rho_min", react_rho_min)
     call pp%query("react_rho_max", react_rho_max)
     call pp%query("disable_shock_burning", disable_shock_burning)
-#ifdef DIFFUSION
-    call pp%query("diffuse_cutoff_density", diffuse_cutoff_density)
-#endif
-#ifdef DIFFUSION
-    call pp%query("diffuse_cond_scale_fac", diffuse_cond_scale_fac)
-#endif
     call pp%query("do_grav", do_grav)
     call pp%query("grav_source_type", grav_source_type)
     call pp%query("do_rotation", do_rotation)
-#ifdef ROTATION
-    call pp%query("rotational_period", rot_period)
-#endif
-#ifdef ROTATION
-    call pp%query("rotational_dPdt", rot_period_dot)
-#endif
-#ifdef ROTATION
-    call pp%query("rotation_include_centrifugal", rotation_include_centrifugal)
-#endif
-#ifdef ROTATION
-    call pp%query("rotation_include_coriolis", rotation_include_coriolis)
-#endif
-#ifdef ROTATION
-    call pp%query("rotation_include_domegadt", rotation_include_domegadt)
-#endif
-#ifdef ROTATION
-    call pp%query("state_in_rotating_frame", state_in_rotating_frame)
-#endif
-#ifdef ROTATION
-    call pp%query("rot_source_type", rot_source_type)
-#endif
-#ifdef ROTATION
-    call pp%query("implicit_rotation_update", implicit_rotation_update)
-#endif
-#ifdef ROTATION
-    call pp%query("rot_axis", rot_axis)
-#endif
-#ifdef POINTMASS
-    call pp%query("point_mass", point_mass)
-#endif
-#ifdef POINTMASS
-    call pp%query("point_mass_fix_solution", point_mass_fix_solution)
-#endif
     call pp%query("do_acc", do_acc)
     call pp%query("grown_factor", grown_factor)
     call pp%query("track_grid_losses", track_grid_losses)

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -40,7 +40,7 @@ module meth_params_module
   integer, save :: NQ         
 
 #ifdef RADIATION
-  integer, save :: QRADVAR, QRAD, QRADHI, QPTOT, QREITOT
+  integer, save :: QRAD, QRADHI, QPTOT, QREITOT
   integer, save :: fspace_type
   logical, save :: do_inelastic_scattering
   logical, save :: comoving
@@ -90,7 +90,7 @@ module meth_params_module
   !$acc create(NQ) &
 #ifdef RADIATION
   !$acc create(QGAMCG, QCG, QLAMS) &
-  !$acc create(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
+  !$acc create(QRAD, QRADHI, QPTOT, QREITOT) &
   !$acc create(fspace_type, do_inelastic_scattering, comoving) &
 #endif
   !$acc create(QFA, QFS, QFX) &
@@ -562,7 +562,7 @@ contains
     
     !$acc update &
     !$acc device(NQ,NQAUX) &
-    !$acc device(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
+    !$acc device(QRAD, QRADHI, QPTOT, QREITOT) &
     !$acc device(fspace_type) &
     !$acc device(do_inelastic_scattering) &
     !$acc device(comoving)

--- a/Source/driver/meth_params.template
+++ b/Source/driver/meth_params.template
@@ -35,7 +35,7 @@ module meth_params_module
   integer, save :: NQ         
 
 #ifdef RADIATION
-  integer, save :: QRADVAR, QRAD, QRADHI, QPTOT, QREITOT
+  integer, save :: QRAD, QRADHI, QPTOT, QREITOT
   integer, save :: fspace_type
   logical, save :: do_inelastic_scattering
   logical, save :: comoving
@@ -85,7 +85,7 @@ module meth_params_module
   !$acc create(NQ) &
 #ifdef RADIATION
   !$acc create(QGAMCG, QCG, QLAMS) &
-  !$acc create(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
+  !$acc create(QRAD, QRADHI, QPTOT, QREITOT) &
   !$acc create(fspace_type, do_inelastic_scattering, comoving) &
 #endif
   !$acc create(QFA, QFS, QFX) &
@@ -221,7 +221,7 @@ contains
     
     !$acc update &
     !$acc device(NQ,NQAUX) &
-    !$acc device(QRADVAR, QRAD, QRADHI, QPTOT, QREITOT) &
+    !$acc device(QRAD, QRADHI, QPTOT, QREITOT) &
     !$acc device(fspace_type) &
     !$acc device(do_inelastic_scattering) &
     !$acc device(comoving)

--- a/Source/driver/meth_params.template
+++ b/Source/driver/meth_params.template
@@ -196,19 +196,6 @@ contains
     integer, intent(in) :: fsp_type_in, do_is_in, com_in
     real(rt)        , intent(in) :: fppt
 
-    QPTOT  = QVAR+1
-    QREITOT = QVAR+2
-    QRAD = QVAR+3
-    QRADHI = qrad+ngroups-1
-  
-    QRADVAR = QVAR + 2 + ngroups
-  
-    ! update NQ -- it was already initialized in the hydro
-    NQ = QRADVAR
-
-    ! NQAUX already knows about the hydro and the non-group-dependent
-    ! rad variables, update it here
-    NQAUX = NQAUX + ngroups
 
     if (ngroups .eq. 1) then
        fspace_type = 1

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -3,6 +3,32 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
+#ifdef DIFFUSION
+int         Castro::diffuse_temp = 0;
+int         Castro::diffuse_enth = 0;
+int         Castro::diffuse_spec = 0;
+int         Castro::diffuse_vel = 0;
+amrex::Real Castro::diffuse_cutoff_density = -1.e200;
+amrex::Real Castro::diffuse_cond_scale_fac = 1.0;
+#endif
+#ifdef PARTICLES
+int         Castro::do_tracer_particles = 0;
+#endif
+#ifdef ROTATION
+amrex::Real Castro::rotational_period = -1.e200;
+amrex::Real Castro::rotational_dPdt = 0.0;
+int         Castro::rotation_include_centrifugal = 1;
+int         Castro::rotation_include_coriolis = 1;
+int         Castro::rotation_include_domegadt = 1;
+int         Castro::state_in_rotating_frame = 1;
+int         Castro::rot_source_type = 4;
+int         Castro::implicit_rotation_update = 1;
+int         Castro::rot_axis = 3;
+#endif
+#ifdef POINTMASS
+amrex::Real Castro::point_mass = 0.0;
+int         Castro::point_mass_fix_solution = 0;
+#endif
 int         Castro::state_interp_order = 1;
 int         Castro::lin_limit_state_interp = 0;
 int         Castro::state_nghost = 0;
@@ -84,61 +110,10 @@ amrex::Real Castro::react_T_max = 1.e200;
 amrex::Real Castro::react_rho_min = 0.0;
 amrex::Real Castro::react_rho_max = 1.e200;
 int         Castro::disable_shock_burning = 0;
-#ifdef DIFFUSION
-int         Castro::diffuse_temp = 0;
-#endif
-#ifdef DIFFUSION
-int         Castro::diffuse_enth = 0;
-#endif
-#ifdef DIFFUSION
-int         Castro::diffuse_spec = 0;
-#endif
-#ifdef DIFFUSION
-int         Castro::diffuse_vel = 0;
-#endif
-#ifdef DIFFUSION
-amrex::Real Castro::diffuse_cutoff_density = -1.e200;
-#endif
-#ifdef DIFFUSION
-amrex::Real Castro::diffuse_cond_scale_fac = 1.0;
-#endif
 int         Castro::do_grav = -1;
 int         Castro::moving_center = 0;
 int         Castro::grav_source_type = 4;
 int         Castro::do_rotation = -1;
-#ifdef ROTATION
-amrex::Real Castro::rotational_period = -1.e200;
-#endif
-#ifdef ROTATION
-amrex::Real Castro::rotational_dPdt = 0.0;
-#endif
-#ifdef ROTATION
-int         Castro::rotation_include_centrifugal = 1;
-#endif
-#ifdef ROTATION
-int         Castro::rotation_include_coriolis = 1;
-#endif
-#ifdef ROTATION
-int         Castro::rotation_include_domegadt = 1;
-#endif
-#ifdef ROTATION
-int         Castro::state_in_rotating_frame = 1;
-#endif
-#ifdef ROTATION
-int         Castro::rot_source_type = 4;
-#endif
-#ifdef ROTATION
-int         Castro::implicit_rotation_update = 1;
-#endif
-#ifdef ROTATION
-int         Castro::rot_axis = 3;
-#endif
-#ifdef POINTMASS
-amrex::Real Castro::point_mass = 0.0;
-#endif
-#ifdef POINTMASS
-int         Castro::point_mass_fix_solution = 0;
-#endif
 int         Castro::do_acc = -1;
 int         Castro::bndry_func_thread_safe = 1;
 int         Castro::grown_factor = 1;
@@ -164,6 +139,3 @@ std::string Castro::job_name = "";
 int         Castro::output_at_completion = 1;
 amrex::Real Castro::reset_checkpoint_time = -1.e200;
 int         Castro::reset_checkpoint_step = -1;
-#ifdef PARTICLES
-int         Castro::do_tracer_particles = 0;
-#endif

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -3,6 +3,32 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
+#ifdef DIFFUSION
+static int diffuse_temp;
+static int diffuse_enth;
+static int diffuse_spec;
+static int diffuse_vel;
+static amrex::Real diffuse_cutoff_density;
+static amrex::Real diffuse_cond_scale_fac;
+#endif
+#ifdef PARTICLES
+static int do_tracer_particles;
+#endif
+#ifdef ROTATION
+static amrex::Real rotational_period;
+static amrex::Real rotational_dPdt;
+static int rotation_include_centrifugal;
+static int rotation_include_coriolis;
+static int rotation_include_domegadt;
+static int state_in_rotating_frame;
+static int rot_source_type;
+static int implicit_rotation_update;
+static int rot_axis;
+#endif
+#ifdef POINTMASS
+static amrex::Real point_mass;
+static int point_mass_fix_solution;
+#endif
 static int state_interp_order;
 static int lin_limit_state_interp;
 static int state_nghost;
@@ -84,61 +110,10 @@ static amrex::Real react_T_max;
 static amrex::Real react_rho_min;
 static amrex::Real react_rho_max;
 static int disable_shock_burning;
-#ifdef DIFFUSION
-static int diffuse_temp;
-#endif
-#ifdef DIFFUSION
-static int diffuse_enth;
-#endif
-#ifdef DIFFUSION
-static int diffuse_spec;
-#endif
-#ifdef DIFFUSION
-static int diffuse_vel;
-#endif
-#ifdef DIFFUSION
-static amrex::Real diffuse_cutoff_density;
-#endif
-#ifdef DIFFUSION
-static amrex::Real diffuse_cond_scale_fac;
-#endif
 static int do_grav;
 static int moving_center;
 static int grav_source_type;
 static int do_rotation;
-#ifdef ROTATION
-static amrex::Real rotational_period;
-#endif
-#ifdef ROTATION
-static amrex::Real rotational_dPdt;
-#endif
-#ifdef ROTATION
-static int rotation_include_centrifugal;
-#endif
-#ifdef ROTATION
-static int rotation_include_coriolis;
-#endif
-#ifdef ROTATION
-static int rotation_include_domegadt;
-#endif
-#ifdef ROTATION
-static int state_in_rotating_frame;
-#endif
-#ifdef ROTATION
-static int rot_source_type;
-#endif
-#ifdef ROTATION
-static int implicit_rotation_update;
-#endif
-#ifdef ROTATION
-static int rot_axis;
-#endif
-#ifdef POINTMASS
-static amrex::Real point_mass;
-#endif
-#ifdef POINTMASS
-static int point_mass_fix_solution;
-#endif
 static int do_acc;
 static int bndry_func_thread_safe;
 static int grown_factor;
@@ -156,6 +131,3 @@ static std::string job_name;
 static int output_at_completion;
 static amrex::Real reset_checkpoint_time;
 static int reset_checkpoint_step;
-#ifdef PARTICLES
-static int do_tracer_particles;
-#endif

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -3,6 +3,32 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
+#ifdef DIFFUSION
+pp.query("diffuse_temp", diffuse_temp);
+pp.query("diffuse_enth", diffuse_enth);
+pp.query("diffuse_spec", diffuse_spec);
+pp.query("diffuse_vel", diffuse_vel);
+pp.query("diffuse_cutoff_density", diffuse_cutoff_density);
+pp.query("diffuse_cond_scale_fac", diffuse_cond_scale_fac);
+#endif
+#ifdef PARTICLES
+pp.query("do_tracer_particles", do_tracer_particles);
+#endif
+#ifdef ROTATION
+pp.query("rotational_period", rotational_period);
+pp.query("rotational_dPdt", rotational_dPdt);
+pp.query("rotation_include_centrifugal", rotation_include_centrifugal);
+pp.query("rotation_include_coriolis", rotation_include_coriolis);
+pp.query("rotation_include_domegadt", rotation_include_domegadt);
+pp.query("state_in_rotating_frame", state_in_rotating_frame);
+pp.query("rot_source_type", rot_source_type);
+pp.query("implicit_rotation_update", implicit_rotation_update);
+pp.query("rot_axis", rot_axis);
+#endif
+#ifdef POINTMASS
+pp.query("point_mass", point_mass);
+pp.query("point_mass_fix_solution", point_mass_fix_solution);
+#endif
 pp.query("state_interp_order", state_interp_order);
 pp.query("lin_limit_state_interp", lin_limit_state_interp);
 pp.query("state_nghost", state_nghost);
@@ -84,61 +110,10 @@ pp.query("react_T_max", react_T_max);
 pp.query("react_rho_min", react_rho_min);
 pp.query("react_rho_max", react_rho_max);
 pp.query("disable_shock_burning", disable_shock_burning);
-#ifdef DIFFUSION
-pp.query("diffuse_temp", diffuse_temp);
-#endif
-#ifdef DIFFUSION
-pp.query("diffuse_enth", diffuse_enth);
-#endif
-#ifdef DIFFUSION
-pp.query("diffuse_spec", diffuse_spec);
-#endif
-#ifdef DIFFUSION
-pp.query("diffuse_vel", diffuse_vel);
-#endif
-#ifdef DIFFUSION
-pp.query("diffuse_cutoff_density", diffuse_cutoff_density);
-#endif
-#ifdef DIFFUSION
-pp.query("diffuse_cond_scale_fac", diffuse_cond_scale_fac);
-#endif
 pp.query("do_grav", do_grav);
 pp.query("moving_center", moving_center);
 pp.query("grav_source_type", grav_source_type);
 pp.query("do_rotation", do_rotation);
-#ifdef ROTATION
-pp.query("rotational_period", rotational_period);
-#endif
-#ifdef ROTATION
-pp.query("rotational_dPdt", rotational_dPdt);
-#endif
-#ifdef ROTATION
-pp.query("rotation_include_centrifugal", rotation_include_centrifugal);
-#endif
-#ifdef ROTATION
-pp.query("rotation_include_coriolis", rotation_include_coriolis);
-#endif
-#ifdef ROTATION
-pp.query("rotation_include_domegadt", rotation_include_domegadt);
-#endif
-#ifdef ROTATION
-pp.query("state_in_rotating_frame", state_in_rotating_frame);
-#endif
-#ifdef ROTATION
-pp.query("rot_source_type", rot_source_type);
-#endif
-#ifdef ROTATION
-pp.query("implicit_rotation_update", implicit_rotation_update);
-#endif
-#ifdef ROTATION
-pp.query("rot_axis", rot_axis);
-#endif
-#ifdef POINTMASS
-pp.query("point_mass", point_mass);
-#endif
-#ifdef POINTMASS
-pp.query("point_mass_fix_solution", point_mass_fix_solution);
-#endif
 pp.query("do_acc", do_acc);
 pp.query("bndry_func_thread_safe", bndry_func_thread_safe);
 pp.query("grown_factor", grown_factor);
@@ -156,6 +131,3 @@ pp.query("job_name", job_name);
 pp.query("output_at_completion", output_at_completion);
 pp.query("reset_checkpoint_time", reset_checkpoint_time);
 pp.query("reset_checkpoint_step", reset_checkpoint_step);
-#ifdef PARTICLES
-pp.query("do_tracer_particles", do_tracer_particles);
-#endif

--- a/Source/driver/parse_castro_params.py
+++ b/Source/driver/parse_castro_params.py
@@ -145,9 +145,6 @@ class Param(object):
 
         ostr = ""
 
-        if not self.ifdef is None:
-            ostr = "#ifdef {}\n".format(self.ifdef)
-
         if not self.debug_default is None:
             ostr += "#ifdef DEBUG\n"
             ostr += "{} = {};\n".format(tstr, self.debug_default)
@@ -156,9 +153,6 @@ class Param(object):
             ostr += "#endif\n"
         else:
             ostr += "{} = {};\n".format(tstr, self.default)
-
-        if not self.ifdef is None:
-            ostr += "#endif\n"
 
         return ostr
 
@@ -214,18 +208,12 @@ class Param(object):
         # This goes into castro_queries.H included into Castro.cpp
 
         ostr = ""
-        if not self.ifdef is None:
-            ostr += "#ifdef {}\n".format(self.ifdef)
-
         if language == "C++":
             ostr += "pp.query(\"{}\", {});\n".format(self.name, self.cpp_var_name)
         elif language == "F90":
             ostr += "    call pp%query(\"{}\", {})\n".format(self.name, self.f90_name)
         else:
             sys.exit("invalid language choice in get_query_string")
-
-        if not self.ifdef is None:
-            ostr += "#endif\n".format(self.ifdef)
 
         return ostr
 
@@ -247,14 +235,7 @@ class Param(object):
             sys.exit("invalid data type for parameter {}".format(self.name))
 
         ostr = ""
-
-        if not self.ifdef is None:
-            ostr = "#ifdef {}\n".format(self.ifdef)
-
         ostr += tstr
-
-        if not self.ifdef is None:
-            ostr += "#endif\n"
 
         return ostr
 
@@ -335,16 +316,31 @@ def write_meth_module(plist, meth_template):
             print("Fortran namespaces: ", namespaces)
             for nm in namespaces:
                 params_nm = [q for q in params if q.namespace == nm]
+                ifdefs = list(set([q.ifdef for q in params_nm]))
 
-                for p in params_nm:
-                    mo.write(p.get_f90_default_string())
+                for ifdef in ifdefs:
+                    if ifdef is None:
+                        for p in [q for q in params_nm if q.ifdef is None]:
+                            mo.write(p.get_f90_default_string())
+                    else:
+                        mo.write("#ifdef {}\n".format(ifdef))
+                        for p in [q for q in params_nm if q.ifdef == ifdef]:
+                            mo.write(p.get_f90_default_string())
+                        mo.write("#endif\n")
 
                 mo.write("\n")
 
                 mo.write('    call amrex_parmparse_build(pp, "{}")\n'.format(nm))
 
-                for p in params_nm:
-                    mo.write(p.get_query_string("F90"))
+                for ifdef in ifdefs:
+                    if ifdef is None:
+                        for p in [q for q in params_nm if q.ifdef is None]:
+                            mo.write(p.get_query_string("F90"))
+                    else:
+                        mo.write("#ifdef {}\n".format(ifdef))
+                        for p in [q for q in params_nm if q.ifdef == ifdef]:
+                            mo.write(p.get_query_string("F90"))
+                        mo.write("#endif\n")
 
                 mo.write('    call amrex_parmparse_destroy(pp)\n')
                 
@@ -486,6 +482,7 @@ def parse_params(infile, meth_template):
     for nm in namespaces:
 
         params_nm = [q for q in params if q.namespace == nm]
+        ifdefs = list(set([q.ifdef for q in params_nm]))
 
         # write name_defaults.H
         try: cd = open("{}/{}_defaults.H".format(param_include_dir, nm), "w")
@@ -494,8 +491,15 @@ def parse_params(infile, meth_template):
 
         cd.write(CWARNING)
 
-        for p in params_nm:
-            cd.write(p.get_default_string())
+        for ifdef in ifdefs:
+            if ifdef is None:
+                for p in [q for q in params_nm if q.ifdef is None]:
+                    cd.write(p.get_default_string())
+            else:
+                cd.write("#ifdef {}\n".format(ifdef))
+                for p in [q for q in params_nm if q.ifdef == ifdef]:
+                    cd.write(p.get_default_string())
+                cd.write("#endif\n")
 
         cd.close()
 
@@ -506,8 +510,15 @@ def parse_params(infile, meth_template):
 
         cp.write(CWARNING)
 
-        for p in params_nm:
-            cp.write(p.get_decl_string())
+        for ifdef in ifdefs:
+            if ifdef is None:
+                for p in [q for q in params_nm if q.ifdef is None]:
+                    cp.write(p.get_decl_string())
+            else:
+                cp.write("#ifdef {}\n".format(ifdef))
+                for p in [q for q in params_nm if q.ifdef == ifdef]:
+                    cp.write(p.get_decl_string())
+                cp.write("#endif\n")
 
         cp.close()
 
@@ -518,8 +529,15 @@ def parse_params(infile, meth_template):
 
         cq.write(CWARNING)
 
-        for p in params_nm:
-            cq.write(p.get_query_string("C++"))
+        for ifdef in ifdefs:
+            if ifdef is None:
+                for p in [q for q in params_nm if q.ifdef is None]:
+                    cq.write(p.get_query_string("C++"))
+            else:
+                cq.write("#ifdef {}\n".format(ifdef))
+                for p in [q for q in params_nm if q.ifdef == ifdef]:
+                    cq.write(p.get_query_string("C++"))
+                cq.write("#endif\n")
 
         cq.close()
 

--- a/Source/driver/set_conserved.H
+++ b/Source/driver/set_conserved.H
@@ -1,0 +1,57 @@
+  int cnt = 0;
+  Density = cnt;
+  cnt += 1;
+
+  Xmom = cnt;
+  cnt += 1;
+
+  Ymom = cnt;
+  cnt += 1;
+
+  Zmom = cnt;
+  cnt += 1;
+
+#ifdef HYBRID_MOMENTUM
+  Rmom = cnt;
+  cnt += 1;
+#endif
+
+#ifdef HYBRID_MOMENTUM
+  Lmom = cnt;
+  cnt += 1;
+#endif
+
+#ifdef HYBRID_MOMENTUM
+  Pmom = cnt;
+  cnt += 1;
+#endif
+
+  Eden = cnt;
+  cnt += 1;
+
+  Eint = cnt;
+  cnt += 1;
+
+  Temp = cnt;
+  cnt += 1;
+
+  if (NumAdv > 0) {
+    FirstAdv = cnt;
+    cnt += NumAdv;
+  }
+
+  if (NumSpec > 0) {
+    FirstSpec = cnt;
+    cnt += NumSpec;
+  }
+
+  if (NumAux > 0) {
+    FirstAux = cnt;
+    cnt += NumAux;
+  }
+
+#ifdef SHOCK_VAR
+  Shock = cnt;
+  cnt += 1;
+#endif
+

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -14,97 +14,6 @@ subroutine check_equal(index1, index2)
 end subroutine check_equal
 
 
-subroutine ca_set_conserved_indices( &
-                                    Shock, &
-                                    Temp, &
-                                    Zmom, &
-                                    Eint, &
-                                    Xmom, &
-                                    Ymom, &
-                                    Eden, &
-                                    FirstSpec, &
-                                    FirstAux, &
-                                    Density, &
-                                    FirstAdv)
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-  implicit none
-  integer, intent(in) :: Shock
-  integer, intent(in) :: Temp
-  integer, intent(in) :: Zmom
-  integer, intent(in) :: Eint
-  integer, intent(in) :: Xmom
-  integer, intent(in) :: Ymom
-  integer, intent(in) :: Eden
-  integer, intent(in) :: FirstSpec
-  integer, intent(in) :: FirstAux
-  integer, intent(in) :: Density
-  integer, intent(in) :: FirstAdv
-
-  NVAR = 1
-
-  URHO = NVAR
-  NVAR = NVAR + 1
-  call check_equal(URHO,Density+1)
-
-  UMX = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UMX,Xmom+1)
-
-  UMY = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UMY,Ymom+1)
-
-  UMZ = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UMZ,Zmom+1)
-
-  UEDEN = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UEDEN,Eden+1)
-
-  UEINT = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UEINT,Eint+1)
-
-  UTEMP = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UTEMP,Temp+1)
-
-  UFA = NVAR
-  NVAR = NVAR + nadv
-  call check_equal(UFA,FirstAdv+1)
-
-  UFS = NVAR
-  NVAR = NVAR + nspec
-  call check_equal(UFS,FirstSpec+1)
-
-  UFX = NVAR
-  NVAR = NVAR + naux
-  call check_equal(UFX,FirstAux+1)
-
-#ifdef HYBRID_MOMENTUM
-  UMR = NVAR
-  NVAR = NVAR + 1
-
-  UML = NVAR
-  NVAR = NVAR + 1
-
-  UMP = NVAR
-  NVAR = NVAR + 1
-
-#endif
-#ifdef SHOCK_VAR
-  USHK = NVAR
-  NVAR = NVAR + 1
-  call check_equal(USHK,Shock+1)
-
-#endif
-  NVAR = NVAR - 1
-end subroutine ca_set_conserved_indices
-
 subroutine ca_set_godunov_indices()
 
 
@@ -135,11 +44,13 @@ subroutine ca_set_godunov_indices()
 #ifdef RADIATION
   GDLAMS = NGDNV
   NGDNV = NGDNV + ngroups
+#endif
 
+#ifdef RADIATION
   GDERADS = NGDNV
   NGDNV = NGDNV + ngroups
-
 #endif
+
   NGDNV = NGDNV - 1
 end subroutine ca_set_godunov_indices
 
@@ -167,14 +78,18 @@ subroutine ca_set_auxillary_indices()
 #ifdef RADIATION
   QGAMCC = NQAUX
   NQAUX = NQAUX + 1
+#endif
 
+#ifdef RADIATION
   QCG = NQAUX
   NQAUX = NQAUX + 1
+#endif
 
+#ifdef RADIATION
   QLAMS = NQAUX
   NQAUX = NQAUX + ngroups
-
 #endif
+
   NQAUX = NQAUX - 1
 end subroutine ca_set_auxillary_indices
 
@@ -217,6 +132,24 @@ subroutine ca_set_primitive_indices()
   NQ = NQ + 1
   QVAR = QVAR + 1
 
+#ifdef MHD
+  QMAGX = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+#endif
+
+#ifdef MHD
+  QMAGY = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+#endif
+
+#ifdef MHD
+  QMAGZ = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+#endif
+
   QTEMP = NQ
   NQ = NQ + 1
   QVAR = QVAR + 1
@@ -233,32 +166,143 @@ subroutine ca_set_primitive_indices()
   NQ = NQ + naux
   QVAR = QVAR + naux
 
-#ifdef MHD
-  QMAGX = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QMAGY = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QMAGZ = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-#endif
 #ifdef RADIATION
   QPTOT = NQ
   NQ = NQ + 1
+#endif
 
+#ifdef RADIATION
   QREITOT = NQ
   NQ = NQ + 1
+#endif
 
+#ifdef RADIATION
   QRAD = NQ
   NQ = NQ + ngroups
-
 #endif
+
   NQ = NQ - 1
   QVAR = QVAR - 1
 end subroutine ca_set_primitive_indices
+
+subroutine ca_set_conserved_indices( &
+#ifdef HYBRID_MOMENTUM
+                                    Rmom, &
+#endif
+#ifdef HYBRID_MOMENTUM
+                                    Lmom, &
+#endif
+#ifdef HYBRID_MOMENTUM
+                                    Pmom, &
+#endif
+#ifdef SHOCK_VAR
+                                    Shock, &
+#endif
+                                    Density, &
+                                    Xmom, &
+                                    Ymom, &
+                                    Zmom, &
+                                    Eden, &
+                                    Eint, &
+                                    Temp, &
+                                    FirstAdv, &
+                                    FirstSpec, &
+                                    FirstAux &
+                                   )
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+  implicit none
+  integer, intent(in) :: Density
+  integer, intent(in) :: Xmom
+  integer, intent(in) :: Ymom
+  integer, intent(in) :: Zmom
+#ifdef HYBRID_MOMENTUM
+  integer, intent(in) :: Rmom
+#endif
+#ifdef HYBRID_MOMENTUM
+  integer, intent(in) :: Lmom
+#endif
+#ifdef HYBRID_MOMENTUM
+  integer, intent(in) :: Pmom
+#endif
+  integer, intent(in) :: Eden
+  integer, intent(in) :: Eint
+  integer, intent(in) :: Temp
+  integer, intent(in) :: FirstAdv
+  integer, intent(in) :: FirstSpec
+  integer, intent(in) :: FirstAux
+#ifdef SHOCK_VAR
+  integer, intent(in) :: Shock
+#endif
+
+  NVAR = 1
+
+  URHO = NVAR
+  NVAR = NVAR + 1
+  call check_equal(URHO,Density+1)
+
+  UMX = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMX,Xmom+1)
+
+  UMY = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMY,Ymom+1)
+
+  UMZ = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMZ,Zmom+1)
+
+#ifdef HYBRID_MOMENTUM
+  UMR = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMR,Rmom+1)
+#endif
+
+#ifdef HYBRID_MOMENTUM
+  UML = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UML,Lmom+1)
+#endif
+
+#ifdef HYBRID_MOMENTUM
+  UMP = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMP,Pmom+1)
+#endif
+
+  UEDEN = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UEDEN,Eden+1)
+
+  UEINT = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UEINT,Eint+1)
+
+  UTEMP = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UTEMP,Temp+1)
+
+  UFA = NVAR
+  NVAR = NVAR + nadv
+  call check_equal(UFA,FirstAdv+1)
+
+  UFS = NVAR
+  NVAR = NVAR + nspec
+  call check_equal(UFS,FirstSpec+1)
+
+  UFX = NVAR
+  NVAR = NVAR + naux
+  call check_equal(UFX,FirstAux+1)
+
+#ifdef SHOCK_VAR
+  USHK = NVAR
+  NVAR = NVAR + 1
+  call check_equal(USHK,Shock+1)
+#endif
+
+  NVAR = NVAR - 1
+end subroutine ca_set_conserved_indices
 

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -14,177 +14,6 @@ subroutine check_equal(index1, index2)
 end subroutine check_equal
 
 
-subroutine ca_set_godunov_indices()
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-  implicit none
-
-  NGDNV = 1
-
-  GDRHO = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDU = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDV = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDW = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDPRES = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDGAME = NGDNV
-  NGDNV = NGDNV + 1
-
-#ifdef RADIATION
-  GDLAMS = NGDNV
-  NGDNV = NGDNV + ngroups
-#endif
-
-#ifdef RADIATION
-  GDERADS = NGDNV
-  NGDNV = NGDNV + ngroups
-#endif
-
-  NGDNV = NGDNV - 1
-end subroutine ca_set_godunov_indices
-
-subroutine ca_set_primitive_indices()
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-  implicit none
-
-  NQ = 1
-
-  QVAR = 1
-
-  QRHO = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QU = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QV = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QW = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QGAME = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QPRES = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QREINT = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-#ifdef MHD
-  QMAGX = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-#endif
-
-#ifdef MHD
-  QMAGY = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-#endif
-
-#ifdef MHD
-  QMAGZ = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-#endif
-
-  QTEMP = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QFA = NQ
-  NQ = NQ + nadv
-  QVAR = QVAR + nadv
-
-  QFS = NQ
-  NQ = NQ + nspec
-  QVAR = QVAR + nspec
-
-  QFX = NQ
-  NQ = NQ + naux
-  QVAR = QVAR + naux
-
-#ifdef RADIATION
-  QPTOT = NQ
-  NQ = NQ + 1
-#endif
-
-#ifdef RADIATION
-  QREITOT = NQ
-  NQ = NQ + 1
-#endif
-
-#ifdef RADIATION
-  QRAD = NQ
-  NQ = NQ + ngroups
-#endif
-
-  NQ = NQ - 1
-  QVAR = QVAR - 1
-end subroutine ca_set_primitive_indices
-
-subroutine ca_set_auxillary_indices()
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-  implicit none
-
-  NQAUX = 1
-
-  QGAMC = NQAUX
-  NQAUX = NQAUX + 1
-
-  QC = NQAUX
-  NQAUX = NQAUX + 1
-
-  QDPDR = NQAUX
-  NQAUX = NQAUX + 1
-
-  QDPDE = NQAUX
-  NQAUX = NQAUX + 1
-
-#ifdef RADIATION
-  QGAMCC = NQAUX
-  NQAUX = NQAUX + 1
-#endif
-
-#ifdef RADIATION
-  QCG = NQAUX
-  NQAUX = NQAUX + 1
-#endif
-
-#ifdef RADIATION
-  QLAMS = NQAUX
-  NQAUX = NQAUX + ngroups
-#endif
-
-  NQAUX = NQAUX - 1
-end subroutine ca_set_auxillary_indices
-
 subroutine ca_set_conserved_indices( &
 #ifdef HYBRID_MOMENTUM
                                     Rmom, &
@@ -213,6 +42,9 @@ subroutine ca_set_conserved_indices( &
 
   use meth_params_module
   use network, only: naux, nspec
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
   implicit none
   integer, intent(in) :: Density
   integer, intent(in) :: Xmom
@@ -317,4 +149,184 @@ subroutine ca_set_conserved_indices( &
 
   NVAR = NVAR - 1
 end subroutine ca_set_conserved_indices
+
+subroutine ca_set_godunov_indices()
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
+  implicit none
+
+  NGDNV = 1
+
+  GDRHO = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDU = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDV = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDW = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDPRES = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDGAME = NGDNV
+  NGDNV = NGDNV + 1
+
+#ifdef RADIATION
+  GDLAMS = NGDNV
+  NGDNV = NGDNV + ngroups
+#endif
+
+#ifdef RADIATION
+  GDERADS = NGDNV
+  NGDNV = NGDNV + ngroups
+#endif
+
+  NGDNV = NGDNV - 1
+end subroutine ca_set_godunov_indices
+
+subroutine ca_set_auxillary_indices()
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
+  implicit none
+
+  NQAUX = 1
+
+  QGAMC = NQAUX
+  NQAUX = NQAUX + 1
+
+  QC = NQAUX
+  NQAUX = NQAUX + 1
+
+  QDPDR = NQAUX
+  NQAUX = NQAUX + 1
+
+  QDPDE = NQAUX
+  NQAUX = NQAUX + 1
+
+#ifdef RADIATION
+  QGAMCG = NQAUX
+  NQAUX = NQAUX + 1
+#endif
+
+#ifdef RADIATION
+  QCG = NQAUX
+  NQAUX = NQAUX + 1
+#endif
+
+#ifdef RADIATION
+  QLAMS = NQAUX
+  NQAUX = NQAUX + ngroups
+#endif
+
+  NQAUX = NQAUX - 1
+end subroutine ca_set_auxillary_indices
+
+subroutine ca_set_primitive_indices()
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
+  implicit none
+
+  NQ = 1
+
+  QVAR = 1
+
+  QRHO = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QU = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QV = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QW = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QGAME = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QPRES = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QREINT = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+#ifdef MHD
+  QMAGX = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+#endif
+
+#ifdef MHD
+  QMAGY = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+#endif
+
+#ifdef MHD
+  QMAGZ = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+#endif
+
+  QTEMP = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QFA = NQ
+  NQ = NQ + nadv
+  QVAR = QVAR + nadv
+
+  QFS = NQ
+  NQ = NQ + nspec
+  QVAR = QVAR + nspec
+
+  QFX = NQ
+  NQ = NQ + naux
+  QVAR = QVAR + naux
+
+#ifdef RADIATION
+  QPTOT = NQ
+  NQ = NQ + 1
+#endif
+
+#ifdef RADIATION
+  QREITOT = NQ
+  NQ = NQ + 1
+#endif
+
+#ifdef RADIATION
+  QRAD = NQ
+  NQ = NQ + ngroups
+#endif
+
+  NQ = NQ - 1
+  QVAR = QVAR - 1
+end subroutine ca_set_primitive_indices
 

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -69,52 +69,77 @@ subroutine ca_set_conserved_indices( &
   integer, intent(in) :: Shock
 #endif
 
+  print *, "in set"
+  print *, "Rmom = ", Rmom
+  print *, "Lmom = ", Lmom
+  print *, "Pmom = ", Pmom
+  print *, "Density = ", Density
+  print *, "Xmom = ", Xmom
+  print *, "Ymom = ", Ymom
+  print *, "Zmom = ", Zmom
+  print *, "Eden = ", Eden
+  print *, "Eint = ", Eint
+  print *, "Temp = ", Temp
+  print *, "FirstAdv = ", FirstAdv
+  print *, "FirstSpec = ", FirstSpec
+  print *, "FirstAux = ", FirstAux
+
   NVAR = 1
 
   URHO = NVAR
   NVAR = NVAR + 1
+  print *, "dens"
   call check_equal(URHO,Density+1)
 
   UMX = NVAR
   NVAR = NVAR + 1
+  print *, "umx"
   call check_equal(UMX,Xmom+1)
 
   UMY = NVAR
   NVAR = NVAR + 1
+  print *, "umy"
   call check_equal(UMY,Ymom+1)
 
   UMZ = NVAR
   NVAR = NVAR + 1
+  print *, "umz"
   call check_equal(UMZ,Zmom+1)
 
 #ifdef HYBRID_MOMENTUM
   UMR = NVAR
   NVAR = NVAR + 1
+  print *, "umr"
   call check_equal(UMR,Rmom+1)
 #endif
 
 #ifdef HYBRID_MOMENTUM
   UML = NVAR
   NVAR = NVAR + 1
+  print *, "uml"
   call check_equal(UML,Lmom+1)
 #endif
 
 #ifdef HYBRID_MOMENTUM
   UMP = NVAR
   NVAR = NVAR + 1
+  print *, "ump"
   call check_equal(UMP,Pmom+1)
 #endif
 
   UEDEN = NVAR
   NVAR = NVAR + 1
+  print *, "ueden"
   call check_equal(UEDEN,Eden+1)
 
   UEINT = NVAR
   NVAR = NVAR + 1
+  print *, "ueint"
   call check_equal(UEINT,Eint+1)
 
   UTEMP = NVAR
   NVAR = NVAR + 1
+  print *, "utemp"
   call check_equal(UTEMP,Temp+1)
 
   if (nadv > 0) then

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -1,3 +1,126 @@
+subroutine ca_set_godunov_indices( &
+                                )
+
+  use meth_params_module
+
+  NGDNV = 1
+
+  GDRHO = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDU = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDV = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDW = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDPRES = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDGAME = NGDNV
+  NGDNV = NGDNV + 1
+
+#ifdef RADIATION
+  GDLAMS = NGDNV
+  NGDNV = NGDNV + ngroups
+
+  GDERADS = NGDNV
+  NGDNV = NGDNV + ngroups
+
+#endif
+  NGDNV = NGDNV - 1
+end subroutine ca_set_godunov_indices
+
+subroutine ca_set_conserved_indices( &
+                                   Eint, &
+                                   Temp, &
+                                   Zmom, &
+                                   Density, &
+                                   Eden, &
+                                   FirstAdv, &
+                                   Shock, &
+                                   FirstSpec, &
+                                   Ymom, &
+                                   FirstAux, &
+                                   Xmom, &
+                                  )
+
+  use meth_params_module
+  integer, intent(in) :: Eint
+  integer, intent(in) :: Temp
+  integer, intent(in) :: Zmom
+  integer, intent(in) :: Density
+  integer, intent(in) :: Eden
+  integer, intent(in) :: FirstAdv
+  integer, intent(in) :: Shock
+  integer, intent(in) :: FirstSpec
+  integer, intent(in) :: Ymom
+  integer, intent(in) :: FirstAux
+  integer, intent(in) :: Xmom
+
+  NVAR = 1
+
+  URHO = NVAR
+  NVAR = NVAR + 1
+  call check_equal(URHO,Density+1)
+
+  UMX = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMX,Xmom+1)
+
+  UMY = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMY,Ymom+1)
+
+  UMZ = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMZ,Zmom+1)
+
+  UEDEN = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UEDEN,Eden+1)
+
+  UEINT = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UEINT,Eint+1)
+
+  UTEMP = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UTEMP,Temp+1)
+
+  UFA = NVAR
+  NVAR = NVAR + numadv
+  call check_equal(UFA,FirstAdv+1)
+
+  UFS = NVAR
+  NVAR = NVAR + nspec
+  call check_equal(UFS,FirstSpec+1)
+
+  UFX = NVAR
+  NVAR = NVAR + naux
+  call check_equal(UFX,FirstAux+1)
+
+  USHK = NVAR
+  NVAR = NVAR + 1
+  call check_equal(USHK,Shock+1)
+
+#ifdef HYBRID_MOMENTUM
+  UMR = NVAR
+  NVAR = NVAR + 1
+
+  UML = NVAR
+  NVAR = NVAR + 1
+
+  UMP = NVAR
+  NVAR = NVAR + 1
+
+#endif
+  NVAR = NVAR - 1
+end subroutine ca_set_conserved_indices
+
 subroutine ca_set_auxillary_indices( &
                                   )
 
@@ -37,6 +160,8 @@ subroutine ca_set_primitive_indices( &
   use meth_params_module
 
   NQ = 1
+
+  QVAR = 1
 
   QRHO = NQ
   NQ = NQ + 1
@@ -110,127 +235,4 @@ subroutine ca_set_primitive_indices( &
   NQ = NQ - 1
   QVAR = QVAR - 1
 end subroutine ca_set_primitive_indices
-
-subroutine ca_set_godunov_indices( &
-                                )
-
-  use meth_params_module
-
-  NGDNV = 1
-
-  GDRHO = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDU = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDV = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDW = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDPRES = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDGAME = NGDNV
-  NGDNV = NGDNV + 1
-
-#ifdef RADIATION
-  GDLAMS = NGDNV
-  NGDNV = NGDNV + ngroups
-
-  GDERADS = NGDNV
-  NGDNV = NGDNV + ngroups
-
-#endif
-  NGDNV = NGDNV - 1
-end subroutine ca_set_godunov_indices
-
-subroutine ca_set_conserved_indices( &
-                                   Xmom, &
-                                   Eint, &
-                                   Eden, &
-                                   Shock, &
-                                   Temp, &
-                                   FirstSpec, &
-                                   FirstAdv, &
-                                   Density, &
-                                   FirstAux, &
-                                   Ymom, &
-                                   Zmom, &
-                                  )
-
-  use meth_params_module
-  integer, intent(in) :: Xmom
-  integer, intent(in) :: Eint
-  integer, intent(in) :: Eden
-  integer, intent(in) :: Shock
-  integer, intent(in) :: Temp
-  integer, intent(in) :: FirstSpec
-  integer, intent(in) :: FirstAdv
-  integer, intent(in) :: Density
-  integer, intent(in) :: FirstAux
-  integer, intent(in) :: Ymom
-  integer, intent(in) :: Zmom
-
-  NVAR = 1
-
-  URHO = NVAR
-  NVAR = NVAR + 1
-  call check_equal(URHO,Density+1)
-
-  UMX = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UMX,Xmom+1)
-
-  UMY = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UMY,Ymom+1)
-
-  UMZ = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UMZ,Zmom+1)
-
-  UEDEN = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UEDEN,Eden+1)
-
-  UEINT = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UEINT,Eint+1)
-
-  UTEMP = NVAR
-  NVAR = NVAR + 1
-  call check_equal(UTEMP,Temp+1)
-
-  UFA = NVAR
-  NVAR = NVAR + numadv
-  call check_equal(UFA,FirstAdv+1)
-
-  UFS = NVAR
-  NVAR = NVAR + nspec
-  call check_equal(UFS,FirstSpec+1)
-
-  UFX = NVAR
-  NVAR = NVAR + naux
-  call check_equal(UFX,FirstAux+1)
-
-  USHK = NVAR
-  NVAR = NVAR + 1
-  call check_equal(USHK,Shock+1)
-
-#ifdef HYBRID_MOMENTUM
-  UMR = NVAR
-  NVAR = NVAR + 1
-
-  UML = NVAR
-  NVAR = NVAR + 1
-
-  UMP = NVAR
-  NVAR = NVAR + 1
-
-#endif
-  NVAR = NVAR - 1
-end subroutine ca_set_conserved_indices
 

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -14,144 +14,6 @@ subroutine check_equal(index1, index2)
 end subroutine check_equal
 
 
-subroutine ca_set_primitive_indices()
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-#ifdef RADIATION
-  use rad_params_module, only : ngroups
-#endif
-  implicit none
-
-  NQ = 1
-
-  QVAR = 1
-
-  QRHO = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QU = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QV = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QW = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QGAME = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QPRES = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QREINT = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-#ifdef MHD
-  QMAGX = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-#endif
-
-#ifdef MHD
-  QMAGY = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-#endif
-
-#ifdef MHD
-  QMAGZ = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-#endif
-
-  QTEMP = NQ
-  NQ = NQ + 1
-  QVAR = QVAR + 1
-
-  QFA = NQ
-  NQ = NQ + nadv
-  QVAR = QVAR + nadv
-
-  QFS = NQ
-  NQ = NQ + nspec
-  QVAR = QVAR + nspec
-
-  QFX = NQ
-  NQ = NQ + naux
-  QVAR = QVAR + naux
-
-#ifdef RADIATION
-  QPTOT = NQ
-  NQ = NQ + 1
-#endif
-
-#ifdef RADIATION
-  QREITOT = NQ
-  NQ = NQ + 1
-#endif
-
-#ifdef RADIATION
-  QRAD = NQ
-  NQ = NQ + ngroups
-#endif
-
-  NQ = NQ - 1
-  QVAR = QVAR - 1
-end subroutine ca_set_primitive_indices
-
-subroutine ca_set_godunov_indices()
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-#ifdef RADIATION
-  use rad_params_module, only : ngroups
-#endif
-  implicit none
-
-  NGDNV = 1
-
-  GDRHO = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDU = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDV = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDW = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDPRES = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDGAME = NGDNV
-  NGDNV = NGDNV + 1
-
-#ifdef RADIATION
-  GDLAMS = NGDNV
-  NGDNV = NGDNV + ngroups
-#endif
-
-#ifdef RADIATION
-  GDERADS = NGDNV
-  NGDNV = NGDNV + ngroups
-#endif
-
-  NGDNV = NGDNV - 1
-end subroutine ca_set_godunov_indices
-
 subroutine ca_set_auxillary_indices()
 
 
@@ -329,4 +191,142 @@ subroutine ca_set_conserved_indices( &
 
   NVAR = NVAR - 1
 end subroutine ca_set_conserved_indices
+
+subroutine ca_set_godunov_indices()
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
+  implicit none
+
+  NGDNV = 1
+
+  GDRHO = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDU = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDV = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDW = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDPRES = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDGAME = NGDNV
+  NGDNV = NGDNV + 1
+
+#ifdef RADIATION
+  GDLAMS = NGDNV
+  NGDNV = NGDNV + ngroups
+#endif
+
+#ifdef RADIATION
+  GDERADS = NGDNV
+  NGDNV = NGDNV + ngroups
+#endif
+
+  NGDNV = NGDNV - 1
+end subroutine ca_set_godunov_indices
+
+subroutine ca_set_primitive_indices()
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
+  implicit none
+
+  NQ = 1
+
+  QVAR = 1
+
+  QRHO = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QU = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QV = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QW = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QGAME = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QPRES = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QREINT = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+#ifdef MHD
+  QMAGX = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+#endif
+
+#ifdef MHD
+  QMAGY = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+#endif
+
+#ifdef MHD
+  QMAGZ = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+#endif
+
+  QTEMP = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QFA = NQ
+  NQ = NQ + nadv
+  QVAR = QVAR + nadv
+
+  QFS = NQ
+  NQ = NQ + nspec
+  QVAR = QVAR + nspec
+
+  QFX = NQ
+  NQ = NQ + naux
+  QVAR = QVAR + naux
+
+#ifdef RADIATION
+  QPTOT = NQ
+  NQ = NQ + 1
+#endif
+
+#ifdef RADIATION
+  QREITOT = NQ
+  NQ = NQ + 1
+#endif
+
+#ifdef RADIATION
+  QRAD = NQ
+  NQ = NQ + ngroups
+#endif
+
+  NQ = NQ - 1
+  QVAR = QVAR - 1
+end subroutine ca_set_primitive_indices
 

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -1,7 +1,25 @@
-subroutine ca_set_godunov_indices( &
-                                )
+
+subroutine check_equal(index1, index2)
+
+  use bl_error_module
+
+  implicit none
+
+  integer, intent(in) :: index1, index2
+
+  if (index1 /= index2) then
+    call bl_error("ERROR: mismatch of indices")
+  endif
+
+end subroutine check_equal
+
+
+subroutine ca_set_godunov_indices()
+
 
   use meth_params_module
+  use network, only: naux, nspec
+  implicit none
 
   NGDNV = 1
 
@@ -35,31 +53,33 @@ subroutine ca_set_godunov_indices( &
 end subroutine ca_set_godunov_indices
 
 subroutine ca_set_conserved_indices( &
-                                   Eint, &
-                                   Temp, &
-                                   Zmom, &
-                                   Density, &
-                                   Eden, &
-                                   FirstAdv, &
-                                   Shock, &
-                                   FirstSpec, &
-                                   Ymom, &
-                                   FirstAux, &
-                                   Xmom, &
-                                  )
+                                    Ymom, &
+                                    Zmom, &
+                                    Eint, &
+                                    Shock, &
+                                    Density, &
+                                    FirstSpec, &
+                                    FirstAdv, &
+                                    FirstAux, &
+                                    Xmom, &
+                                    Temp, &
+                                    Eden)
+
 
   use meth_params_module
-  integer, intent(in) :: Eint
-  integer, intent(in) :: Temp
-  integer, intent(in) :: Zmom
-  integer, intent(in) :: Density
-  integer, intent(in) :: Eden
-  integer, intent(in) :: FirstAdv
-  integer, intent(in) :: Shock
-  integer, intent(in) :: FirstSpec
+  use network, only: naux, nspec
+  implicit none
   integer, intent(in) :: Ymom
+  integer, intent(in) :: Zmom
+  integer, intent(in) :: Eint
+  integer, intent(in) :: Shock
+  integer, intent(in) :: Density
+  integer, intent(in) :: FirstSpec
+  integer, intent(in) :: FirstAdv
   integer, intent(in) :: FirstAux
   integer, intent(in) :: Xmom
+  integer, intent(in) :: Temp
+  integer, intent(in) :: Eden
 
   NVAR = 1
 
@@ -92,7 +112,7 @@ subroutine ca_set_conserved_indices( &
   call check_equal(UTEMP,Temp+1)
 
   UFA = NVAR
-  NVAR = NVAR + numadv
+  NVAR = NVAR + nadv
   call check_equal(UFA,FirstAdv+1)
 
   UFS = NVAR
@@ -121,10 +141,12 @@ subroutine ca_set_conserved_indices( &
   NVAR = NVAR - 1
 end subroutine ca_set_conserved_indices
 
-subroutine ca_set_auxillary_indices( &
-                                  )
+subroutine ca_set_auxillary_indices()
+
 
   use meth_params_module
+  use network, only: naux, nspec
+  implicit none
 
   NQAUX = 1
 
@@ -154,10 +176,12 @@ subroutine ca_set_auxillary_indices( &
   NQAUX = NQAUX - 1
 end subroutine ca_set_auxillary_indices
 
-subroutine ca_set_primitive_indices( &
-                                  )
+subroutine ca_set_primitive_indices()
+
 
   use meth_params_module
+  use network, only: naux, nspec
+  implicit none
 
   NQ = 1
 
@@ -196,8 +220,8 @@ subroutine ca_set_primitive_indices( &
   QVAR = QVAR + 1
 
   QFA = NQ
-  NQ = NQ + numadv
-  QVAR = QVAR + numadv
+  NQ = NQ + nadv
+  QVAR = QVAR + nadv
 
   QFS = NQ
   NQ = NQ + nspec
@@ -207,17 +231,6 @@ subroutine ca_set_primitive_indices( &
   NQ = NQ + naux
   QVAR = QVAR + naux
 
-#ifdef RADIATION
-  QPTOT = NQ
-  NQ = NQ + 1
-
-  QREITOT = NQ
-  NQ = NQ + 1
-
-  QRAD = NQ
-  NQ = NQ + ngroups
-
-#endif
 #ifdef MHD
   QMAGX = NQ
   NQ = NQ + 1
@@ -230,6 +243,17 @@ subroutine ca_set_primitive_indices( &
   QMAGZ = NQ
   NQ = NQ + 1
   QVAR = QVAR + 1
+
+#endif
+#ifdef RADIATION
+  QPTOT = NQ
+  NQ = NQ + 1
+
+  QREITOT = NQ
+  NQ = NQ + 1
+
+  QRAD = NQ
+  NQ = NQ + ngroups
 
 #endif
   NQ = NQ - 1

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -1,0 +1,236 @@
+subroutine ca_set_auxillary_indices( &
+                                  )
+
+  use meth_params_module
+
+  NQAUX = 1
+
+  QGAMC = NQAUX
+  NQAUX = NQAUX + 1
+
+  QC = NQAUX
+  NQAUX = NQAUX + 1
+
+  QDPDR = NQAUX
+  NQAUX = NQAUX + 1
+
+  QDPDE = NQAUX
+  NQAUX = NQAUX + 1
+
+#ifdef RADIATION
+  QGAMCC = NQAUX
+  NQAUX = NQAUX + 1
+
+  QCG = NQAUX
+  NQAUX = NQAUX + 1
+
+  QLAMS = NQAUX
+  NQAUX = NQAUX + ngroups
+
+#endif
+  NQAUX = NQAUX - 1
+end subroutine ca_set_auxillary_indices
+
+subroutine ca_set_primitive_indices( &
+                                  )
+
+  use meth_params_module
+
+  NQ = 1
+
+  QRHO = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QU = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QV = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QW = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QGAME = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QPRES = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QREINT = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QTEMP = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QFA = NQ
+  NQ = NQ + numadv
+  QVAR = QVAR + numadv
+
+  QFS = NQ
+  NQ = NQ + nspec
+  QVAR = QVAR + nspec
+
+  QFX = NQ
+  NQ = NQ + naux
+  QVAR = QVAR + naux
+
+#ifdef RADIATION
+  QPTOT = NQ
+  NQ = NQ + 1
+
+  QREITOT = NQ
+  NQ = NQ + 1
+
+  QRAD = NQ
+  NQ = NQ + ngroups
+
+#endif
+#ifdef MHD
+  QMAGX = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QMAGY = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+  QMAGZ = NQ
+  NQ = NQ + 1
+  QVAR = QVAR + 1
+
+#endif
+  NQ = NQ - 1
+  QVAR = QVAR - 1
+end subroutine ca_set_primitive_indices
+
+subroutine ca_set_godunov_indices( &
+                                )
+
+  use meth_params_module
+
+  NGDNV = 1
+
+  GDRHO = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDU = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDV = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDW = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDPRES = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDGAME = NGDNV
+  NGDNV = NGDNV + 1
+
+#ifdef RADIATION
+  GDLAMS = NGDNV
+  NGDNV = NGDNV + ngroups
+
+  GDERADS = NGDNV
+  NGDNV = NGDNV + ngroups
+
+#endif
+  NGDNV = NGDNV - 1
+end subroutine ca_set_godunov_indices
+
+subroutine ca_set_conserved_indices( &
+                                   Xmom, &
+                                   Eint, &
+                                   Eden, &
+                                   Shock, &
+                                   Temp, &
+                                   FirstSpec, &
+                                   FirstAdv, &
+                                   Density, &
+                                   FirstAux, &
+                                   Ymom, &
+                                   Zmom, &
+                                  )
+
+  use meth_params_module
+  integer, intent(in) :: Xmom
+  integer, intent(in) :: Eint
+  integer, intent(in) :: Eden
+  integer, intent(in) :: Shock
+  integer, intent(in) :: Temp
+  integer, intent(in) :: FirstSpec
+  integer, intent(in) :: FirstAdv
+  integer, intent(in) :: Density
+  integer, intent(in) :: FirstAux
+  integer, intent(in) :: Ymom
+  integer, intent(in) :: Zmom
+
+  NVAR = 1
+
+  URHO = NVAR
+  NVAR = NVAR + 1
+  call check_equal(URHO,Density+1)
+
+  UMX = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMX,Xmom+1)
+
+  UMY = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMY,Ymom+1)
+
+  UMZ = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMZ,Zmom+1)
+
+  UEDEN = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UEDEN,Eden+1)
+
+  UEINT = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UEINT,Eint+1)
+
+  UTEMP = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UTEMP,Temp+1)
+
+  UFA = NVAR
+  NVAR = NVAR + numadv
+  call check_equal(UFA,FirstAdv+1)
+
+  UFS = NVAR
+  NVAR = NVAR + nspec
+  call check_equal(UFS,FirstSpec+1)
+
+  UFX = NVAR
+  NVAR = NVAR + naux
+  call check_equal(UFX,FirstAux+1)
+
+  USHK = NVAR
+  NVAR = NVAR + 1
+  call check_equal(USHK,Shock+1)
+
+#ifdef HYBRID_MOMENTUM
+  UMR = NVAR
+  NVAR = NVAR + 1
+
+  UML = NVAR
+  NVAR = NVAR + 1
+
+  UMP = NVAR
+  NVAR = NVAR + 1
+
+#endif
+  NVAR = NVAR - 1
+end subroutine ca_set_conserved_indices
+

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -14,72 +14,34 @@ subroutine check_equal(index1, index2)
 end subroutine check_equal
 
 
-subroutine ca_set_godunov_indices()
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-  implicit none
-
-  NGDNV = 1
-
-  GDRHO = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDU = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDV = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDW = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDPRES = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDGAME = NGDNV
-  NGDNV = NGDNV + 1
-
-#ifdef RADIATION
-  GDLAMS = NGDNV
-  NGDNV = NGDNV + ngroups
-
-  GDERADS = NGDNV
-  NGDNV = NGDNV + ngroups
-
-#endif
-  NGDNV = NGDNV - 1
-end subroutine ca_set_godunov_indices
-
 subroutine ca_set_conserved_indices( &
-                                    Ymom, &
+                                    Shock, &
+                                    Temp, &
                                     Zmom, &
                                     Eint, &
-                                    Shock, &
-                                    Density, &
-                                    FirstSpec, &
-                                    FirstAdv, &
-                                    FirstAux, &
                                     Xmom, &
-                                    Temp, &
-                                    Eden)
+                                    Ymom, &
+                                    Eden, &
+                                    FirstSpec, &
+                                    FirstAux, &
+                                    Density, &
+                                    FirstAdv)
 
 
   use meth_params_module
   use network, only: naux, nspec
   implicit none
-  integer, intent(in) :: Ymom
+  integer, intent(in) :: Shock
+  integer, intent(in) :: Temp
   integer, intent(in) :: Zmom
   integer, intent(in) :: Eint
-  integer, intent(in) :: Shock
-  integer, intent(in) :: Density
-  integer, intent(in) :: FirstSpec
-  integer, intent(in) :: FirstAdv
-  integer, intent(in) :: FirstAux
   integer, intent(in) :: Xmom
-  integer, intent(in) :: Temp
+  integer, intent(in) :: Ymom
   integer, intent(in) :: Eden
+  integer, intent(in) :: FirstSpec
+  integer, intent(in) :: FirstAux
+  integer, intent(in) :: Density
+  integer, intent(in) :: FirstAdv
 
   NVAR = 1
 
@@ -123,10 +85,6 @@ subroutine ca_set_conserved_indices( &
   NVAR = NVAR + naux
   call check_equal(UFX,FirstAux+1)
 
-  USHK = NVAR
-  NVAR = NVAR + 1
-  call check_equal(USHK,Shock+1)
-
 #ifdef HYBRID_MOMENTUM
   UMR = NVAR
   NVAR = NVAR + 1
@@ -138,8 +96,52 @@ subroutine ca_set_conserved_indices( &
   NVAR = NVAR + 1
 
 #endif
+#ifdef SHOCK_VAR
+  USHK = NVAR
+  NVAR = NVAR + 1
+  call check_equal(USHK,Shock+1)
+
+#endif
   NVAR = NVAR - 1
 end subroutine ca_set_conserved_indices
+
+subroutine ca_set_godunov_indices()
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+  implicit none
+
+  NGDNV = 1
+
+  GDRHO = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDU = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDV = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDW = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDPRES = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDGAME = NGDNV
+  NGDNV = NGDNV + 1
+
+#ifdef RADIATION
+  GDLAMS = NGDNV
+  NGDNV = NGDNV + ngroups
+
+  GDERADS = NGDNV
+  NGDNV = NGDNV + ngroups
+
+#endif
+  NGDNV = NGDNV - 1
+end subroutine ca_set_godunov_indices
 
 subroutine ca_set_auxillary_indices()
 

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -54,45 +54,6 @@ subroutine ca_set_godunov_indices()
   NGDNV = NGDNV - 1
 end subroutine ca_set_godunov_indices
 
-subroutine ca_set_auxillary_indices()
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-  implicit none
-
-  NQAUX = 1
-
-  QGAMC = NQAUX
-  NQAUX = NQAUX + 1
-
-  QC = NQAUX
-  NQAUX = NQAUX + 1
-
-  QDPDR = NQAUX
-  NQAUX = NQAUX + 1
-
-  QDPDE = NQAUX
-  NQAUX = NQAUX + 1
-
-#ifdef RADIATION
-  QGAMCC = NQAUX
-  NQAUX = NQAUX + 1
-#endif
-
-#ifdef RADIATION
-  QCG = NQAUX
-  NQAUX = NQAUX + 1
-#endif
-
-#ifdef RADIATION
-  QLAMS = NQAUX
-  NQAUX = NQAUX + ngroups
-#endif
-
-  NQAUX = NQAUX - 1
-end subroutine ca_set_auxillary_indices
-
 subroutine ca_set_primitive_indices()
 
 
@@ -184,6 +145,45 @@ subroutine ca_set_primitive_indices()
   NQ = NQ - 1
   QVAR = QVAR - 1
 end subroutine ca_set_primitive_indices
+
+subroutine ca_set_auxillary_indices()
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+  implicit none
+
+  NQAUX = 1
+
+  QGAMC = NQAUX
+  NQAUX = NQAUX + 1
+
+  QC = NQAUX
+  NQAUX = NQAUX + 1
+
+  QDPDR = NQAUX
+  NQAUX = NQAUX + 1
+
+  QDPDE = NQAUX
+  NQAUX = NQAUX + 1
+
+#ifdef RADIATION
+  QGAMCC = NQAUX
+  NQAUX = NQAUX + 1
+#endif
+
+#ifdef RADIATION
+  QCG = NQAUX
+  NQAUX = NQAUX + 1
+#endif
+
+#ifdef RADIATION
+  QLAMS = NQAUX
+  NQAUX = NQAUX + ngroups
+#endif
+
+  NQAUX = NQAUX - 1
+end subroutine ca_set_auxillary_indices
 
 subroutine ca_set_conserved_indices( &
 #ifdef HYBRID_MOMENTUM
@@ -285,16 +285,28 @@ subroutine ca_set_conserved_indices( &
   NVAR = NVAR + 1
   call check_equal(UTEMP,Temp+1)
 
-  UFA = NVAR
-  NVAR = NVAR + nadv
+  if (nadv > 0) then
+    UFA = NVAR
+    NVAR = NVAR + nadv
+  else
+    UFA = 0
+  endif
   call check_equal(UFA,FirstAdv+1)
 
-  UFS = NVAR
-  NVAR = NVAR + nspec
+  if (nspec > 0) then
+    UFS = NVAR
+    NVAR = NVAR + nspec
+  else
+    UFS = 0
+  endif
   call check_equal(UFS,FirstSpec+1)
 
-  UFX = NVAR
-  NVAR = NVAR + naux
+  if (naux > 0) then
+    UFX = NVAR
+    NVAR = NVAR + naux
+  else
+    UFX = 0
+  endif
   call check_equal(UFX,FirstAux+1)
 
 #ifdef SHOCK_VAR

--- a/Source/driver/set_indices.F90
+++ b/Source/driver/set_indices.F90
@@ -14,252 +14,6 @@ subroutine check_equal(index1, index2)
 end subroutine check_equal
 
 
-subroutine ca_set_conserved_indices( &
-#ifdef HYBRID_MOMENTUM
-                                    Rmom, &
-#endif
-#ifdef HYBRID_MOMENTUM
-                                    Lmom, &
-#endif
-#ifdef HYBRID_MOMENTUM
-                                    Pmom, &
-#endif
-#ifdef SHOCK_VAR
-                                    Shock, &
-#endif
-                                    Density, &
-                                    Xmom, &
-                                    Ymom, &
-                                    Zmom, &
-                                    Eden, &
-                                    Eint, &
-                                    Temp, &
-                                    FirstAdv, &
-                                    FirstSpec, &
-                                    FirstAux &
-                                   )
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-#ifdef RADIATION
-  use rad_params_module, only : ngroups
-#endif
-  implicit none
-  integer, intent(in) :: Density
-  integer, intent(in) :: Xmom
-  integer, intent(in) :: Ymom
-  integer, intent(in) :: Zmom
-#ifdef HYBRID_MOMENTUM
-  integer, intent(in) :: Rmom
-#endif
-#ifdef HYBRID_MOMENTUM
-  integer, intent(in) :: Lmom
-#endif
-#ifdef HYBRID_MOMENTUM
-  integer, intent(in) :: Pmom
-#endif
-  integer, intent(in) :: Eden
-  integer, intent(in) :: Eint
-  integer, intent(in) :: Temp
-  integer, intent(in) :: FirstAdv
-  integer, intent(in) :: FirstSpec
-  integer, intent(in) :: FirstAux
-#ifdef SHOCK_VAR
-  integer, intent(in) :: Shock
-#endif
-
-  print *, "in set"
-  print *, "Rmom = ", Rmom
-  print *, "Lmom = ", Lmom
-  print *, "Pmom = ", Pmom
-  print *, "Density = ", Density
-  print *, "Xmom = ", Xmom
-  print *, "Ymom = ", Ymom
-  print *, "Zmom = ", Zmom
-  print *, "Eden = ", Eden
-  print *, "Eint = ", Eint
-  print *, "Temp = ", Temp
-  print *, "FirstAdv = ", FirstAdv
-  print *, "FirstSpec = ", FirstSpec
-  print *, "FirstAux = ", FirstAux
-
-  NVAR = 1
-
-  URHO = NVAR
-  NVAR = NVAR + 1
-  print *, "dens"
-  call check_equal(URHO,Density+1)
-
-  UMX = NVAR
-  NVAR = NVAR + 1
-  print *, "umx"
-  call check_equal(UMX,Xmom+1)
-
-  UMY = NVAR
-  NVAR = NVAR + 1
-  print *, "umy"
-  call check_equal(UMY,Ymom+1)
-
-  UMZ = NVAR
-  NVAR = NVAR + 1
-  print *, "umz"
-  call check_equal(UMZ,Zmom+1)
-
-#ifdef HYBRID_MOMENTUM
-  UMR = NVAR
-  NVAR = NVAR + 1
-  print *, "umr"
-  call check_equal(UMR,Rmom+1)
-#endif
-
-#ifdef HYBRID_MOMENTUM
-  UML = NVAR
-  NVAR = NVAR + 1
-  print *, "uml"
-  call check_equal(UML,Lmom+1)
-#endif
-
-#ifdef HYBRID_MOMENTUM
-  UMP = NVAR
-  NVAR = NVAR + 1
-  print *, "ump"
-  call check_equal(UMP,Pmom+1)
-#endif
-
-  UEDEN = NVAR
-  NVAR = NVAR + 1
-  print *, "ueden"
-  call check_equal(UEDEN,Eden+1)
-
-  UEINT = NVAR
-  NVAR = NVAR + 1
-  print *, "ueint"
-  call check_equal(UEINT,Eint+1)
-
-  UTEMP = NVAR
-  NVAR = NVAR + 1
-  print *, "utemp"
-  call check_equal(UTEMP,Temp+1)
-
-  if (nadv > 0) then
-    UFA = NVAR
-    NVAR = NVAR + nadv
-  else
-    UFA = 0
-  endif
-  call check_equal(UFA,FirstAdv+1)
-
-  if (nspec > 0) then
-    UFS = NVAR
-    NVAR = NVAR + nspec
-  else
-    UFS = 0
-  endif
-  call check_equal(UFS,FirstSpec+1)
-
-  if (naux > 0) then
-    UFX = NVAR
-    NVAR = NVAR + naux
-  else
-    UFX = 0
-  endif
-  call check_equal(UFX,FirstAux+1)
-
-#ifdef SHOCK_VAR
-  USHK = NVAR
-  NVAR = NVAR + 1
-  call check_equal(USHK,Shock+1)
-#endif
-
-  NVAR = NVAR - 1
-end subroutine ca_set_conserved_indices
-
-subroutine ca_set_godunov_indices()
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-#ifdef RADIATION
-  use rad_params_module, only : ngroups
-#endif
-  implicit none
-
-  NGDNV = 1
-
-  GDRHO = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDU = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDV = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDW = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDPRES = NGDNV
-  NGDNV = NGDNV + 1
-
-  GDGAME = NGDNV
-  NGDNV = NGDNV + 1
-
-#ifdef RADIATION
-  GDLAMS = NGDNV
-  NGDNV = NGDNV + ngroups
-#endif
-
-#ifdef RADIATION
-  GDERADS = NGDNV
-  NGDNV = NGDNV + ngroups
-#endif
-
-  NGDNV = NGDNV - 1
-end subroutine ca_set_godunov_indices
-
-subroutine ca_set_auxillary_indices()
-
-
-  use meth_params_module
-  use network, only: naux, nspec
-#ifdef RADIATION
-  use rad_params_module, only : ngroups
-#endif
-  implicit none
-
-  NQAUX = 1
-
-  QGAMC = NQAUX
-  NQAUX = NQAUX + 1
-
-  QC = NQAUX
-  NQAUX = NQAUX + 1
-
-  QDPDR = NQAUX
-  NQAUX = NQAUX + 1
-
-  QDPDE = NQAUX
-  NQAUX = NQAUX + 1
-
-#ifdef RADIATION
-  QGAMCG = NQAUX
-  NQAUX = NQAUX + 1
-#endif
-
-#ifdef RADIATION
-  QCG = NQAUX
-  NQAUX = NQAUX + 1
-#endif
-
-#ifdef RADIATION
-  QLAMS = NQAUX
-  NQAUX = NQAUX + ngroups
-#endif
-
-  NQAUX = NQAUX - 1
-end subroutine ca_set_auxillary_indices
-
 subroutine ca_set_primitive_indices()
 
 
@@ -354,4 +108,225 @@ subroutine ca_set_primitive_indices()
   NQ = NQ - 1
   QVAR = QVAR - 1
 end subroutine ca_set_primitive_indices
+
+subroutine ca_set_godunov_indices()
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
+  implicit none
+
+  NGDNV = 1
+
+  GDRHO = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDU = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDV = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDW = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDPRES = NGDNV
+  NGDNV = NGDNV + 1
+
+  GDGAME = NGDNV
+  NGDNV = NGDNV + 1
+
+#ifdef RADIATION
+  GDLAMS = NGDNV
+  NGDNV = NGDNV + ngroups
+#endif
+
+#ifdef RADIATION
+  GDERADS = NGDNV
+  NGDNV = NGDNV + ngroups
+#endif
+
+  NGDNV = NGDNV - 1
+end subroutine ca_set_godunov_indices
+
+subroutine ca_set_auxillary_indices()
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
+  implicit none
+
+  NQAUX = 1
+
+  QGAMC = NQAUX
+  NQAUX = NQAUX + 1
+
+  QC = NQAUX
+  NQAUX = NQAUX + 1
+
+  QDPDR = NQAUX
+  NQAUX = NQAUX + 1
+
+  QDPDE = NQAUX
+  NQAUX = NQAUX + 1
+
+#ifdef RADIATION
+  QGAMCG = NQAUX
+  NQAUX = NQAUX + 1
+#endif
+
+#ifdef RADIATION
+  QCG = NQAUX
+  NQAUX = NQAUX + 1
+#endif
+
+#ifdef RADIATION
+  QLAMS = NQAUX
+  NQAUX = NQAUX + ngroups
+#endif
+
+  NQAUX = NQAUX - 1
+end subroutine ca_set_auxillary_indices
+
+subroutine ca_set_conserved_indices( &
+#ifdef HYBRID_MOMENTUM
+                                    Rmom, &
+#endif
+#ifdef HYBRID_MOMENTUM
+                                    Lmom, &
+#endif
+#ifdef HYBRID_MOMENTUM
+                                    Pmom, &
+#endif
+#ifdef SHOCK_VAR
+                                    Shock, &
+#endif
+                                    Density, &
+                                    Xmom, &
+                                    Ymom, &
+                                    Zmom, &
+                                    Eden, &
+                                    Eint, &
+                                    Temp, &
+                                    FirstAdv, &
+                                    FirstSpec, &
+                                    FirstAux &
+                                   )
+
+
+  use meth_params_module
+  use network, only: naux, nspec
+#ifdef RADIATION
+  use rad_params_module, only : ngroups
+#endif
+  implicit none
+  integer, intent(in) :: Density
+  integer, intent(in) :: Xmom
+  integer, intent(in) :: Ymom
+  integer, intent(in) :: Zmom
+#ifdef HYBRID_MOMENTUM
+  integer, intent(in) :: Rmom
+#endif
+#ifdef HYBRID_MOMENTUM
+  integer, intent(in) :: Lmom
+#endif
+#ifdef HYBRID_MOMENTUM
+  integer, intent(in) :: Pmom
+#endif
+  integer, intent(in) :: Eden
+  integer, intent(in) :: Eint
+  integer, intent(in) :: Temp
+  integer, intent(in) :: FirstAdv
+  integer, intent(in) :: FirstSpec
+  integer, intent(in) :: FirstAux
+#ifdef SHOCK_VAR
+  integer, intent(in) :: Shock
+#endif
+
+  NVAR = 1
+
+  URHO = NVAR
+  NVAR = NVAR + 1
+  call check_equal(URHO,Density+1)
+
+  UMX = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMX,Xmom+1)
+
+  UMY = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMY,Ymom+1)
+
+  UMZ = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMZ,Zmom+1)
+
+#ifdef HYBRID_MOMENTUM
+  UMR = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMR,Rmom+1)
+#endif
+
+#ifdef HYBRID_MOMENTUM
+  UML = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UML,Lmom+1)
+#endif
+
+#ifdef HYBRID_MOMENTUM
+  UMP = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UMP,Pmom+1)
+#endif
+
+  UEDEN = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UEDEN,Eden+1)
+
+  UEINT = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UEINT,Eint+1)
+
+  UTEMP = NVAR
+  NVAR = NVAR + 1
+  call check_equal(UTEMP,Temp+1)
+
+  if (nadv > 0) then
+    UFA = NVAR
+    NVAR = NVAR + nadv
+  else
+    UFA = 0
+  endif
+  call check_equal(UFA,FirstAdv+1)
+
+  if (nspec > 0) then
+    UFS = NVAR
+    NVAR = NVAR + nspec
+  else
+    UFS = 0
+  endif
+  call check_equal(UFS,FirstSpec+1)
+
+  if (naux > 0) then
+    UFX = NVAR
+    NVAR = NVAR + naux
+  else
+    UFX = 0
+  endif
+  call check_equal(UFX,FirstAux+1)
+
+#ifdef SHOCK_VAR
+  USHK = NVAR
+  NVAR = NVAR + 1
+  call check_equal(USHK,Shock+1)
+#endif
+
+  NVAR = NVAR - 1
+end subroutine ca_set_conserved_indices
 

--- a/Source/driver/set_variables.py
+++ b/Source/driver/set_variables.py
@@ -186,6 +186,7 @@ def doit():
             sub += "\n\n"
             sub += "  use meth_params_module\n"
             sub += "  use network, only: naux, nspec\n"
+            sub += "#ifdef RADIATION\n  use rad_params_module, only : ngroups\n#endif\n"
             sub += "  implicit none\n"
 
             for i in set_indices:

--- a/Source/driver/set_variables.py
+++ b/Source/driver/set_variables.py
@@ -121,7 +121,7 @@ def doit():
                 sub += "#endif\n"
 
             # finalize the counters
-            sub += "  {} = {} - 1\n".format(s, s)
+            sub += "  {} = {} - 1\n".format(default_set[s], default_set[s])
             for a in adds_to:
                 if a is None:
                     continue

--- a/Source/driver/set_variables.py
+++ b/Source/driver/set_variables.py
@@ -146,7 +146,7 @@ def doit():
         # arg list will be C++ names to compare to
         f.write(CHECK_EQUAL)
 
-        for s in unique_sets:
+        for s in sorted(unique_sets):
             subname = "ca_set_{}_indices".format(s)
 
             set_indices = [q for q in indices if q.iset == s]
@@ -160,7 +160,7 @@ def doit():
             # write the function heading
             sub = ""
 
-            if len(cxx_names) == 0:
+            if not cxx_names:
                 sub += "subroutine {}()\n".format(subname)
             else:
                 sub += "subroutine {}( &\n".format(subname)

--- a/Source/driver/set_variables.py
+++ b/Source/driver/set_variables.py
@@ -106,6 +106,10 @@ def doit():
 
             # initialize the counters
             sub += "  {} = 1\n\n".format(default_set[s])
+            for a in adds_to:
+                if a is None:
+                    continue
+                sub += "  {} = 1\n\n".format(a)
 
             # write the lines to set the indices
             # first do those without an ifex

--- a/Source/driver/set_variables.py
+++ b/Source/driver/set_variables.py
@@ -1,0 +1,139 @@
+# parse the _variables file and write the set of functions that will
+# define the indices
+#
+# ca_set_conserved_indices: the conserved state
+#
+# ca_set_primitive_indices: the primitive variable state
+#
+# ca_set_godunov_indices: the interface state
+#
+# ca_set_auxillary_indices: the auxillary state information
+
+class Index(object):
+    """an index that we want to set"""
+    def __init__(self, name, f90_var, default_group=None, iset=None,
+                 also_adds_to=None, count=1, cxx_var=None, ifdef=None):
+        self.name = name
+        self.cxx_var = cxx_var
+        self.f90_var = f90_var
+        self.iset = iset
+        self.default_group = default_group
+        self.adds_to = also_adds_to
+        self.count = count
+        self.ifdef = ifdef
+
+    def __str__(self):
+        return self.f90_var
+
+    def get_set_string(self):
+        sstr = ""
+        sstr += "  {} = {}\n".format(self.f90_var, self.default_group)
+        sstr += "  {} = {} + {}\n".format(self.default_group, self.default_group, self.count)
+        if self.adds_to is not None:
+            sstr += "  {} = {} + {}\n".format(self.adds_to, self.adds_to, self.count)
+        if self.cxx_var is not None:
+            sstr += "  call check_equal({},{}+1)\n".format(self.f90_var, self.cxx_var)
+        sstr += "\n"
+        return sstr
+
+def doit():
+
+    # read the file and create a list of indices
+    indices = []
+    default_set = {}
+    with open("_variables", "r") as f:
+        current_set = None
+        default_group = None
+        for line in f:
+            if line.startswith("#") or line.strip() == "":
+                continue
+            elif line.startswith("@"):
+                print(line)
+                _, current_set, default_group = line.split()
+                default_set[current_set] = default_group
+            else:
+                name, cxx_var, f90_var, adds_to, count, ifdef = line.split()
+                if adds_to == "None":
+                    adds_to = None
+                if cxx_var == "None":
+                    cxx_var = None
+                if ifdef == "None":
+                    ifdef = None
+
+                indices.append(Index(name, f90_var, default_group=default_group,
+                                     iset=current_set, also_adds_to=adds_to,
+                                     count=count, cxx_var=cxx_var, ifdef=ifdef))
+
+
+    # find the set of set names
+    unique_sets = set([q.iset for q in indices])
+
+    # all these routines will live in a single file
+    with open("set_indices.F90", "w") as f:
+
+        # loop over sets and create the function
+        # arg list will be C++ names to compare to
+        for s in unique_sets:
+            subname = "ca_set_{}_indices".format(s)
+
+            set_indices = [q for q in indices if q.iset == s]
+
+            # within this set, find the unique ifdef names
+            ifdefs = set([q.ifdef for q in set_indices])
+
+            # cxx names in this set
+            cxx_names = set([q.cxx_var for q in set_indices])
+
+            # add to
+            adds_to = set([q.adds_to for q in set_indices])
+
+            # write the function heading
+            sub = ""
+            sub += "subroutine {}( &\n".format(subname)
+            for n, cxx in enumerate(cxx_names):
+                if cxx is None:
+                    continue
+                sub += "          {} {}, &\n".format(" "*len(subname), cxx)
+
+            sub += "          {})\n\n".format(" "*len(subname), cxx)
+            sub += "  use meth_params_module\n"
+
+            for cxx in cxx_names:
+                if cxx is None:
+                    continue
+                sub += "  integer, intent(in) :: {}\n".format(cxx)
+            sub += "\n"
+
+            # initialize the counters
+            sub += "  {} = 1\n\n".format(default_set[s])
+
+            # write the lines to set the indices
+            # first do those without an ifex
+            for i in [q for q in set_indices if q.ifdef is None]:
+                sub += i.get_set_string()
+
+            for ifd in ifdefs:
+                if ifd is None:
+                    continue
+                sub += "#ifdef {}\n".format(ifd)
+                for i in [q for q in set_indices if q.ifdef == ifd]:
+                    sub += i.get_set_string()
+                sub += "#endif\n"
+
+            # finalize the counters
+            sub += "  {} = {} - 1\n".format(s, s)
+            for a in adds_to:
+                if a is None:
+                    continue
+                sub += "  {} = {} - 1\n".format(a, a)
+
+            # end the function
+            sub += "end subroutine {}\n\n".format(subname)
+
+            f.write(sub)
+
+    # write the C++ function signatures
+
+
+if __name__ == "__main__":
+    doit()

--- a/Source/radiation/Rad_nd.f90
+++ b/Source/radiation/Rad_nd.f90
@@ -359,30 +359,3 @@ subroutine ca_compute_scattering_2(lo, hi, &
   end if
 
 end subroutine ca_compute_scattering_2
-
-subroutine ca_init_godunov_indices_rad() bind(C, name="ca_init_godunov_indices_rad")
-
-  use meth_params_module, only : GDRHO, GDU, GDV, GDW, GDPRES, GDGAME, ngdnv, &
-       GDLAMS, GDERADS, &
-       QU, QV, QW
-  use rad_params_module, only: ngroups
-
-  use amrex_fort_module, only : rt => amrex_real
-  implicit none
-
-  ngdnv = 6 + 2*ngroups
-  GDRHO = 1
-  GDU = 2
-  GDV = 3
-  GDW = 4
-  GDPRES = 5
-  GDGAME = 6
-  GDLAMS = GDGAME+1            ! starting index for rad lambda
-  GDERADS = GDLAMS + ngroups   ! starting index for rad energy
-
-  ! sanity check
-  if ((QU /= GDU) .or. (QV /= GDV) .or. (QW /= GDW)) then
-     call bl_error("ERROR: velocity components for godunov and primitive state are not aligned")
-  endif
-
-end subroutine ca_init_godunov_indices_rad

--- a/Source/radiation/Rad_nd.f90
+++ b/Source/radiation/Rad_nd.f90
@@ -67,7 +67,6 @@ subroutine ca_initsinglegroup(ngr) bind(C, name="ca_initsinglegroup")
   ! Local variables
   integer   :: i
 
-  ngroups = ngr
   ng0 = 0
   ng1 = 0
 
@@ -100,7 +99,6 @@ subroutine ca_initgroups(nugr, dnugr, ngr, ngr0, ngr1)
   ! Local variables
   integer   :: i
 
-  ngroups = ngr
   ng0     = ngr0
   ng1     = ngr1
 
@@ -126,8 +124,6 @@ subroutine ca_initgroups2(nugr, dnugr, xnugr, ngr)
 
   ! Local variables
   integer   :: i
-
-  ngroups = ngr
 
   allocate(nugroup( 0:ngroups-1))
   allocate(dnugroup(0:ngroups-1))
@@ -159,7 +155,6 @@ subroutine ca_initgroups3(nugr, dnugr, dlognugr, xnugr, ngr, ngr0, ngr1)
   ! Local variables
   integer   :: i
 
-  ngroups = ngr
   ng0     = ngr0
   ng1     = ngr1
 

--- a/Source/radiation/rad_util.f90
+++ b/Source/radiation/rad_util.f90
@@ -12,12 +12,12 @@ contains
 
   subroutine compute_ptot_ctot(lam, q, cg, ptot, ctot, gamc_tot)
 
-    use meth_params_module, only : QPRES, QRHO, comoving, QRAD, QPTOT, QRADVAR
+    use meth_params_module, only : QPRES, QRHO, comoving, QRAD, QPTOT, NQ
     use fluxlimiter_module, only : Edd_factor
 
     use amrex_fort_module, only : rt => amrex_real
     real(rt)        , intent(in) :: lam(0:ngroups-1)
-    real(rt)        , intent(in) :: q(QRADVAR)
+    real(rt)        , intent(in) :: q(NQ)
     real(rt)        , intent(in) :: cg
     real(rt)        , intent(out) :: ptot
     real(rt)        , intent(out) :: ctot


### PR DESCRIPTION
We now list variable indices in a plain text file `_variables`.  These are used as the index keys into state
arrays both in C++ (for conserved state) and Fortran (for all the states).  This is the first part of a clean-up of how we define variables.  This addresses part of #267.  At the moment, we run the script `set_variables.py` manually to write the Fortran routines that C++ include file.  We also do some checking to ensure that we are synced up between C++ and Fortran.