### PR TITLE
Fix incorrect flux register logic when using retries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@
      the middle of a group of subcycles, rather than at the
      beginning of the advance (#358).
 
+  -- A bug with the logic of refluxing when using retries was
+     fixed (#357).
+
   -- Tagging can now be done on relative gradients, in addition
      to the existing capability for absolute gradients (#354).
      For example, tempgrad_rel is a relative gradient criterion

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 # changes since the last release
 
+  -- A bug was fixed that occurred when a retry was triggered in
+     the middle of a group of subcycles, rather than at the
+     beginning of the advance (#358).
+
   -- Tagging can now be done on relative gradients, in addition
      to the existing capability for absolute gradients (#354).
      For example, tempgrad_rel is a relative gradient criterion

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -1046,10 +1046,6 @@ Castro::retry_advance(Real& time, Real dt, int amr_iteration, int amr_ncycle)
 
         do_retry = true;
 
-        // Subtract off the timestep taken.
-
-        time -= dt;
-
         dt_subcycle = std::min(dt, dt_subcycle) * retry_subcycle_factor;
 
         if (verbose && ParallelDescriptor::IOProcessor()) {
@@ -1124,8 +1120,6 @@ Castro::retry_advance(Real& time, Real dt, int amr_iteration, int amr_ncycle)
 Real
 Castro::subcycle_advance(const Real time, const Real dt, int amr_iteration, int amr_ncycle)
 {
-
-    Real t = time;
 
     // Start the subcycle time off with the main dt,
     // unless we already came in here with an estimate
@@ -1233,13 +1227,14 @@ Castro::subcycle_advance(const Real time, const Real dt, int amr_iteration, int 
 
         if (use_retry) {
 
-            // If we hit a retry, signal that we want to try again by subtracting the
-            // time from our counter; the retry function will handle resetting the state,
+            // If we hit a retry, signal that we want to try again.
+            // The retry function will handle resetting the state,
             // and updating dt_subcycle.
 
             if (retry_advance(subcycle_time, dt_subcycle, amr_iteration, amr_ncycle)) {
                 do_swap = false;
-                sub_iteration -= 1;
+                sub_iteration = 0;
+                subcycle_time = time;
                 lastDtRetryLimited = true;
                 lastDtFromRetry = dt_subcycle;
             }

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -1071,6 +1071,25 @@ Castro::retry_advance(Real& time, Real dt, int amr_iteration, int amr_ncycle)
 
         sources_for_hydro.setVal(0.0, NUM_GROW);
 
+        // Clear the contribution to the fluxes from this step.
+
+        for (int dir = 0; dir < 3; ++dir)
+            fluxes[dir]->setVal(0.0);
+
+        for (int dir = 0; dir < 3; ++dir)
+            mass_fluxes[dir]->setVal(0.0);
+
+#if (BL_SPACEDIM <= 2)
+        if (!Geometry::IsCartesian())
+            P_radial.setVal(0.0);
+#endif
+
+#ifdef RADIATION
+        if (Radiation::rad_hydro_combined)
+            for (int dir = 0; dir < BL_SPACEDIM; ++dir)
+                rad_fluxes[dir]->setVal(0.0);
+#endif
+
 #ifndef SDC
         if (source_term_predictor == 1) {
 


### PR DESCRIPTION
The fluxes were not properly zeroed out when doing a retry. This led to incorrect refluxes.

Fixes #357