### PR TITLE
Decrease the amount of work done in the source_nonzero check

### DIFF
--- a/Source/hydro/Castro_ctu_nd.F90
+++ b/Source/hydro/Castro_ctu_nd.F90
@@ -168,24 +168,18 @@ contains
     endif
 
     ! preprocess the sources -- we don't want to trace under a source
-    ! that is empty.  Note, we need to do this check over the entire
-    ! grid, to be sure, e.g., use vlo:vhi. On the GPU, this check is
-    ! expensive and for now we just disable this optimization and eat
-    ! the cost of processing the sources, even if they're zero.
+    ! that is empty. This check only needs to be done over the tile
+    ! we're working on, since the PPM reconstruction and integration
+    ! done here is only local to this tile.
 
-#ifdef AMREX_USE_CUDA
-    source_nonzero(:) = .true.
-#else
     do n = 1, NQSRC
-       if (minval(srcQ(vlo(1)-2:vhi(1)+2,vlo(2)-2*dg(2):vhi(2)+2*dg(2),vlo(3)-2*dg(3):vhi(3)+2*dg(3),n)) == ZERO .and. &
-            maxval(srcQ(vlo(1)-2:vhi(1)+2,vlo(2)-2*dg(2):vhi(2)+2*dg(2),vlo(3)-2*dg(3):vhi(3)+2*dg(3),n)) == ZERO) then
+       if (minval(srcQ(lo(1)-2:hi(1)+2,lo(2)-2*dg(2):hi(2)+2*dg(2),lo(3)-2*dg(3):hi(3)+2*dg(3),n)) == ZERO .and. &
+           maxval(srcQ(lo(1)-2:hi(1)+2,lo(2)-2*dg(2):hi(2)+2*dg(2),lo(3)-2*dg(3):hi(3)+2*dg(3),n)) == ZERO) then
           source_nonzero(n) = .false.
        else
           source_nonzero(n) = .true.
        endif
     enddo
-#endif
-
 
     do idir = 1, AMREX_SPACEDIM
 


### PR DESCRIPTION
## PR summary

We only need to check the local tile, not the whole box. With this insight, we can also now do this check on the GPU too, since the GPU will only be doing the work of its current index +/- 2 zones, which gives a decent speedup there, compared to doing the PPM reconstruction if the sources really are zero.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
