### PR TITLE
Mlmg diffusion

### DIFF
--- a/Docs/runtime_parameters/runtime_parameters.tex
+++ b/Docs/runtime_parameters/runtime_parameters.tex
@@ -658,7 +658,9 @@
 
 
 \rowcolor{tableShade}
+\runparamNS{mlmg\_maxorder}{diffusion} &  & 4 \\
 \runparamNS{use\_mlmg\_solver}{diffusion} &  Use MLMG as the operator & 0 \\
+\rowcolor{tableShade}
 \runparamNS{v}{diffusion} &  the level of verbosity for the diffusion solve (higher number means more output) & 0 \\
 
 

--- a/Docs/runtime_parameters/runtime_parameters.tex
+++ b/Docs/runtime_parameters/runtime_parameters.tex
@@ -658,6 +658,7 @@
 
 
 \rowcolor{tableShade}
+\runparamNS{use\_mlmg\_solver}{diffusion} &  Use MLMG as the operator & 0 \\
 \runparamNS{v}{diffusion} &  the level of verbosity for the diffusion solve (higher number means more output) & 0 \\
 
 

--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -76,11 +76,7 @@ endif
 USE_MG = FALSE
 
 ifndef USE_MLMG
-  ifneq ($(DIM),1)
-    USE_MLMG = TRUE
-  else
-    USE_MLMG = FALSE
-  endif
+  USE_MLMG = TRUE
 endif
 
 #------------------------------------------------------------------------------

--- a/Source/diffusion/Diffusion.H
+++ b/Source/diffusion/Diffusion.H
@@ -3,6 +3,10 @@
 
 #include <AMReX_AmrLevel.H>
 
+#ifdef CASTRO_MLMG
+#include <AMReX_MLLinOp.H>
+#endif
+
 class Diffusion {
 
 public:
@@ -26,13 +30,6 @@ public:
 
   void make_mg_bc();
 
-  void GetCrsePhi(int level, 
-                  amrex::MultiFab& phi_crse,
-                  amrex::Real time);
-
-  void zeroPhiFluxReg (int level);
-
-
 protected:
   //
   // Pointers to amr,amrlevel.
@@ -54,6 +51,11 @@ protected:
 
   amrex::BCRec*       phys_bc;
 
+#ifdef CASTRO_MLMG
+  std::array<amrex::MLLinOp::BCType,AMREX_SPACEDIM> mlmg_lobc;
+  std::array<amrex::MLLinOp::BCType,AMREX_SPACEDIM> mlmg_hibc;
+#endif
+
 #include "diffusion_params.H"
 
   static int   stencil_type;
@@ -63,6 +65,21 @@ protected:
   void   weight_cc(int level,amrex::MultiFab& cc);
   void unweight_cc(int level,amrex::MultiFab& cc);
 #endif
+
+  void applyop_fmg(int level,amrex::MultiFab& Temperature,amrex::MultiFab& CrseTemp,
+                   amrex::MultiFab& DiffTerm, amrex::Vector<std::unique_ptr<amrex::MultiFab> >& temp_cond_coef);
+
+  void applyViscOp_fmg(int level,amrex::MultiFab& Vel, amrex::MultiFab& CrseVel,
+                       amrex::MultiFab& ViscTerm, amrex::Vector<std::unique_ptr<amrex::MultiFab> >& visc_coeff);
+
+#ifdef CASTRO_MLMG
+  void applyop_mlmg(int level,amrex::MultiFab& Temperature,amrex::MultiFab& CrseTemp,
+                    amrex::MultiFab& DiffTerm, amrex::Vector<std::unique_ptr<amrex::MultiFab> >& temp_cond_coef);
+
+  void applyViscOp_mlmg(int level,amrex::MultiFab& Vel, amrex::MultiFab& CrseVel,
+                        amrex::MultiFab& ViscTerm, amrex::Vector<std::unique_ptr<amrex::MultiFab> >& visc_coeff);
+#endif
+
 };
 #endif
 

