### PR TITLE
Add tagging criteria for relative gradients

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,14 @@
 # changes since the last release
 
+  -- Tagging can now be done on relative gradients, in addition
+     to the existing capability for absolute gradients (#354).
+     For example, tempgrad_rel is a relative gradient criterion
+     that will tag a zone with temperature T if any adjacent zone
+     has a temperature that is different by more than tempgrad_rel * T.
+     The tagging is enabled up to a given level with the parameter
+     max_tempgrad_rel_lev. The corresponding new tagging criteria
+     for other fields are named similarly.
+
   -- Retries can now be done in a dynamic fashion (#179). An
      advance is itself a subcycled advance always, and we keep
      subcycling until we are done with the step. By default we

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -786,43 +786,61 @@ subroutine ca_get_tagging_params(name, namlen) &
   character (len=maxlen) :: probin
 
   namelist /tagging/ &
-       denerr,     dengrad,   max_denerr_lev,   max_dengrad_lev, &
-       enterr,     entgrad,   max_enterr_lev,   max_entgrad_lev, &
-       velerr,     velgrad,   max_velerr_lev,   max_velgrad_lev, &
-       presserr, pressgrad, max_presserr_lev, max_pressgrad_lev, &
-       temperr,   tempgrad,  max_temperr_lev,  max_tempgrad_lev, &
-       raderr,     radgrad,   max_raderr_lev,   max_radgrad_lev
+       denerr, dengrad, dengrad_rel, &
+       max_denerr_lev, max_dengrad_lev, max_dengrad_rel_lev, &
+       enterr, entgrad, entgrad_rel, &
+       max_enterr_lev, max_entgrad_lev, max_entgrad_rel_lev, &
+       velerr, velgrad, velgrad_rel, &
+       max_velerr_lev, max_velgrad_lev, max_velgrad_rel_lev, &
+       presserr, pressgrad, pressgrad_rel, &
+       max_presserr_lev, max_pressgrad_lev, max_pressgrad_rel_lev, &
+       temperr, tempgrad, tempgrad_rel, &
+       max_temperr_lev, max_tempgrad_lev, max_tempgrad_rel_lev, &
+       raderr, radgrad, radgrad_rel, &
+       max_raderr_lev, max_radgrad_lev, max_radgrad_rel_lev
 
   ! Set namelist defaults
   denerr = 1.e20_rt
   dengrad = 1.e20_rt
+  dengrad_rel = 1.e20_rt
   max_denerr_lev = 10
   max_dengrad_lev = 10
+  max_dengrad_rel_lev = -1
 
   enterr = 1.e20_rt
   entgrad = 1.e20_rt
+  entgrad_rel = 1.e20_rt
   max_enterr_lev = -1
   max_entgrad_lev = -1
+  max_entgrad_rel_lev = -1
 
   presserr = 1.e20_rt
   pressgrad = 1.e20_rt
+  pressgrad_rel = 1.e20_rt
   max_presserr_lev = -1
   max_pressgrad_lev = -1
+  max_pressgrad_rel_lev = -1
 
   velerr  = 1.e20_rt
   velgrad = 1.e20_rt
+  velgrad_rel = 1.e20_rt
   max_velerr_lev = -1
   max_velgrad_lev = -1
+  max_velgrad_rel_lev = -1
 
   temperr  = 1.e20_rt
   tempgrad = 1.e20_rt
+  tempgrad_rel = 1.e20_rt
   max_temperr_lev = -1
   max_tempgrad_lev = -1
+  max_tempgrad_rel_lev = -1
 
   raderr  = 1.e20_rt
   radgrad = 1.e20_rt
+  radgrad_rel = 1.e20_rt
   max_raderr_lev = -1
   max_radgrad_lev = -1
+  max_radgrad_rel_lev = -1
 
   ! create the filename
 #ifndef AMREX_USE_CUDA

--- a/Source/driver/Tagging_nd.f90
+++ b/Source/driver/Tagging_nd.f90
@@ -3,18 +3,18 @@ module tagging_module
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
-  real(rt)        , save ::    denerr,   dengrad
-  real(rt)        , save ::    enterr,   entgrad
-  real(rt)        , save ::    velerr,   velgrad
-  real(rt)        , save ::   temperr,  tempgrad
-  real(rt)        , save ::  presserr, pressgrad
-  real(rt)        , save ::    raderr,   radgrad
-  integer         , save ::  max_denerr_lev,   max_dengrad_lev
-  integer         , save ::  max_enterr_lev,   max_entgrad_lev
-  integer         , save ::  max_velerr_lev,   max_velgrad_lev
-  integer         , save ::  max_temperr_lev,  max_tempgrad_lev
-  integer         , save ::  max_presserr_lev, max_pressgrad_lev
-  integer         , save ::  max_raderr_lev,   max_radgrad_lev
+  real(rt)        , save ::    denerr,   dengrad, dengrad_rel
+  real(rt)        , save ::    enterr,   entgrad, entgrad_rel
+  real(rt)        , save ::    velerr,   velgrad, velgrad_rel
+  real(rt)        , save ::   temperr,  tempgrad, tempgrad_rel
+  real(rt)        , save ::  presserr, pressgrad, pressgrad_rel
+  real(rt)        , save ::    raderr,   radgrad, radgrad_rel
+  integer         , save ::  max_denerr_lev,   max_dengrad_lev, max_dengrad_rel_lev
+  integer         , save ::  max_enterr_lev,   max_entgrad_lev, max_entgrad_rel_lev
+  integer         , save ::  max_velerr_lev,   max_velgrad_lev, max_velgrad_rel_lev
+  integer         , save ::  max_temperr_lev,  max_tempgrad_lev, max_tempgrad_rel_lev
+  integer         , save ::  max_presserr_lev, max_pressgrad_lev, max_pressgrad_rel_lev
+  integer         , save ::  max_raderr_lev,   max_radgrad_lev, max_radgrad_rel_lev
 
   public
 
@@ -53,8 +53,8 @@ contains
                              bind(C, name="ca_laplac_error")
 
     use prob_params_module, only: dg, dim
-
     use amrex_fort_module, only : rt => amrex_real
+
     implicit none
 
     integer,    intent(in) :: set, clear, nd, level
@@ -190,8 +190,8 @@ contains
                          bind(C, name="ca_denerror")
 
     use prob_params_module, only: dg
-
     use amrex_fort_module, only : rt => amrex_real
+
     implicit none
 
     integer, intent(in) :: set, clear, nd, level
@@ -219,7 +219,7 @@ contains
     endif
 
     !     Tag on regions of high density gradient
-    if (level .lt. max_dengrad_lev) then
+    if (level .lt. max_dengrad_lev .or. level .lt. max_dengrad_rel_lev) then
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
@@ -229,7 +229,7 @@ contains
                 ax = MAX(ax,ABS(den(i,j,k,1) - den(i-1*dg(1),j,k,1)))
                 ay = MAX(ay,ABS(den(i,j,k,1) - den(i,j-1*dg(2),k,1)))
                 az = MAX(az,ABS(den(i,j,k,1) - den(i,j,k-1*dg(3),1)))
-                if ( MAX(ax,ay,az) .ge. dengrad) then
+                if (MAX(ax,ay,az) .ge. dengrad .or. MAX(ax,ay,az) .ge. ABS(dengrad_rel * den(i,j,k,1))) then
                    tag(i,j,k) = set
                 endif
              enddo
@@ -251,8 +251,8 @@ contains
                           bind(C, name="ca_temperror")
 
     use prob_params_module, only: dg
-
     use amrex_fort_module, only : rt => amrex_real
+
     implicit none
 
     integer, intent(in) :: set, clear, np, level
@@ -280,7 +280,7 @@ contains
     endif
 
     !     Tag on regions of high temperature gradient
-    if (level .lt. max_tempgrad_lev) then
+    if (level .lt. max_tempgrad_lev .or. level .lt. max_tempgrad_rel_lev) then
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
@@ -290,7 +290,7 @@ contains
                 ax = MAX(ax,ABS(temp(i,j,k,1) - temp(i-1*dg(1),j,k,1)))
                 ay = MAX(ay,ABS(temp(i,j,k,1) - temp(i,j-1*dg(2),k,1)))
                 az = MAX(az,ABS(temp(i,j,k,1) - temp(i,j,k-1*dg(3),1)))
-                if ( MAX(ax,ay,az) .ge. tempgrad) then
+                if (MAX(ax,ay,az) .ge. tempgrad .or. MAX(ax,ay,az) .ge. ABS(tempgrad_rel * temp(i,j,k,1))) then
                    tag(i,j,k) = set
                 endif
              enddo
@@ -312,8 +312,8 @@ contains
                            bind(C, name="ca_presserror")
 
     use prob_params_module, only: dg
-
     use amrex_fort_module, only : rt => amrex_real
+
     implicit none
 
     integer, intent(in) :: set, clear, np, level
@@ -341,7 +341,7 @@ contains
     endif
 
     !     Tag on regions of high pressure gradient
-    if (level .lt. max_pressgrad_lev) then
+    if (level .lt. max_pressgrad_lev .or. level .lt. max_pressgrad_rel_lev) then
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
@@ -351,7 +351,7 @@ contains
                 ax = MAX(ax,ABS(press(i,j,k,1) - press(i-1*dg(1),j,k,1)))
                 ay = MAX(ay,ABS(press(i,j,k,1) - press(i,j-1*dg(2),k,1)))
                 az = MAX(az,ABS(press(i,j,k,1) - press(i,j,k-1*dg(3),1)))
-                if ( MAX(ax,ay,az) .ge. pressgrad) then
+                if (MAX(ax,ay,az) .ge. pressgrad .or. MAX(ax,ay,az) .ge. ABS(pressgrad_rel * press(i,j,k,1))) then
                    tag(i,j,k) = set
                 endif
              enddo
@@ -373,8 +373,8 @@ contains
                          bind(C, name="ca_velerror")
 
     use prob_params_module, only: dg
-
     use amrex_fort_module, only : rt => amrex_real
+
     implicit none
 
     integer, intent(in) :: set, clear, nv, level
@@ -402,7 +402,7 @@ contains
     endif
 
     !     Tag on regions of high velocity gradient
-    if (level .lt. max_velgrad_lev) then
+    if (level .lt. max_velgrad_lev .or. level .lt. max_velgrad_rel_lev) then
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
@@ -412,7 +412,7 @@ contains
                 ax = MAX(ax,ABS(vel(i,j,k,1) - vel(i-1*dg(1),j,k,1)))
                 ay = MAX(ay,ABS(vel(i,j,k,1) - vel(i,j-1*dg(2),k,1)))
                 az = MAX(az,ABS(vel(i,j,k,1) - vel(i,j,k-1*dg(3),1)))
-                if ( MAX(ax,ay,az) .ge. velgrad) then
+                if (MAX(ax,ay,az) .ge. velgrad .or. MAX(ax,ay,az) .ge. ABS(velgrad_rel * vel(i,j,k,1))) then
                    tag(i,j,k) = set
                 endif
              enddo
@@ -434,8 +434,8 @@ contains
                          bind(C, name="ca_raderror")
 
     use prob_params_module, only: dg
-
     use amrex_fort_module, only : rt => amrex_real
+
     implicit none
 
     integer, intent(in) :: set, clear, nr, level
@@ -463,7 +463,7 @@ contains
     endif
 
     !     Tag on regions of high radiation gradient
-    if (level .lt. max_radgrad_lev) then
+    if (level .lt. max_radgrad_lev .or. level .lt. max_radgrad_rel_lev) then
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
@@ -473,7 +473,7 @@ contains
                 ax = MAX(ax,ABS(rad(i,j,k,1) - rad(i-1*dg(1),j,k,1)))
                 ay = MAX(ay,ABS(rad(i,j,k,1) - rad(i,j-1*dg(2),k,1)))
                 az = MAX(az,ABS(rad(i,j,k,1) - rad(i,j,k-1*dg(3),1)))
-                if ( MAX(ax,ay,az) .ge. radgrad) then
+                if (MAX(ax,ay,az) .ge. radgrad .or. MAX(ax,ay,az) .ge. ABS(radgrad_rel * rad(i,j,k,1))) then
                    tag(i,j,k) = set
                 endif
              enddo
@@ -495,8 +495,8 @@ contains
                          bind(C, name="ca_enterror")
 
     use prob_params_module, only: dg
-
     use amrex_fort_module, only : rt => amrex_real
+
     implicit none
 
     integer, intent(in) :: set, clear, nr, level
@@ -524,7 +524,7 @@ contains
     endif
 
     !     Tag on regions of high radiation gradient
-    if (level .lt. max_entgrad_lev) then
+    if (level .lt. max_entgrad_lev .or. level .lt. max_entgrad_rel_lev) then
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
@@ -534,7 +534,7 @@ contains
                 ax = MAX(ax,ABS(ent(i,j,k,1) - ent(i-1*dg(1),j,k,1)))
                 ay = MAX(ay,ABS(ent(i,j,k,1) - ent(i,j-1*dg(2),k,1)))
                 az = MAX(az,ABS(ent(i,j,k,1) - ent(i,j,k-1*dg(3),1)))
-                if ( MAX(ax,ay,az) .ge. entgrad) then
+                if (MAX(ax,ay,az) .ge. entgrad .or. MAX(ax,ay,az) .ge. ABS(entgrad_rel * ent(i,j,k,1))) then
                    tag(i,j,k) = set
                 endif
              enddo
@@ -559,8 +559,8 @@ contains
                          bind(C, name="ca_nucerror")
 
     use meth_params_module, only: dxnuc, dxnuc_max
-
     use amrex_fort_module, only : rt => amrex_real
+
     implicit none
 
     integer, intent(in) :: set, clear, nr, level


### PR DESCRIPTION
Tagging can now be done on relative gradients, in addition to the existing capability for absolute gradients. For example, tempgrad_rel is a relative gradient criterion that will tag a zone with temperature T if any adjacent zone has a temperature that is different by more than tempgrad_rel * T. The tagging is enabled up to a given level with the parameter max_tempgrad_rel_lev. The corresponding new tagging criteria for other fields are named similarly.

Closes #354