### PR TITLE
remove the FillPatch from do_old_sources

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -93,6 +93,7 @@ Castro::do_advance_ctu(Real time,
     if (apply_sources()) {
 
       do_old_sources(old_source, Sborder, prev_time, dt, amr_iteration, amr_ncycle);
+      AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), prev_time, Source_Type, 0, NUM_STATE);
       apply_source_to_state(S_new, old_source, dt, 0);
       int is_new = 1;
       clean_state(is_new, 0);

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -93,7 +93,6 @@ Castro::do_advance_ctu(Real time,
     if (apply_sources()) {
 
       do_old_sources(old_source, Sborder, prev_time, dt, amr_iteration, amr_ncycle);
-      AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), prev_time, Source_Type, 0, NUM_STATE);
       apply_source_to_state(S_new, old_source, dt, 0);
       int is_new = 1;
       clean_state(is_new, 0);

--- a/Source/driver/Castro_advance_mol.cpp
+++ b/Source/driver/Castro_advance_mol.cpp
@@ -92,6 +92,9 @@ Castro::do_advance_mol (Real time,
     if (fourth_order) {
       do_old_sources(old_source, sources_for_hydro, time, dt, amr_iteration, amr_ncycle);
 
+      // fill the ghost cells for the sources
+      AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), time, Source_Type, 0, NUM_STATE);
+
       // Note: this filled the ghost cells for us, so we can now convert to
       // cell averages.  This loop cannot be tiled.
       for (MFIter mfi(S_new); mfi.isValid(); ++mfi) {
@@ -106,6 +109,11 @@ Castro::do_advance_mol (Real time,
 
     } else {
       do_old_sources(old_source, Sborder, time, dt, amr_iteration, amr_ncycle);
+
+      // The individual source terms only calculate the source on the valid domain.
+      // FillPatch to get valid data in the ghost zones.
+      AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), time, Source_Type, 0, NUM_STATE);
+
     }
 #endif
 
@@ -199,10 +207,11 @@ Castro::do_advance_mol (Real time,
   // always require State_Type to have 1 ghost cell?
   expand_state(Sborder, prev_time, 0, Sborder.nGrow());
   do_old_sources(old_source, Sborder, prev_time, dt, amr_iteration, amr_ncycle);
+  AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), prev_time, Source_Type, 0, NUM_STATE);
 
   expand_state(Sborder, cur_time, 1, Sborder.nGrow());
   do_old_sources(new_source, Sborder, cur_time, dt, amr_iteration, amr_ncycle);
-
+  AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), cur_time, Source_Type, 0, NUM_STATE);
 
   // Do the second half of the reactions.
 

--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -118,7 +118,7 @@ Castro::do_advance_sdc (Real time,
 
         // The individual source terms only calculate the source on the valid domain.
         // FillPatch to get valid data in the ghost zones.
-        AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), time, Source_Type, 0, NUM_STATE);
+        AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), node_time, Source_Type, 0, NUM_STATE);
 
       }
 #endif

--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -99,6 +99,9 @@ Castro::do_advance_sdc (Real time,
       if (fourth_order) {
         do_old_sources(old_source, sources_for_hydro, time, dt, amr_iteration, amr_ncycle);
 
+        // fill the ghost cells for the sources
+        AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), time, Source_Type, 0, NUM_STATE);
+
         // Note: this filled the ghost cells for us, so we can now convert to
         // cell averages.  This loop cannot be tiled.
         for (MFIter mfi(S_new); mfi.isValid(); ++mfi) {
@@ -112,6 +115,11 @@ Castro::do_advance_sdc (Real time,
 
       } else {
         do_old_sources(old_source, Sborder, node_time, dt, amr_iteration, amr_ncycle);
+
+        // The individual source terms only calculate the source on the valid domain.
+        // FillPatch to get valid data in the ghost zones.
+        AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), time, Source_Type, 0, NUM_STATE);
+
       }
 #endif
 
@@ -236,10 +244,11 @@ Castro::do_advance_sdc (Real time,
   // always require State_Type to have 1 ghost cell?
   expand_state(Sborder, prev_time, 0, Sborder.nGrow());
   do_old_sources(old_source, Sborder, prev_time, dt, amr_iteration, amr_ncycle);
+  AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), prev_time, Source_Type, 0, NUM_STATE);
 
   expand_state(Sborder, cur_time, 1, Sborder.nGrow());
   do_old_sources(new_source, Sborder, cur_time, dt, amr_iteration, amr_ncycle);
-
+  AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), cur_time, Source_Type, 0, NUM_STATE);
 
   finalize_do_advance(time, dt, amr_iteration, amr_ncycle);
 

--- a/Source/sources/Castro_sources.cpp
+++ b/Source/sources/Castro_sources.cpp
@@ -102,11 +102,6 @@ Castro::do_old_sources(MultiFab& source, MultiFab& state_in, Real time, Real dt,
     for (int n = 0; n < num_src; ++n)
         construct_old_source(n, source, state_in, time, dt, amr_iteration, amr_ncycle);
 
-    // The individual source terms only calculate the source on the valid domain.
-    // FillPatch to get valid data in the ghost zones.
-
-    AmrLevel::FillPatch(*this, source, source.nGrow(), time, Source_Type, 0, NUM_STATE);
-
     // Optionally print out diagnostic information about how much
     // these source terms changed the state.
 


### PR DESCRIPTION
turns out a lot of times we don't need to FillPatch in do_old_sources.  When we do, we can simply do so after the call.  This increases the flexibility of things.