--- a/Source/diffusion/Diffusion.cpp
+++ b/Source/diffusion/Diffusion.cpp
@@ -362,6 +362,7 @@ Diffusion::applyop_mlmg (int level, MultiFab& Temperature,
     
     MLABecLaplacian mlabec({geom}, {ba}, {dm},
                            LPInfo().setMetricTerm(true).setMaxCoarseningLevel(0));
+    mlabec.setMaxOrder(mlmg_maxorder);
 
     mlabec.setDomainBC(mlmg_lobc, mlmg_hibc);
 
@@ -397,6 +398,7 @@ Diffusion::applyViscOp_mlmg (int level, MultiFab& Vel,
     
     MLABecLaplacian mlabec({geom}, {ba}, {dm},
                            LPInfo().setMetricTerm(false).setMaxCoarseningLevel(0));
+    mlabec.setMaxOrder(mlmg_maxorder);
 
     mlabec.setDomainBC(mlmg_lobc, mlmg_hibc);
 

--- a/Source/diffusion/Diffusion.cpp
+++ b/Source/diffusion/Diffusion.cpp
@@ -152,12 +152,12 @@ Diffusion::applyViscOp (int level, MultiFab& Vel,
 #ifdef CASTRO_MLMG
     if (use_mlmg_solver)
     {
-        applyViscOp_mlmg(level, Vel, CrseVel, Visc_Coeff, visc_coeff);
+        applyViscOp_mlmg(level, Vel, CrseVel, ViscTerm, visc_coeff);
     }
     else
 #endif
     {
-        applyViscOp_fmg(level, Vel, CrseVel, Visc_Coeff, visc_coeff);
+        applyViscOp_fmg(level, Vel, CrseVel, ViscTerm, visc_coeff);
     }
 }
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -609,3 +609,6 @@ mlmg_nsolve                  int           0                  n
 # more output)
 (v, verbose)                int            0                
 
+# Use MLMG as the operator
+use_mlmg_solver              int           0                  n
+

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -611,4 +611,4 @@ mlmg_nsolve                  int           0                  n
 
 # Use MLMG as the operator
 use_mlmg_solver              int           0                  n
-
+mlmg_maxorder                int           4                  n

--- a/Source/driver/param_includes/diffusion_defaults.H
+++ b/Source/driver/param_includes/diffusion_defaults.H
@@ -5,3 +5,4 @@
 
 int         Diffusion::verbose = 0;
 int         Diffusion::use_mlmg_solver = 0;
+int         Diffusion::mlmg_maxorder = 4;

--- a/Source/driver/param_includes/diffusion_defaults.H
+++ b/Source/driver/param_includes/diffusion_defaults.H
@@ -4,3 +4,4 @@
 // mk_params.sh
 
 int         Diffusion::verbose = 0;
+int         Diffusion::use_mlmg_solver = 0;

--- a/Source/driver/param_includes/diffusion_job_info_tests.H
+++ b/Source/driver/param_includes/diffusion_job_info_tests.H
@@ -1,2 +1,3 @@
 jobInfoFile << (Diffusion::verbose == 0 ? "    " : "[*] ") << "diffusion.verbose = " << Diffusion::verbose << std::endl;
 jobInfoFile << (Diffusion::use_mlmg_solver == 0 ? "    " : "[*] ") << "diffusion.use_mlmg_solver = " << Diffusion::use_mlmg_solver << std::endl;
+jobInfoFile << (Diffusion::mlmg_maxorder == 4 ? "    " : "[*] ") << "diffusion.mlmg_maxorder = " << Diffusion::mlmg_maxorder << std::endl;

--- a/Source/driver/param_includes/diffusion_job_info_tests.H
+++ b/Source/driver/param_includes/diffusion_job_info_tests.H
@@ -1,1 +1,2 @@
 jobInfoFile << (Diffusion::verbose == 0 ? "    " : "[*] ") << "diffusion.verbose = " << Diffusion::verbose << std::endl;
+jobInfoFile << (Diffusion::use_mlmg_solver == 0 ? "    " : "[*] ") << "diffusion.use_mlmg_solver = " << Diffusion::use_mlmg_solver << std::endl;

--- a/Source/driver/param_includes/diffusion_params.H
+++ b/Source/driver/param_includes/diffusion_params.H
@@ -5,3 +5,4 @@
 
 static int verbose;
 static int use_mlmg_solver;
+static int mlmg_maxorder;

--- a/Source/driver/param_includes/diffusion_params.H
+++ b/Source/driver/param_includes/diffusion_params.H
@@ -4,3 +4,4 @@
 // mk_params.sh
 
 static int verbose;
+static int use_mlmg_solver;

--- a/Source/driver/param_includes/diffusion_queries.H
+++ b/Source/driver/param_includes/diffusion_queries.H
@@ -4,3 +4,4 @@
 // mk_params.sh
 
 pp.query("v", verbose);
+pp.query("use_mlmg_solver", use_mlmg_solver);

--- a/Source/driver/param_includes/diffusion_queries.H
+++ b/Source/driver/param_includes/diffusion_queries.H
@@ -5,3 +5,4 @@
 
 pp.query("v", verbose);
 pp.query("use_mlmg_solver", use_mlmg_solver);
+pp.query("mlmg_maxorder", mlmg_maxorder);

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -2939,10 +2939,6 @@ Gravity::actual_solve_with_mlmg (int crse_level, int fine_level,
         mlpoisson.setLevelBC(ilev, phi[ilev]);
     }
 
-#if (AMREX_SPACEDIM == 1)
-    static_assert(false, "solve_phi_with_mlmg: 1d not supported yet");
-#endif
-
     MLMG mlmg(mlpoisson);
     mlmg.setVerbose(verbose);
     if (crse_level == 0) {

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -2092,8 +2092,9 @@ Gravity::make_mg_bc ()
     }
 
     // Set Neumann bc at r=0.
-    if (Geometry::IsSPHERICAL() || Geometry::IsRZ() )
+    if (Geometry::IsSPHERICAL() || Geometry::IsRZ() ) {
         mg_bc[0] = MGT_BC_NEU;
+    }
 
 #ifdef CASTRO_MLMG
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {


### PR DESCRIPTION
This pull request adds the option to use MLMG as diffusion operator.  Two new runtime parameters are added. 

- diffusion.use_mlmg_solver = 0
  This is a boolean flag.
- diffusion.mlmg_maxorder = 4
  The other valid value is 3.  This parameter controls the order of polynomial interpolation at boundaries.

