### PR TITLE
Do not zero out state boundary when using radiation

### DIFF
--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -211,8 +211,6 @@ Castro::initialize_do_advance(Real time, Real dt, int amr_iteration, int amr_ncy
       get_old_data(Rad_Type).setVal(0.0);
       get_new_data(Rad_Type).setVal(0.0);
     }
-    get_old_data(State_Type).setBndry(0.0);
-    get_new_data(State_Type).setBndry(0.0);
 #endif
 
     // Reset the grid loss tracking.


### PR DESCRIPTION
## PR summary

It may make sense to zero out the Rad_Type BCs in initialize_do_advance,
but it does not make sense to do so for State_Type: this data should be
valid as a result of FillPatching, and zeroing it makes it invalid.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
