### PR TITLE
eliminate castro.fourth_order.

### DIFF
--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -507,7 +507,7 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
       src_q.define(grids, dmap, NQSRC, NUM_GROW);
     }
 
-    if (fourth_order) {
+    if (mol_order == 4 || sdc_order == 4) {
       q_bar.define(grids, dmap, NQ, NUM_GROW);
       qaux_bar.define(grids, dmap, NQAUX, NUM_GROW);
     }
@@ -612,7 +612,7 @@ Castro::finalize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
       src_q.clear();
     }
 
-    if (fourth_order) {
+    if (mol_order == 4 || sdc_order == 4) {
       q_bar.clear();
       qaux_bar.clear();
     }

--- a/Source/driver/Castro_advance_mol.cpp
+++ b/Source/driver/Castro_advance_mol.cpp
@@ -75,7 +75,7 @@ Castro::do_advance_mol (Real time,
   if (apply_sources()) {
 
 #ifndef AMREX_USE_CUDA
-    if (fourth_order) {
+    if (mol_order == 4) {
       // if we are 4th order, convert to cell-center Sborder -> Sborder_cc
       // we'll reuse sources_for_hydro for this memory buffer at the moment
 
@@ -89,7 +89,7 @@ Castro::do_advance_mol (Real time,
     }
 
     // we pass in the stage time here
-    if (fourth_order) {
+    if (mol_order == 4) {
       do_old_sources(old_source, sources_for_hydro, time, dt, amr_iteration, amr_ncycle);
 
       // fill the ghost cells for the sources
@@ -142,7 +142,7 @@ Castro::do_advance_mol (Real time,
   if (do_hydro)
     {
       // Construct the primitive variables.
-      if (fourth_order) {
+      if (mol_order == 4) {
 #ifndef AMREX_USE_CUDA
         cons_to_prim_fourth(time);
 #endif

--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -82,7 +82,7 @@ Castro::do_advance_sdc (Real time,
 
     if (apply_sources()) {
 #ifndef AMREX_USE_CUDA
-      if (fourth_order) {
+      if (sdc_order == 4) {
         // if we are 4th order, convert to cell-center Sborder -> Sborder_cc
         // we'll reuse sources_for_hydro for this memory buffer at the moment
 
@@ -96,7 +96,7 @@ Castro::do_advance_sdc (Real time,
       }
 
       // we pass in the stage time here
-      if (fourth_order) {
+      if (sdc_order == 4) {
         do_old_sources(old_source, sources_for_hydro, time, dt, amr_iteration, amr_ncycle);
 
         // fill the ghost cells for the sources
@@ -145,7 +145,7 @@ Castro::do_advance_sdc (Real time,
     // will be used to advance us to the next node the new time
 
     // Construct the primitive variables.
-    if (fourth_order) {
+    if (sdc_order == 4) {
       cons_to_prim_fourth(time);
     } else {
       cons_to_prim(time);

--- a/Source/driver/Castro_sdc.cpp
+++ b/Source/driver/Castro_sdc.cpp
@@ -26,9 +26,9 @@ Castro::do_sdc_update(int m_start, int m_end, Real dt_m) {
 #ifdef REACTIONS
   // SDC_Source_Type is only defined for 4th order
   MultiFab tmp;
-  MultiFab& C_source = (fourth_order == 1) ? get_new_data(SDC_Source_Type) : tmp;
+  MultiFab& C_source = (sdc_order == 4) ? get_new_data(SDC_Source_Type) : tmp;
 
-  if (fourth_order == 1) {
+  if (sdc_order == 4) {
 
     // for 4th order reacting flow, we need to create the "source" C
     // as averages and then convert it to cell centers.  The cell-center

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -686,7 +686,7 @@ Castro::variableSetUp ()
 
 
 #ifdef REACTIONS
-  if (time_integration_method == SpectralDeferredCorrections && fourth_order == 1) {
+  if (time_integration_method == SpectralDeferredCorrections && (mol_order == 4 || sdc_order == 4)) {
 
     // we are doing 4th order reactive SDC.  We need 2 ghost cells here
     SDC_Source_Type = desc_lst.size();

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -61,9 +61,6 @@ do_hydro                     int          -1                  y
 # how do we advance in time? 0 = CTU + Strang, 1 = MOL + Strang, 2 = SDC
 time_integration_method      int           0                  y
 
-# do we do fourth-order accurate spatial reconstruction for hydro? (requires SDC or MOL integration)
-fourth_order                 int           0                  y
-
 # do we use a limiter with the fourth-order accurate reconstruction?
 limit_fourth_order           int           1                  y
 

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -1,15 +1,16 @@
 
-module meth_params_module
 ! This file is automatically created by parse_castro_params.py.  To update
 ! or add runtime parameters, please edit _cpp_parameters and then run
 ! mk_params.sh
 
-! This module stores the runtime parameters and integer names for
+! This module stores the runtime parameters and integer names for 
 ! indexing arrays.
 !
 ! The Fortran-specific parameters are initialized in set_method_params(),
 ! and the ones that we are mirroring from C++ and obtaining through the
 ! ParmParse module are initialized in ca_set_castro_method_params().
+
+module meth_params_module
 
   use amrex_error_module
   use amrex_fort_module, only: rt => amrex_real
@@ -69,8 +70,8 @@ module meth_params_module
   ! these flags are for interpreting the EXT_DIR BCs
   integer, parameter :: EXT_UNDEFINED = -1
   integer, parameter :: EXT_HSE = 1
-  integer, parameter :: EXT_INTERP = 2
-
+  integer, parameter :: EXT_INTERP = 2 
+  
   integer, allocatable, save :: xl_ext, yl_ext, zl_ext, xr_ext, yr_ext, zr_ext
 
   ! Create versions of these variables on the GPU
@@ -119,7 +120,6 @@ module meth_params_module
   real(rt), allocatable, save :: small_ener
   integer,  allocatable, save :: do_hydro
   integer,  allocatable, save :: time_integration_method
-  integer,  allocatable, save :: fourth_order
   integer,  allocatable, save :: limit_fourth_order
   integer,  allocatable, save :: use_reconstructed_gamma1
   integer,  allocatable, save :: hybrid_hydro
@@ -207,7 +207,6 @@ attributes(managed) :: small_pres
 attributes(managed) :: small_ener
 attributes(managed) :: do_hydro
 attributes(managed) :: time_integration_method
-attributes(managed) :: fourth_order
 attributes(managed) :: limit_fourth_order
 attributes(managed) :: use_reconstructed_gamma1
 attributes(managed) :: hybrid_hydro
@@ -326,7 +325,6 @@ attributes(managed) :: get_g_from_phi
   !$acc create(small_ener) &
   !$acc create(do_hydro) &
   !$acc create(time_integration_method) &
-  !$acc create(fourth_order) &
   !$acc create(limit_fourth_order) &
   !$acc create(use_reconstructed_gamma1) &
   !$acc create(hybrid_hydro) &
@@ -516,8 +514,6 @@ contains
     do_hydro = -1;
     allocate(time_integration_method)
     time_integration_method = 0;
-    allocate(fourth_order)
-    fourth_order = 0;
     allocate(limit_fourth_order)
     limit_fourth_order = 1;
     allocate(use_reconstructed_gamma1)
@@ -671,7 +667,6 @@ contains
     call pp%query("small_ener", small_ener)
     call pp%query("do_hydro", do_hydro)
     call pp%query("time_integration_method", time_integration_method)
-    call pp%query("fourth_order", fourth_order)
     call pp%query("limit_fourth_order", limit_fourth_order)
     call pp%query("use_reconstructed_gamma1", use_reconstructed_gamma1)
     call pp%query("hybrid_hydro", hybrid_hydro)
@@ -744,30 +739,31 @@ contains
     !$acc update &
     !$acc device(difmag, small_dens, small_temp) &
     !$acc device(small_pres, small_ener, do_hydro) &
-    !$acc device(time_integration_method, fourth_order, limit_fourth_order) &
-    !$acc device(use_reconstructed_gamma1, hybrid_hydro, ppm_type) &
-    !$acc device(ppm_temp_fix, ppm_predict_gammae, ppm_reference_eigenvectors) &
-    !$acc device(plm_iorder, hybrid_riemann, riemann_solver) &
-    !$acc device(cg_maxiter, cg_tol, cg_blend) &
-    !$acc device(use_eos_in_riemann, use_flattening, transverse_use_eos) &
-    !$acc device(transverse_reset_density, transverse_reset_rhoe, dual_energy_eta1) &
-    !$acc device(dual_energy_eta2, use_pslope, fix_mass_flux) &
-    !$acc device(limit_fluxes_on_small_dens, density_reset_method, allow_small_energy) &
-    !$acc device(do_sponge, sponge_implicit, first_order_hydro) &
-    !$acc device(hse_zero_vels, hse_interp_temp, hse_reflect_vels) &
-    !$acc device(mol_order, sdc_order, sdc_solver) &
-    !$acc device(sdc_solver_tol, sdc_solve_for_rhoe, sdc_use_analytic_jac) &
-    !$acc device(cfl, dtnuc_e, dtnuc_X) &
-    !$acc device(dtnuc_X_threshold, do_react, react_T_min) &
-    !$acc device(react_T_max, react_rho_min, react_rho_max) &
-    !$acc device(disable_shock_burning, T_guess, diffuse_cutoff_density) &
-    !$acc device(diffuse_cutoff_density_hi, diffuse_cond_scale_fac, do_grav) &
-    !$acc device(grav_source_type, do_rotation, rot_period) &
-    !$acc device(rot_period_dot, rotation_include_centrifugal, rotation_include_coriolis) &
-    !$acc device(rotation_include_domegadt, state_in_rotating_frame, rot_source_type) &
-    !$acc device(implicit_rotation_update, rot_axis, use_point_mass) &
-    !$acc device(point_mass, point_mass_fix_solution, do_acc) &
-    !$acc device(grown_factor, track_grid_losses, const_grav, get_g_from_phi)
+    !$acc device(time_integration_method, limit_fourth_order, use_reconstructed_gamma1) &
+    !$acc device(hybrid_hydro, ppm_type, ppm_temp_fix) &
+    !$acc device(ppm_predict_gammae, ppm_reference_eigenvectors, plm_iorder) &
+    !$acc device(hybrid_riemann, riemann_solver, cg_maxiter) &
+    !$acc device(cg_tol, cg_blend, use_eos_in_riemann) &
+    !$acc device(use_flattening, transverse_use_eos, transverse_reset_density) &
+    !$acc device(transverse_reset_rhoe, dual_energy_eta1, dual_energy_eta2) &
+    !$acc device(use_pslope, fix_mass_flux, limit_fluxes_on_small_dens) &
+    !$acc device(density_reset_method, allow_small_energy, do_sponge) &
+    !$acc device(sponge_implicit, first_order_hydro, hse_zero_vels) &
+    !$acc device(hse_interp_temp, hse_reflect_vels, mol_order) &
+    !$acc device(sdc_order, sdc_solver, sdc_solver_tol) &
+    !$acc device(sdc_solve_for_rhoe, sdc_use_analytic_jac, cfl) &
+    !$acc device(dtnuc_e, dtnuc_X, dtnuc_X_threshold) &
+    !$acc device(do_react, react_T_min, react_T_max) &
+    !$acc device(react_rho_min, react_rho_max, disable_shock_burning) &
+    !$acc device(T_guess, diffuse_cutoff_density, diffuse_cutoff_density_hi) &
+    !$acc device(diffuse_cond_scale_fac, do_grav, grav_source_type) &
+    !$acc device(do_rotation, rot_period, rot_period_dot) &
+    !$acc device(rotation_include_centrifugal, rotation_include_coriolis, rotation_include_domegadt) &
+    !$acc device(state_in_rotating_frame, rot_source_type, implicit_rotation_update) &
+    !$acc device(rot_axis, use_point_mass, point_mass) &
+    !$acc device(point_mass_fix_solution, do_acc, grown_factor) &
+    !$acc device(track_grid_losses, const_grav) &
+    !$acc device(get_g_from_phi)
 
 
 #ifdef GRAVITY
@@ -790,7 +786,7 @@ contains
     select case (xl_ext_bc_type)
     case ("hse", "HSE")
        xl_ext = EXT_HSE
-    case ("interp", "INTERP")
+    case ("interp", "INTERP")       
        xl_ext = EXT_INTERP
     case default
        xl_ext = EXT_UNDEFINED
@@ -799,7 +795,7 @@ contains
     select case (yl_ext_bc_type)
     case ("hse", "HSE")
        yl_ext = EXT_HSE
-    case ("interp", "INTERP")
+    case ("interp", "INTERP")       
        yl_ext = EXT_INTERP
     case default
        yl_ext = EXT_UNDEFINED
@@ -808,7 +804,7 @@ contains
     select case (zl_ext_bc_type)
     case ("hse", "HSE")
        zl_ext = EXT_HSE
-    case ("interp", "INTERP")
+    case ("interp", "INTERP")       
        zl_ext = EXT_INTERP
     case default
        zl_ext = EXT_UNDEFINED
@@ -817,7 +813,7 @@ contains
     select case (xr_ext_bc_type)
     case ("hse", "HSE")
        xr_ext = EXT_HSE
-    case ("interp", "INTERP")
+    case ("interp", "INTERP")       
        xr_ext = EXT_INTERP
     case default
        xr_ext = EXT_UNDEFINED
@@ -826,7 +822,7 @@ contains
     select case (yr_ext_bc_type)
     case ("hse", "HSE")
        yr_ext = EXT_HSE
-    case ("interp", "INTERP")
+    case ("interp", "INTERP")       
        yr_ext = EXT_INTERP
     case default
        yr_ext = EXT_UNDEFINED
@@ -835,7 +831,7 @@ contains
     select case (zr_ext_bc_type)
     case ("hse", "HSE")
        zr_ext = EXT_HSE
-    case ("interp", "INTERP")
+    case ("interp", "INTERP")       
        zr_ext = EXT_INTERP
     case default
        zr_ext = EXT_UNDEFINED
@@ -885,9 +881,6 @@ contains
     end if
     if (allocated(time_integration_method)) then
         deallocate(time_integration_method)
-    end if
-    if (allocated(fourth_order)) then
-        deallocate(fourth_order)
     end if
     if (allocated(limit_fourth_order)) then
         deallocate(limit_fourth_order)
@@ -1125,7 +1118,7 @@ contains
     end if
 
 
-
+    
   end subroutine ca_finalize_meth_params
 
 
@@ -1154,9 +1147,9 @@ contains
        call amrex_error("Unknown fspace_type", fspace_type)
     end if
 #endif
-
+    
     do_inelastic_scattering = (do_is_in .ne. 0)
-
+    
     if (com_in .eq. 1) then
        comoving = .true.
     else if (com_in .eq. 0) then
@@ -1166,9 +1159,9 @@ contains
        call amrex_error("Wrong value for comoving", fspace_type)
 #endif
     end if
-
+    
     flatten_pp_threshold = fppt
-
+    
     !$acc update &
     !$acc device(QRAD, QRADHI, QPTOT, QREITOT) &
     !$acc device(fspace_type) &

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -36,7 +36,6 @@ amrex::Real Castro::small_pres = -1.e200;
 amrex::Real Castro::small_ener = -1.e200;
 int         Castro::do_hydro = -1;
 int         Castro::time_integration_method = 0;
-int         Castro::fourth_order = 0;
 int         Castro::limit_fourth_order = 1;
 int         Castro::use_reconstructed_gamma1 = 0;
 int         Castro::add_ext_src = 0;

--- a/Source/driver/param_includes/castro_job_info_tests.H
+++ b/Source/driver/param_includes/castro_job_info_tests.H
@@ -31,7 +31,6 @@ jobInfoFile << (Castro::small_pres == -1.e200 ? "    " : "[*] ") << "castro.smal
 jobInfoFile << (Castro::small_ener == -1.e200 ? "    " : "[*] ") << "castro.small_ener = " << Castro::small_ener << std::endl;
 jobInfoFile << (Castro::do_hydro == -1 ? "    " : "[*] ") << "castro.do_hydro = " << Castro::do_hydro << std::endl;
 jobInfoFile << (Castro::time_integration_method == 0 ? "    " : "[*] ") << "castro.time_integration_method = " << Castro::time_integration_method << std::endl;
-jobInfoFile << (Castro::fourth_order == 0 ? "    " : "[*] ") << "castro.fourth_order = " << Castro::fourth_order << std::endl;
 jobInfoFile << (Castro::limit_fourth_order == 1 ? "    " : "[*] ") << "castro.limit_fourth_order = " << Castro::limit_fourth_order << std::endl;
 jobInfoFile << (Castro::use_reconstructed_gamma1 == 0 ? "    " : "[*] ") << "castro.use_reconstructed_gamma1 = " << Castro::use_reconstructed_gamma1 << std::endl;
 jobInfoFile << (Castro::add_ext_src == 0 ? "    " : "[*] ") << "castro.add_ext_src = " << Castro::add_ext_src << std::endl;

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -36,7 +36,6 @@ static amrex::Real small_pres;
 static amrex::Real small_ener;
 static int do_hydro;
 static int time_integration_method;
-static int fourth_order;
 static int limit_fourth_order;
 static int use_reconstructed_gamma1;
 static int add_ext_src;

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -36,7 +36,6 @@ pp.query("small_pres", small_pres);
 pp.query("small_ener", small_ener);
 pp.query("do_hydro", do_hydro);
 pp.query("time_integration_method", time_integration_method);
-pp.query("fourth_order", fourth_order);
 pp.query("limit_fourth_order", limit_fourth_order);
 pp.query("use_reconstructed_gamma1", use_reconstructed_gamma1);
 pp.query("add_ext_src", add_ext_src);

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -78,7 +78,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
     int priv_nstep_fsp = -1;
 #endif
     // The fourth order stuff cannot do tiling because of the Laplacian corrections
-    for (MFIter mfi(S_new, (fourth_order) ? no_tile_size : hydro_tile_size); mfi.isValid(); ++mfi)
+    for (MFIter mfi(S_new, (mol_order == 4) ? no_tile_size : hydro_tile_size); mfi.isValid(); ++mfi)
       {
 	const Box& bx  = mfi.tilebox();
 
@@ -122,7 +122,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 	  pradial.resize(amrex::surroundingNodes(bx,0),1);
 	}
 #endif
-        if (fourth_order) {
+        if (mol_order == 4) {
           ca_fourth_single_stage
             (ARLIM_3D(lo), ARLIM_3D(hi), &time, ARLIM_3D(domain_lo), ARLIM_3D(domain_hi),
              &stage_weight,

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -8,17 +8,18 @@
 
 using namespace amrex;
 
+///
+/// Construct the hydrodynamic source at the specified time
+/// (essentially the flux divergence).  This source is suitable for
+/// method of lines or SDC integration.  The output, as a MultiFab
+/// is stored in A_update, which comes through the argument list.
+///
 void
 Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 {
 
   BL_PROFILE("Castro::construct_mol_hydro_source()");
 
-  // this constructs the hydrodynamic source (essentially the flux
-  // divergence) using method of lines integration.  The output, as a
-
-  // update to the state, is stored in the multifab A_update, which is
-  // passed in
 
   const Real strt_time = ParallelDescriptor::second();
 
@@ -78,7 +79,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
     int priv_nstep_fsp = -1;
 #endif
     // The fourth order stuff cannot do tiling because of the Laplacian corrections
-    for (MFIter mfi(S_new, (mol_order == 4) ? no_tile_size : hydro_tile_size); mfi.isValid(); ++mfi)
+    for (MFIter mfi(S_new, (mol_order == 4 || sdc_order == 4) ? no_tile_size : hydro_tile_size); mfi.isValid(); ++mfi)
       {
 	const Box& bx  = mfi.tilebox();
 
@@ -122,7 +123,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 	  pradial.resize(amrex::surroundingNodes(bx,0),1);
 	}
 #endif
-        if (mol_order == 4) {
+        if (mol_order == 4 || sdc_order == 4) {
           ca_fourth_single_stage
             (ARLIM_3D(lo), ARLIM_3D(hi), &time, ARLIM_3D(domain_lo), ARLIM_3D(domain_hi),
              &stage_weight,


### PR DESCRIPTION
4th order spatial reconstruction is now automatic based on the sdc or mol order

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

## PR summary

This eliminates the `castro.fourth_order` runtime parameter, instead inferring whether we need 
fourth order spatial reconstruction from the integrator's order for both MOL and SDC

This closes #556 

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
