### PR TITLE
fix box side in cmpflx call after transyz

### DIFF
--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -822,7 +822,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
               hdt, hdtdy, hdtdz);
 
 #pragma gpu
-      cmpflx_plus_godunov(AMREX_INT_ANYD(cxbx.loVect()), AMREX_INT_ANYD(cxbx.hiVect()),
+      cmpflx_plus_godunov(AMREX_INT_ANYD(xbx.loVect()), AMREX_INT_ANYD(xbx.hiVect()),
                           BL_TO_FORTRAN_ANYD(ql),
                           BL_TO_FORTRAN_ANYD(qr), 1, 1,
                           BL_TO_FORTRAN_ANYD(flux[0]),


### PR DESCRIPTION
## PR summary

We were using the wrong box size in the call to `cmpflx` after `transyz` -- they should box operate on the same box.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
