### PR TITLE
Removed extraneous redirection operator from test script

### DIFF
--- a/Exec/hydro_tests/acoustic_pulse/convergence.sh
+++ b/Exec/hydro_tests/acoustic_pulse/convergence.sh
@@ -5,4 +5,4 @@ mpiexec -n 8 ./Castro2d.gnu.MPI.ex inputs.2d.128 castro.fourth_order=1 castro.mo
 mpiexec -n 8 ./Castro2d.gnu.MPI.ex inputs.2d.256 castro.fourth_order=1 castro.mol_order=4
 mpiexec -n 8 ./Castro2d.gnu.MPI.ex inputs.2d.512 castro.fourth_order=1 castro.mol_order=4
 
-RichardsonConvergenceTest2d.gnu.ex coarFile=acoustic_pulse_128_plt00161 mediFile=acoustic_pulse_256_plt00321 fineFile=acoustic_pulse_512_plt00641 mediError=med.out coarError=coar.out > > convergence.out
+RichardsonConvergenceTest2d.gnu.ex coarFile=acoustic_pulse_128_plt00161 mediFile=acoustic_pulse_256_plt00321 fineFile=acoustic_pulse_512_plt00641 mediError=med.out coarError=coar.out > convergence.out


### PR DESCRIPTION
The convergence.sh script for the acoustic pulse test problem  would previously crash due to an extra '>'