### PR TITLE
Fix logic for dealing with CFL violations during retries

### DIFF
--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -118,7 +118,7 @@ Castro::advance (Real time,
 
     // Optionally kill the job at this point, if we've detected a violation.
 
-    if (cfl_violation && hard_cfl_limit)
+    if (cfl_violation && hard_cfl_limit && !use_retry)
         amrex::Abort("CFL is too high at this level -- go back to a checkpoint and restart with lower cfl number");
 
     // If we didn't kill the job, reset the violation counter.
@@ -270,7 +270,7 @@ Castro::do_advance (Real time,
       check_for_cfl_violation(dt);
 
       // If we detect one, return immediately.
-      if (cfl_violation)
+      if (cfl_violation && hard_cfl_limit)
           return dt;
 
       construct_hydro_source(time, dt);
@@ -1221,7 +1221,7 @@ Castro::subcycle_advance(const Real time, const Real dt, int amr_iteration, int 
         // If we have hit a CFL violation during this subcycle, we must abort.
 
         if (cfl_violation && hard_cfl_limit)
-            amrex::Abort("CFL is too high at this level -- go back to a checkpoint and restart with lower cfl number");
+            amrex::Abort("CFL is too high at this level, and we are already inside a retry -- go back to a checkpoint and restart with lower cfl number");
 
     }
 


### PR DESCRIPTION
castro.hard_cfl_limit now has the behavior that it is ignored during the initial advance if you're using a retry, and is enforced during the retries. Thus the default behavior is now that when a CFL violation is detected and retries are enabled, a retry will be taken, and if a subcycle in that retry violates CFL stability, the run aborts.

Fixes #334