### PR TITLE
Put conductivity into the eos type

### DIFF
--- a/Microphysics/EOS/eos_type.F90
+++ b/Microphysics/EOS/eos_type.F90
@@ -1,5 +1,6 @@
 module eos_type_module
 
+  use amrex_error_module, only: amrex_error
   use amrex_fort_module, only : rt => amrex_real
   use network, only: nspec, naux
 
@@ -16,7 +17,7 @@ module eos_type_module
   integer, parameter :: eos_input_ph = 7  ! p, h are inputs
   integer, parameter :: eos_input_th = 8  ! T, h are inputs
 
-  ! these are used to allow for a generic interface to the 
+  ! these are used to allow for a generic interface to the
   ! root finding
   integer, parameter :: itemp = 1
   integer, parameter :: idens = 2
@@ -121,6 +122,7 @@ module eos_type_module
   ! dedZ     -- d energy/ d zbar
   ! dpde     -- d pressure / d energy |_rho
   ! dpdr_e   -- d pressure / d rho |_energy
+  ! conductivity -- thermal conductivity (in erg/cm/K/sec)
 
   type :: eos_t
 
@@ -172,10 +174,11 @@ module eos_type_module
     real(rt) :: dedZ
 #endif
 
+    real(rt) :: conductivity
+
   end type eos_t
 
 contains
