### PR TITLE
Tuple -> Array

### DIFF
--- a/Source/radiation/HypreABec.H
+++ b/Source/radiation/HypreABec.H
@@ -1,7 +1,7 @@
 #ifndef _HypreABec_H_
 #define _HypreABec_H_
 
-#include <AMReX_Tuple.H>
+#include <AMReX_Array.H>
 #include <AMReX_MultiFab.H>
 
 #include "NGBndry.H"

--- a/Source/radiation/HypreExtMultiABec.H
+++ b/Source/radiation/HypreExtMultiABec.H
@@ -130,10 +130,10 @@ class HypreExtMultiABec : public HypreMultiABec {
 
  protected:
 
-  amrex::Vector<std::unique_ptr<amrex::Tuple<amrex::MultiFab, BL_SPACEDIM> > > a2coefs; ///< face-based
-  amrex::Vector<std::unique_ptr<amrex::Tuple<amrex::MultiFab, BL_SPACEDIM> > > ccoefs;  ///< face-based, 2 component
-  amrex::Vector<std::unique_ptr<amrex::Tuple<amrex::MultiFab, BL_SPACEDIM> > > d1coefs; ///< cell-based but directional
-  amrex::Vector<std::unique_ptr<amrex::Tuple<amrex::MultiFab, BL_SPACEDIM> > > d2coefs; ///< face-based
+  amrex::Vector<std::unique_ptr<amrex::Array<amrex::MultiFab, BL_SPACEDIM> > > a2coefs; ///< face-based
+  amrex::Vector<std::unique_ptr<amrex::Array<amrex::MultiFab, BL_SPACEDIM> > > ccoefs;  ///< face-based, 2 component
+  amrex::Vector<std::unique_ptr<amrex::Array<amrex::MultiFab, BL_SPACEDIM> > > d1coefs; ///< cell-based but directional
+  amrex::Vector<std::unique_ptr<amrex::Array<amrex::MultiFab, BL_SPACEDIM> > > d2coefs; ///< face-based
   amrex::Real alpha2, gamma, delta1, delta2; ///< multipliers for the above
 };
 

