### PR TITLE
intiial guess for the 4th order SDC Newton solve

### DIFF
--- a/Exec/reacting_tests/reacting_convergence/analysis/check_convergence.sh
+++ b/Exec/reacting_tests/reacting_convergence/analysis/check_convergence.sh
@@ -18,5 +18,5 @@ RichardsonConvergenceTest2d.gnu.sandybridge.ex coarFile=react_converge_128_sdc_p
 
 RichardsonConvergenceTest2d.gnu.sandybridge.ex coarFile=react_converge_64_sdc4_plt00301 mediFile=react_converge_128_sdc4_plt00601 fineFile=react_converge_256_sdc4_plt01201 > convergence.2d.lo.sdc4.out
 
-RichardsonConvergenceTest2d.gnu.sandybridge.ex coarFile=react_converge_128_sdc4_plt00601 mediFile=react_converge_256_sdc4_plt01201 fineFile=react_converge_256_sdc4_plt02401 > convergence.2d.hi.sdc4.out
+RichardsonConvergenceTest2d.gnu.sandybridge.ex coarFile=react_converge_128_sdc4_plt00601 mediFile=react_converge_256_sdc4_plt01201 fineFile=react_converge_512_sdc4_plt02401 > convergence.2d.hi.sdc4.out
 

--- a/Source/driver/Castro_sdc.cpp
+++ b/Source/driver/Castro_sdc.cpp
@@ -57,6 +57,30 @@ Castro::do_sdc_update(int m_start, int m_end, Real dt) {
     AmrLevel::FillPatch(*this, C_source, C_source.nGrow(), time,
                         SDC_Source_Type, 0, NUM_STATE);
 
+
+    // we'll also construct an initial guess for the nonlinear solve,
+    // and store this in the Sburn MultiFab.  We'll use S_new as the
+    // staging place so we can do a FillPatch
+    MultiFab& S_new = get_new_data(State_Type);
+
+    Real dt_m = dt/2.0;
+
+    for (MFIter mfi(S_new); mfi.isValid(); ++mfi) {
+
+      const Box& bx = mfi.tilebox();
+
+      ca_sdc_compute_initial_guess(BL_TO_FORTRAN_BOX(bx)
+                                   BL_TO_FORTRAN_3D((*k_new[m_start])[mfi]),
+                                   BL_TO_FORTRAN_3D((*k_new[m_end])[mfi]),
+                                   BL_TO_FORTRAN_3D((*A_old[m_start])[mfi]),
+                                   BL_TO_FORTRAN_3D((*R_old[m_start])[mfi]),
+                                   &dt_m, &sdc_iteration);
+
+
+    }
+
+    expand_state(Sburn, cur_time, -1, 2);
+
   }
 #endif
 