-
 
   ! Provides a copy subroutine for the eos_t type to
   ! avoid derived type assignment (OpenACC and CUDA can't handle that)
@@ -234,6 +237,9 @@ contains
     to_eos % dedA = from_eos % dedA
     to_eos % dedZ = from_eos % dedZ
 #endif
+
+    to_eos % conductivity = from_eos % conductivity
+
   end subroutine copy_eos_t
 
 
@@ -322,7 +328,6 @@ contains
   end subroutine normalize_abundances
 
 
-
   ! Ensure that inputs are within reasonable limits.
 
   subroutine clean_state(state)
@@ -354,7 +359,6 @@ contains
     print *, 'Y_E  = ', state % y_e
 
   end subroutine print_state
-
 
 
   subroutine eos_get_small_temp(small_temp_out)
@@ -410,5 +414,91 @@ contains
     max_dens_out = maxdens
 
   end subroutine eos_get_max_dens
+
+
+  ! Check to see if variable ivar is a valid
+  ! independent variable for the given input
+  function eos_input_has_var(input, ivar) result(has)
+
+    implicit none
+
+    integer, intent(in) :: input, ivar
+    logical :: has
+
+    !$gpu
+
+    has = .false.
+    
+    select case (ivar)
+
+    case (itemp)
+
+       if (input == eos_input_rt .or. &
+           input == eos_input_tp .or. &
+           input == eos_input_th) then
+
+          has = .true.
+
+       endif
+
+    case (idens)
+
+       if (input == eos_input_rt .or. &
+           input == eos_input_rh .or. &
+           input == eos_input_rp .or. &
+           input == eos_input_re) then
+
+          has = .true.
+
+       endif
+
+    case (iener)
+
+       if (input == eos_input_re) then
+
+          has = .true.
+
+       endif
+       
+    case (ienth)
+
+       if (input == eos_input_rh .or. &
+           input == eos_input_ph .or. &
+           input == eos_input_th) then
+
+          has = .true.
+
+       endif
+
+    case (ientr)
+
+       if (input == eos_input_ps) then
+
+          has = .true.
+
+       endif
+
+    case (ipres)
+
+       if (input == eos_input_tp .or. &
+           input == eos_input_rp .or. &
+           input == eos_input_ps .or. &
+           input == eos_input_ph) then
+
+          has = .true.
+
+       endif
+
+    case default
+
+#ifdef AMREX_USE_CUDA
+       stop
+#else
+       call amrex_error("EOS: invalid independent variable")
+#endif
+
+    end select
+
+  end function eos_input_has_var
 
 end module eos_type_module

--- a/Microphysics/conductivity/conductivity.F90
+++ b/Microphysics/conductivity/conductivity.F90
@@ -26,7 +26,7 @@ contains
 
   ! a generic wrapper that calls the EOS and then the conductivity
 
-  subroutine conducteos(input, state, cond)
+  subroutine conducteos(input, state)
 
     use actual_conductivity_module
     use eos_type_module, only : eos_t
@@ -36,16 +36,15 @@ contains
 
     integer       , intent(in   ) :: input
     type (eos_t)  , intent(inout) :: state
-    real (kind=rt), intent(inout) :: cond
 
     ! call the EOS, passing through the arguments we called conducteos with
     call eos(input, state)
 
-    call actual_conductivity(state, cond)
+    call actual_conductivity(state)
 
   end subroutine conducteos
 
-  subroutine conductivity(state, cond)
+  subroutine conductivity(state)
 
     use actual_conductivity_module
     use eos_type_module, only : eos_t
@@ -53,9 +52,8 @@ contains
     implicit none
 
     type (eos_t)  , intent(inout) :: state
-    real (kind=rt), intent(inout) :: cond
 
-    call actual_conductivity(state, cond)
+    call actual_conductivity(state)
 
   end subroutine conductivity
 

--- a/Microphysics/conductivity/constant/constant_conductivity.f90
+++ b/Microphysics/conductivity/constant/constant_conductivity.f90
@@ -13,16 +13,15 @@ contains
 
   end subroutine actual_conductivity_init
 
-  subroutine actual_conductivity(eos_state, therm_cond)
+  subroutine actual_conductivity(eos_state)
     
     use extern_probin_module, only: const_conductivity
 
     implicit none
 
     type (eos_t), intent(in) :: eos_state
-    real (kind=rt), intent(inout) :: therm_cond
 
-    therm_cond = const_conductivity
+    eos_state % conductivity = const_conductivity
     
   end subroutine actual_conductivity
 

--- a/Microphysics/conductivity/constant_opacity/constant_conductive_opacity.f90
+++ b/Microphysics/conductivity/constant_opacity/constant_conductive_opacity.f90
@@ -14,14 +14,13 @@ contains
 
   end subroutine actual_conductivity_init
 
-  subroutine actual_conductivity(eos_state, therm_cond)
+  subroutine actual_conductivity(eos_state)
     
     use extern_probin_module, only: const_opacity
 
     type (eos_t), intent(in) :: eos_state
-    real (kind=rt), intent(inout) :: therm_cond
 
-    therm_cond = (16*sigma_SB*(eos_state%T)**3)/(3*const_opacity*eos_state%rho)
+    eos_state % conductivity = (16*sigma_SB*(eos_state%T)**3)/(3*const_opacity*eos_state%rho)
     
   end subroutine actual_conductivity
 

--- a/Source/diffusion/Diffusion_nd.f90
+++ b/Source/diffusion/Diffusion_nd.f90
@@ -243,8 +243,8 @@ contains
              call eos(eos_input_re,eos_state)
 
              if (eos_state%rho > diffuse_cutoff_density) then
-                call conductivity(eos_state, coeff)
-                coeff = coeff / eos_state%cp
+                call conductivity(eos_state)
+                coeff = eos_state % conductivity / eos_state%cp
              else
                 coeff = ZERO
              endif
@@ -316,7 +316,6 @@ contains
     real(rt)         :: coef_cc(lo(1)-1:hi(1)+1,lo(2)-1:hi(2)+1,lo(3)-1:hi(3)+1)
 
     type (eos_t) :: eos_state
-    real(rt)         :: cond
 
     ! fill the cell-centered conductivity
 
@@ -339,11 +338,11 @@ contains
 
              if (eos_state%rho > diffuse_cutoff_density) then
 
-                call conductivity(eos_state, cond)
+                call conductivity(eos_state)
              else
-                cond = ZERO
+                eos_state % conductivity = ZERO
              endif
-             coef_cc(i,j,k) = diffuse_cond_scale_fac * cond
+             coef_cc(i,j,k) = diffuse_cond_scale_fac * eos_state % conductivity
           enddo
        enddo
     enddo
@@ -425,8 +424,8 @@ contains
              call eos(eos_input_re,eos_state)
 
              if (eos_state%rho > diffuse_cutoff_density) then
-                call conductivity(eos_state, cond)
-                cond = cond / eos_state%cp
+                call conductivity(eos_state)
+                cond = eos_state % conductivity / eos_state%cp
              else
                 cond = ZERO
              endif

--- a/Source/driver/Derive_nd.F90
+++ b/Source/driver/Derive_nd.F90
@@ -1155,7 +1155,6 @@ contains
     real(rt), intent(inout) :: cond(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),nd)
     real(rt), intent(in) :: state(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
 
-    real(rt)         :: coeff
     integer          :: i, j, k
 
     type(eos_t) :: eos_state
@@ -1172,12 +1171,12 @@ contains
              call eos(eos_input_re,eos_state)
 
              if (eos_state%rho > diffuse_cutoff_density) then
-                call conductivity(eos_state, coeff)
+                call conductivity(eos_state)
              else
-                coeff = ZERO
+                eos_state % conductivity = ZERO
              endif
 
-             cond(i,j,k,1) = coeff
+             cond(i,j,k,1) = eos_state % conductivity
 
           enddo
        enddo
@@ -1214,7 +1213,6 @@ contains
     real(rt), intent(inout) :: diff(u_lo(1):u_hi(1),u_lo(2):u_hi(2),u_lo(3):u_hi(3),nd)
     real(rt), intent(in) :: state(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),nc)
 