--- a/Source/radiation/HypreExtMultiABec.cpp
+++ b/Source/radiation/HypreExtMultiABec.cpp
@@ -25,7 +25,7 @@ void HypreExtMultiABec::a2Coefficients(int level, const MultiFab &a2, int dir)
   int ngrow=0;
 
   if (!a2coefs[level]) {
-    a2coefs[level].reset(new Tuple<MultiFab, BL_SPACEDIM>);
+    a2coefs[level].reset(new Array<MultiFab, BL_SPACEDIM>);
  
     for (int i = 0; i < BL_SPACEDIM; i++) {
       BoxArray edge_boxes(grids[level]);
@@ -48,7 +48,7 @@ void HypreExtMultiABec::cCoefficients(int level, const MultiFab &c, int dir)
   int ngrow=0;
 
   if (!ccoefs[level]) {
-    ccoefs[level].reset(new Tuple<MultiFab, BL_SPACEDIM>);
+    ccoefs[level].reset(new Array<MultiFab, BL_SPACEDIM>);
  
     for (int i = 0; i < BL_SPACEDIM; i++) {
       BoxArray edge_boxes(grids[level]);
@@ -71,7 +71,7 @@ void HypreExtMultiABec::d1Coefficients(int level, const MultiFab &d1, int dir)
   int ngrow=0;
 
   if (!d1coefs[level]) {
-    d1coefs[level].reset(new Tuple<MultiFab, BL_SPACEDIM>);
+    d1coefs[level].reset(new Array<MultiFab, BL_SPACEDIM>);
 
     for (int i = 0; i < BL_SPACEDIM; i++) {
       (*d1coefs[level])[i].define(grids[level], dmap[level], ncomp, ngrow);
@@ -92,7 +92,7 @@ void HypreExtMultiABec::d2Coefficients(int level, const MultiFab &d2, int dir)
   int ngrow=0;
 
   if (!d2coefs[level]) {
-    d2coefs[level].reset(new Tuple<MultiFab, BL_SPACEDIM>);
+    d2coefs[level].reset(new Array<MultiFab, BL_SPACEDIM>);
  
     for (int i = 0; i < BL_SPACEDIM; i++) {
       BoxArray edge_boxes(grids[level]);

--- a/Source/radiation/HypreMultiABec.H
+++ b/Source/radiation/HypreMultiABec.H
@@ -666,7 +666,7 @@ class HypreMultiABec {
   amrex::Vector< amrex::Vector<amrex::BoxArray> > subgrids;
 
   amrex::Vector<std::unique_ptr<amrex::MultiFab> > acoefs;
-  amrex::Vector<std::unique_ptr<amrex::Tuple<amrex::MultiFab, BL_SPACEDIM> > > bcoefs;
+  amrex::Vector<std::unique_ptr<amrex::Array<amrex::MultiFab, BL_SPACEDIM> > > bcoefs;
   amrex::Real alpha, beta;
   amrex::Real reltol, abstol;
 

--- a/Source/radiation/HypreMultiABec.cpp
+++ b/Source/radiation/HypreMultiABec.cpp
@@ -981,7 +981,7 @@ void HypreMultiABec::buildMatrixStructure()
     acoefs[level].reset(new MultiFab(grids[level], dmap[level], ncomp, ngrow));
     acoefs[level]->setVal(0.0);
 
-    bcoefs[level].reset(new Tuple<MultiFab, BL_SPACEDIM>);
+    bcoefs[level].reset(new Array<MultiFab, BL_SPACEDIM>);
 
     for (int i = 0; i < BL_SPACEDIM; i++) {
       BoxArray edge_boxes(grids[level]);

--- a/Source/radiation/MGFLD.cpp
+++ b/Source/radiation/MGFLD.cpp
@@ -463,7 +463,7 @@ void Radiation::gray_accel(MultiFab& Er_new, MultiFab& Er_pi,
 			   MultiFab& etaT, MultiFab& etaY, MultiFab& eta1,
 			   MultiFab& thetaT, MultiFab& thetaY, 
 			   MultiFab& mugT, MultiFab& mugY, 
-			   Tuple<MultiFab, BL_SPACEDIM>& lambda,
+			   Array<MultiFab, BL_SPACEDIM>& lambda,
 			   RadSolve& solver, MGRadBndry& mgbd, 
 			   const BoxArray& grids, int level, Real time, 
 			   Real delta_t, Real ptc_tau)
@@ -560,7 +560,7 @@ void Radiation::gray_accel(MultiFab& Er_new, MultiFab& Er_pi,
   const DistributionMapping& dm = castro->DistributionMap();
 
   // B & C coefficients
-  Tuple<MultiFab, BL_SPACEDIM> bcoefs, ccoefs, bcgrp;
+  Array<MultiFab, BL_SPACEDIM> bcoefs, ccoefs, bcgrp;
   for (int idim = 0; idim < BL_SPACEDIM; idim++) {
     const BoxArray& edge_boxes = castro->getEdgeBoxArray(idim);
 

--- a/Source/radiation/MGFLDRadSolver.cpp
+++ b/Source/radiation/MGFLDRadSolver.cpp
@@ -46,7 +46,7 @@ void Radiation::MGFLD_implicit_update(int level, int iteration, int ncycle)
   MultiFab& S_new = castro->get_new_data(State_Type);
   AmrLevel::FillPatch(*castro,S_new,ngrow,time,State_Type,0,S_new.nComp(),0); 
 
-  Tuple<MultiFab, BL_SPACEDIM> lambda;
+  Array<MultiFab, BL_SPACEDIM> lambda;
   if (limiter > 0) {
     for (int idim = 0; idim < BL_SPACEDIM; idim++) {
 	lambda[idim].define(castro->getEdgeBoxArray(idim), dmap, nGroups, 0);
@@ -237,7 +237,7 @@ void Radiation::MGFLD_implicit_update(int level, int iteration, int ncycle)
   FluxRegister* flux_in = (level < fine_level) ? flux_trial[level+1].get() : nullptr;
   FluxRegister* flux_out = (level > 0) ? flux_trial[level].get() : nullptr;
 
-  Tuple<MultiFab, BL_SPACEDIM> Flux;
+  Array<MultiFab, BL_SPACEDIM> Flux;
   for (int n = 0; n < BL_SPACEDIM; n++) {
       Flux[n].define(castro->getEdgeBoxArray(n), dmap, 1, 0);
   }

--- a/Source/radiation/RadPlotvar.cpp
+++ b/Source/radiation/RadPlotvar.cpp
@@ -5,7 +5,7 @@
 
 using namespace amrex;
 
-void Radiation::save_lambda_in_plotvar(int level, const Tuple<MultiFab,BL_SPACEDIM>& lambda)
+void Radiation::save_lambda_in_plotvar(int level, const Array<MultiFab,BL_SPACEDIM>& lambda)
 {
     int nlambda = lambda[0].nComp();
 #ifdef _OPENMP
@@ -43,7 +43,7 @@ void Radiation::save_lab_Er_in_plotvar(int level, const MultiFab& Snew,
 }
 
 void Radiation::save_lab_flux_in_plotvar(int level, const MultiFab& Snew, 
-					 const Tuple<MultiFab,BL_SPACEDIM>& lambda,
+					 const Array<MultiFab,BL_SPACEDIM>& lambda,
 					 const MultiFab& Er, const MultiFab& Fr, int iflx)
 {
     const Real flag = 1.0;  // comovinng --> lab
@@ -79,7 +79,7 @@ void Radiation::save_lab_flux_in_plotvar(int level, const MultiFab& Snew,
 }
 
 void Radiation::save_com_flux_in_plotvar(int level, const MultiFab& Snew, 
-					 const Tuple<MultiFab,BL_SPACEDIM>& lambda,
+					 const Array<MultiFab,BL_SPACEDIM>& lambda,
 					 const MultiFab& Er, const MultiFab& Fr, int iflx)
 {
     const Real flag = -1.0;  // lab --> comoving

--- a/Source/radiation/RadSolve.H
+++ b/Source/radiation/RadSolve.H
@@ -109,7 +109,7 @@ class RadSolve {
 
 ///
 /// @param level
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param lambda
 /// @param kappa_r
 /// @param kcomp
@@ -117,7 +117,7 @@ class RadSolve {
 /// @param lamcomp
 ///
   void levelBCoeffs(int level,
-                    amrex::Tuple<amrex::MultiFab, BL_SPACEDIM>& lambda,
+                    amrex::Array<amrex::MultiFab, BL_SPACEDIM>& lambda,
 		    amrex::MultiFab& kappa_r, int kcomp, amrex::Real c, int lamcomp=0);
 
 
@@ -166,36 +166,36 @@ class RadSolve {
 
 ///
 /// @param level
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param Flux
 /// @param Er
 /// @param igroup
 ///
   void levelFlux(int level,
-                 amrex::Tuple<amrex::MultiFab, BL_SPACEDIM>& Flux,
+                 amrex::Array<amrex::MultiFab, BL_SPACEDIM>& Flux,
                  amrex::MultiFab& Er, int igroup);
 
 ///
 /// @param level
 /// @param flux_in
 /// @param flux_out
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param Flux
 /// @param igroup
 ///
   void levelFluxReg(int level,
                     amrex::FluxRegister* flux_in, amrex::FluxRegister* flux_out,
-                    const amrex::Tuple<amrex::MultiFab, BL_SPACEDIM>& Flux,
+                    const amrex::Array<amrex::MultiFab, BL_SPACEDIM>& Flux,
                     int igroup);
 
 ///
 /// @param level
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param Flux
 /// @param flx
 /// @param iflx
 ///
-  void levelFluxFaceToCenter(int level, const amrex::Tuple<amrex::MultiFab, BL_SPACEDIM>& Flux,
+  void levelFluxFaceToCenter(int level, const amrex::Array<amrex::MultiFab, BL_SPACEDIM>& Flux,
 			     amrex::MultiFab& flx, int iflx);
 
 ///
@@ -267,19 +267,19 @@ class RadSolve {
 		const amrex::MultiFab& Er_step, const amrex::MultiFab& rhoe_step, const amrex::MultiFab& rhoYe_step,
 		const amrex::MultiFab& Er_star, const amrex::MultiFab& rhoe_star, const amrex::MultiFab& rhoYe_star,
 		amrex::Real delta_t, int igroup, int it, amrex::Real ptc_tau);
-  void levelSPas(int level, amrex::Tuple<amrex::MultiFab, BL_SPACEDIM>& lambda, int igroup,
+  void levelSPas(int level, amrex::Array<amrex::MultiFab, BL_SPACEDIM>& lambda, int igroup,
 		 int lo_bc[], int hi_bc[]);
 
 ///
 /// </ MGFLD routines>
 ///
 /// @param level
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param lambda
 /// @param vel
 /// @param dcf
 ///
-  void levelDCoeffs(int level, amrex::Tuple<amrex::MultiFab, BL_SPACEDIM>& lambda,
+  void levelDCoeffs(int level, amrex::Array<amrex::MultiFab, BL_SPACEDIM>& lambda,
 		    amrex::MultiFab& vel, amrex::MultiFab& dcf);
 
 ///

--- a/Source/radiation/RadSolve.cpp
+++ b/Source/radiation/RadSolve.cpp
@@ -271,7 +271,7 @@ void RadSolve::levelACoeffs(int level,
   }
 }
 
-void RadSolve::levelSPas(int level, Tuple<MultiFab, BL_SPACEDIM>& lambda, int igroup, 
+void RadSolve::levelSPas(int level, Array<MultiFab, BL_SPACEDIM>& lambda, int igroup, 
 			 int lo_bc[3], int hi_bc[3])
 {
   const BoxArray& grids = parent->boxArray(level);
@@ -324,7 +324,7 @@ void RadSolve::levelSPas(int level, Tuple<MultiFab, BL_SPACEDIM>& lambda, int ig
 }
 
 void RadSolve::levelBCoeffs(int level,
-                            Tuple<MultiFab, BL_SPACEDIM>& lambda,
+                            Array<MultiFab, BL_SPACEDIM>& lambda,
                             MultiFab& kappa_r, int kcomp,
                             Real c, int lamcomp)
 {
@@ -367,7 +367,7 @@ void RadSolve::levelBCoeffs(int level,
   } // -->> over dimension
 }
 
-void RadSolve::levelDCoeffs(int level, Tuple<MultiFab, BL_SPACEDIM>& lambda,
+void RadSolve::levelDCoeffs(int level, Array<MultiFab, BL_SPACEDIM>& lambda,
 			    MultiFab& vel, MultiFab& dcf)
 {
     BL_PROFILE("RadSolve::levelDCoeffs");
@@ -502,7 +502,7 @@ void RadSolve::levelSolve(int level,
   }
 }
 
-void RadSolve::levelFluxFaceToCenter(int level, const Tuple<MultiFab, BL_SPACEDIM>& Flux,
+void RadSolve::levelFluxFaceToCenter(int level, const Array<MultiFab, BL_SPACEDIM>& Flux,
 				     MultiFab& flx, int iflx)
 {
     int nflx = flx.nComp();
@@ -537,7 +537,7 @@ void RadSolve::levelFluxFaceToCenter(int level, const Tuple<MultiFab, BL_SPACEDI
 }
 
 void RadSolve::levelFlux(int level,
-                         Tuple<MultiFab, BL_SPACEDIM>& Flux,
+                         Array<MultiFab, BL_SPACEDIM>& Flux,
                          MultiFab& Er, int igroup)
 {
   BL_PROFILE("RadSolve::levelFlux");
@@ -608,7 +608,7 @@ void RadSolve::levelFlux(int level,
 
 void RadSolve::levelFluxReg(int level,
                             FluxRegister* flux_in, FluxRegister* flux_out,
-                            const Tuple<MultiFab, BL_SPACEDIM>& Flux,
+                            const Array<MultiFab, BL_SPACEDIM>& Flux,
                             int igroup)
 {
   BL_PROFILE("RadSolve::levelFluxReg");
@@ -643,7 +643,7 @@ void RadSolve::levelDterm(int level, MultiFab& Dterm, MultiFab& Er, int igroup)
   const Real* dx = parent->Geom(level).CellSize();
   const Castro *castro = dynamic_cast<Castro*>(&parent->getLevel(level));
 
-  Tuple<MultiFab, BL_SPACEDIM> Dterm_face;
+  Array<MultiFab, BL_SPACEDIM> Dterm_face;
   for (int idim=0; idim<BL_SPACEDIM; idim++) {
       Dterm_face[idim].define(castro->getEdgeBoxArray(idim), dmap, 1, 0);
   }

--- a/Source/radiation/Radiation.H
+++ b/Source/radiation/Radiation.H
@@ -9,7 +9,7 @@
 #include "MGRadBndry.H"
 #include "RadSolve.H"
 #include <AMReX_FluxRegister.H>
-#include <AMReX_Tuple.H>
+#include <AMReX_Array.H>
 
 ///
 /// @class Radiation
@@ -466,7 +466,7 @@ protected:
 /// Computes the scaled gradient for use in flux limiters & Eddington factors
 ///
 /// @param level
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param R
 /// @param kappa_r
 /// @param kcomp
@@ -477,7 +477,7 @@ protected:
 /// @param Rcomp
 ///
   void scaledGradient(int level,
-                      amrex::Tuple<amrex::MultiFab, BL_SPACEDIM>& R,
+                      amrex::Array<amrex::MultiFab, BL_SPACEDIM>& R,
                       amrex::MultiFab& kappa_r, int kcomp,
                       amrex::MultiFab& Er, int igroup,
                       int limiter, int nGrow_Er=0, int Rcomp=0);
@@ -487,13 +487,13 @@ protected:
 /// On output this will be overwritten with the flux limiter.
 ///
 /// @param level
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param lambda
 /// @param limiter
 /// @param lamcomp
 ///
   void fluxLimiter(int level,
-                   amrex::Tuple<amrex::MultiFab, BL_SPACEDIM>& lambda,
+                   amrex::Array<amrex::MultiFab, BL_SPACEDIM>& lambda,
                    int limiter, int lamcomp=0);
 
 ///
@@ -851,7 +851,7 @@ protected:
 		  amrex::MultiFab& etaT, amrex::MultiFab& etaY, amrex::MultiFab& eta1,
 		  amrex::MultiFab& thetaT, amrex::MultiFab& thetaY,
 		  amrex::MultiFab& mugT, amrex::MultiFab& mugY,
-		  amrex::Tuple<amrex::MultiFab, BL_SPACEDIM>& lambda,
+		  amrex::Array<amrex::MultiFab, BL_SPACEDIM>& lambda,
 		  RadSolve& solver, MGRadBndry& mgbd,
 		  const amrex::BoxArray& grids, int level, amrex::Real time, amrex::Real delta_t, amrex::Real ptc_tau);
 
@@ -994,10 +994,10 @@ protected:
 /// </ MGFLD>
 ///
 /// @param level
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param lambda
 ///
-  void save_lambda_in_plotvar(int level, const amrex::Tuple<amrex::MultiFab,BL_SPACEDIM>& lambda);
+  void save_lambda_in_plotvar(int level, const amrex::Array<amrex::MultiFab,BL_SPACEDIM>& lambda);
 
 ///
 /// @param level
@@ -1012,27 +1012,27 @@ protected:
 ///
 /// @param level
 /// @param Snew
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param lambda
 /// @param Er
 /// @param F
 /// @param iflx
 ///
   void save_lab_flux_in_plotvar(int level, const amrex::MultiFab& Snew,
-				const amrex::Tuple<amrex::MultiFab,BL_SPACEDIM>& lambda,
+				const amrex::Array<amrex::MultiFab,BL_SPACEDIM>& lambda,
 				const amrex::MultiFab& Er, const amrex::MultiFab& F, int iflx);
 
 ///
 /// @param level
 /// @param Snew
-/// @param amrex::Tuple<amrex::MultiFab
+/// @param amrex::Array<amrex::MultiFab
 /// @param lambda
 /// @param Er
 /// @param F
 /// @param iflx
 ///
   void save_com_flux_in_plotvar(int level, const amrex::MultiFab& Snew,
-				const amrex::Tuple<amrex::MultiFab,BL_SPACEDIM>& lambda,
+				const amrex::Array<amrex::MultiFab,BL_SPACEDIM>& lambda,
 				const amrex::MultiFab& Er, const amrex::MultiFab& F, int iflx);
 
 protected:

--- a/Source/radiation/Radiation.cpp
+++ b/Source/radiation/Radiation.cpp
@@ -2232,7 +2232,7 @@ void Radiation::reflux(int level)
 // Computes the scaled gradient for use in flux limiters
 
 void Radiation::scaledGradient(int level,
-                               Tuple<MultiFab, BL_SPACEDIM>& R,
+                               Array<MultiFab, BL_SPACEDIM>& R,
                                MultiFab& kappa_r, int kcomp,
                                MultiFab& Er, int igroup,
                                int limiter, int nGrow_Er, int Rcomp)
@@ -2332,7 +2332,7 @@ void Radiation::scaledGradient(int level,
 // On output this will be overwritten with the flux limiter.
 
 void Radiation::fluxLimiter(int level,
-                            Tuple<MultiFab, BL_SPACEDIM>& lambda,
+                            Array<MultiFab, BL_SPACEDIM>& lambda,
                             int limiter, int lamcomp)
 {
   BL_PROFILE("Radiation::fluxLimiter");

--- a/Source/radiation/SGRadSolver.cpp
+++ b/Source/radiation/SGRadSolver.cpp
@@ -44,7 +44,7 @@ void Radiation::single_group_update(int level, int iteration, int ncycle)
   MultiFab Er_old(grids, dmap, Er_new.nComp(), Er_new.nGrow());
   Er_old.copy(Er_new); // all components, including any first moments
 
-  Tuple<MultiFab, BL_SPACEDIM> Ff_new;
+  Array<MultiFab, BL_SPACEDIM> Ff_new;
 
   for (int idim = 0; idim < BL_SPACEDIM; idim++) {
       Ff_new[idim].define(castro->getEdgeBoxArray(idim), dmap, 1, 0);
@@ -94,7 +94,7 @@ void Radiation::single_group_update(int level, int iteration, int ncycle)
   MultiFab eta(grids,dmap,1,0);
   MultiFab etainv(grids,dmap,1,0);  // this is 1-eta, to avoid loss of accuracy
 
-  Tuple<MultiFab, BL_SPACEDIM> lambda;
+  Array<MultiFab, BL_SPACEDIM> lambda;
 
   for (int idim = 0; idim < BL_SPACEDIM; idim++) {
       lambda[idim].define(castro->getEdgeBoxArray(idim), dmap, 1, 0);


### PR DESCRIPTION
`Tuple` in AMReX is a class that was born before C++ standard introduced `array` and `tuple`.  Unfortunately, `amrex::Tuple` is basically `std::array` and it's completely different from `std::tuple`.  In this pull-request, all `amrex::Tuple` are replaced by `amrex::Array`.