@@ -114,6 +138,13 @@ Castro::do_sdc_update(int m_start, int m_end, Real dt) {
       // solve for the updated cell-center U using our cell-centered C -- we
       // need to do this with one ghost cell
       U_new_center.resize(bx1, NUM_STATE);
+
+      // initialize U_new with our guess for the new state, stored as
+      // an average in Sburn
+      ca_make_cell_center(BL_TO_FORTRAN_BOX(bx1),
+                          BL_TO_FORTRAN_FAB(Sburn[mfi]),
+                          BL_TO_FORTRAN_FAB(U_new_center))
+
       ca_sdc_update_centers_o4(BL_TO_FORTRAN_BOX(bx1), &dt_m,
                                BL_TO_FORTRAN_3D(U_center),
                                BL_TO_FORTRAN_3D(U_new_center),

--- a/Source/driver/Castro_sdc.cpp
+++ b/Source/driver/Castro_sdc.cpp
@@ -69,16 +69,18 @@ Castro::do_sdc_update(int m_start, int m_end, Real dt) {
 
       const Box& bx = mfi.tilebox();
 
-      ca_sdc_compute_initial_guess(BL_TO_FORTRAN_BOX(bx)
+      ca_sdc_compute_initial_guess(BL_TO_FORTRAN_BOX(bx),
                                    BL_TO_FORTRAN_3D((*k_new[m_start])[mfi]),
                                    BL_TO_FORTRAN_3D((*k_new[m_end])[mfi]),
                                    BL_TO_FORTRAN_3D((*A_old[m_start])[mfi]),
                                    BL_TO_FORTRAN_3D((*R_old[m_start])[mfi]),
+                                   BL_TO_FORTRAN_3D(S_new[mfi]),
                                    &dt_m, &sdc_iteration);
 
 
     }
 
+    const Real cur_time = state[State_Type].curTime();
     expand_state(Sburn, cur_time, -1, 2);
 
   }
@@ -143,7 +145,7 @@ Castro::do_sdc_update(int m_start, int m_end, Real dt) {
       // an average in Sburn
       ca_make_cell_center(BL_TO_FORTRAN_BOX(bx1),
                           BL_TO_FORTRAN_FAB(Sburn[mfi]),
-                          BL_TO_FORTRAN_FAB(U_new_center))
+                          BL_TO_FORTRAN_FAB(U_new_center));
 
       ca_sdc_update_centers_o4(BL_TO_FORTRAN_BOX(bx1), &dt_m,
                                BL_TO_FORTRAN_3D(U_center),

--- a/Source/driver/sdc_util.F90
+++ b/Source/driver/sdc_util.F90
@@ -803,6 +803,52 @@ contains
 
   end subroutine ca_sdc_compute_C4
 
+  subroutine ca_sdc_compute_initial_guess(lo, hi, &
+                                          U_old, Uo_lo, Uo_hi, &
+                                          U_new, Un_lo, Un_hi, &
+                                          A_old, a_lo, a_hi, &
+                                          R_old, r_lo, r_hi, &
+                                          U_guess, Ug_lo, Ug_hi, &
+                                          dt_m, sdc_iteration) bind(C, name="ca_sdc_compute_initial_guess")
+    ! compute the initial guess for the Newton solve
+
+    use meth_params_module, only : NVAR
+    use amrex_constants_module, only : ONE, HALF, TWO, FIVE, EIGHT
+
+    implicit none
+
+    integer, intent(in) :: lo(3), hi(3)
+    integer, intent(in) :: Uo_lo(3), Uo_hi(3)
+    integer, intent(in) :: Un_lo(3), Un_hi(3)
+    integer, intent(in) :: a_lo(3), a_hi(3)
+    integer, intent(in) :: r_lo(3), r_hi(3)
+    integer, intent(in) :: Ug_lo(3), Ug_hi(3)
+
+    real(rt), intent(in) :: U_old(Uo_lo(1):Uo_hi(1), Uo_lo(2):Uo_hi(2), Uo_lo(3):Uo_hi(3), NVAR)
+    real(rt), intent(in) :: U_new(Un_lo(1):Un_hi(1), Un_lo(2):Un_hi(2), Un_lo(3):Un_hi(3), NVAR)
+    real(rt), intent(in) :: A_old(a_lo(1):a_hi(1), a_lo(2):a_hi(2), a_lo(3):a_hi(3), NVAR)
+    real(rt), intent(in) :: R_old(r_lo(1):r_hi(1), r_lo(2):r_hi(2), r_lo(3):r_hi(3), NVAR)
+    real(rt), intent(inout) :: U_guess(Ug_lo(1):Ug_hi(1), Ug_lo(2):Ug_hi(2), Ug_lo(3):Ug_hi(3), NVAR)
+    real(rt), intent(in) :: dt_m
+    integer, intent(in) :: sdc_iteration
+    integer :: i, j, k
+
+    do k = lo(3), hi(3)
+       do j = lo(2), hi(2)
+          do i = lo(1), hi(1)
+
+             if (sdc_iteration == 0) then
+                U_guess(i,j,k,:) = U_old(i,j,k,:) + dt_m * A_old(i,j,k,:) + dt_m * R_old(i,j,k,:)
+             else
+                U_guess(i,j,k,:) = U_new(i,j,k,:)
+             endif
+
+          enddo
+       enddo
+    enddo
+
+  end subroutine ca_sdc_compute_initial_guess
+
 
   subroutine ca_sdc_update_o2(lo, hi, dt_m, &
                               k_m, kmlo, kmhi, &

--- a/Source/driver/sdc_util.F90
+++ b/Source/driver/sdc_util.F90
@@ -930,10 +930,7 @@ contains
        do j = lo(2), hi(2)
           do i = lo(1), hi(1)
 
-             ! TODO: we should do a more smart initial guess (for the
-             ! Newton case) -- see the second-order version
-
-             U_new(i,j,k,:) = U_old(i,j,k,:)
+             ! we come in with U_new being a guess for the updated solution
 
              call sdc_solve(dt_m, U_old(i,j,k,:), U_new(i,j,k,:), C(i,j,k,:), sdc_iteration)
 

--- a/Source/hydro/Castro_hydro_F.H
+++ b/Source/hydro/Castro_hydro_F.H
@@ -601,6 +601,14 @@ extern "C"
                          const BL_FORT_FAB_ARG_3D(R_2),
                          BL_FORT_FAB_ARG_3D(C),
                          const int* m_start);
+
+  void ca_sdc_compute_initial_guess(const int* lo, const int* hi,
+                                    const BL_FORT_FAB_ARG_3D(U_old),
+                                    const BL_FORT_FAB_ARG_3D(U_new),
+                                    const BL_FORT_FAB_ARG_3D(A_old),
+                                    const BL_FORT_FAB_ARG_3D(R_old),
+                                    BL_FORT_FAB_ARG_3D(U_guess),
+                                    const amrex::Real* dt_m, const int* sdc_iteration);
 #endif
 #endif
 


### PR DESCRIPTION
## PR summary

This computes an initial guess for the 4th order Newton solve (done with cell-centers) following the same idea as we use for the 2nd order solve.

Closes #576 

## PR checklist

- [ ] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