-    real(rt)         :: coeff
     integer          :: i, j, k
 
     type(eos_t) :: eos_state
@@ -1231,12 +1229,12 @@ contains
              call eos(eos_input_re,eos_state)
 
              if (eos_state%rho > diffuse_cutoff_density) then
-                call conductivity(eos_state, coeff)
+                call conductivity(eos_state)
              else
-                coeff = ZERO
+                eos_state % conductivity = ZERO
              endif
 
-             diff(i,j,k,1) = coeff/(eos_state%rho * eos_state%cv)
+             diff(i,j,k,1) = eos_state % conductivity/(eos_state%rho * eos_state%cv)
 
           enddo
        enddo

--- a/Source/driver/timestep.F90
+++ b/Source/driver/timestep.F90
@@ -278,7 +278,7 @@ contains
 
     real(rt)         :: dt1, dt2, dt3, rho_inv
     integer          :: i, j, k
-    real(rt)         :: cond, D
+    real(rt)         :: D
 
     type (eos_t) :: eos_state
 
@@ -304,10 +304,10 @@ contains
                 call eos(eos_input_re, eos_state)
 
                 ! we also need the conductivity
-                call conductivity(eos_state, cond)
+                call conductivity(eos_state)
 
                 ! maybe we should check (and take action) on negative cv here?
-                D = cond*rho_inv/eos_state%cv
+                D = eos_state % conductivity*rho_inv/eos_state%cv
 
                 dt1 = HALF*dx(1)**2/D
 
@@ -356,7 +356,7 @@ contains
 
     real(rt)         :: dt1, dt2, dt3, rho_inv
     integer          :: i, j, k
-    real(rt)         :: cond, D
+    real(rt)         :: D
 
     type (eos_t) :: eos_state
 
@@ -382,9 +382,9 @@ contains
                 call eos(eos_input_re, eos_state)
 
                 ! we also need the conductivity
-                call conductivity(eos_state, cond)
+                call conductivity(eos_state)
 
-                D = cond*rho_inv/eos_state%cp
+                D = eos_state % conductivity*rho_inv/eos_state%cp
 
                 dt1 = HALF*dx(1)**2/D
 


### PR DESCRIPTION
Move conductivity into the eos type for interfacing with the conductivity routines.

Uses the same interface as for the conductivity-update branch in Microphysics.

Depends on https://github.com/starkiller-astro/Microphysics/pull/164