### PR TITLE
Specify number of ghost cells for reset_internal_energy

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -1189,8 +1189,9 @@ public:
 /// Reset the internal energy
 ///
 /// @param State    Current state
+/// @param ng       number of ghost cells
 ///
-    void reset_internal_energy (amrex::MultiFab& State);
+    void reset_internal_energy (amrex::MultiFab& State, int ng);
 
 
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3214,7 +3214,7 @@ Castro::extern_init ()
 }
 
 void
-Castro::reset_internal_energy(MultiFab& S_new)
+Castro::reset_internal_energy(MultiFab& S_new, int ng)
 {
 
     BL_PROFILE("Castro::reset_internal_energy()");
@@ -3228,8 +3228,6 @@ Castro::reset_internal_energy(MultiFab& S_new)
 	old_state.define(S_new.boxArray(), S_new.DistributionMap(), S_new.nComp(), 0);
         MultiFab::Copy(old_state, S_new, 0, 0, S_new.nComp(), 0);
     }
-
-    int ng = S_new.nGrow();
 
     // Ensure (rho e) isn't too small or negative
 #ifdef _OPENMP
@@ -3354,9 +3352,9 @@ Castro::computeTemp(int is_new, int ng)
   }
 
   if (mol_order == 4 || sdc_order == 4) {
-    reset_internal_energy(Stemp);
+    reset_internal_energy(Stemp, ng);
   } else {
-    reset_internal_energy(State);
+    reset_internal_energy(State, ng);
   }
 
 
@@ -3464,7 +3462,7 @@ Castro::computeTemp(MultiFab& State, int ng)
 
   BL_PROFILE("Castro::computeTemp()");
 
-  reset_internal_energy(State);
+  reset_internal_energy(State, ng);
 
 #ifdef RADIATION
   FArrayBox temp;


### PR DESCRIPTION
## PR summary

Specify number of ghost cells for reset_internal_energy. This makes the operation consistent with the other things done in clean_state, and partially addresses #423.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
