### PR TITLE
Avoid merge statements so XL can compile CUDA Fortran

### DIFF
--- a/Source/hydro/slope_nd.F90
+++ b/Source/hydro/slope_nd.F90
@@ -66,7 +66,11 @@ contains
                    dcen = FOURTH * (dlftp1 + drgtp1)
                    dsgn = sign(ONE, dcen)
                    slop = min(abs(dlftp1), abs(drgtp1))
-                   dlim = merge(slop, ZERO, dlftp1*drgtp1 >= ZERO)
+                   if (dlftp1*drgtp1 >= ZERO) then
+                      dlim = slop
+                   else
+                      dlim = ZERO
+                   end if
                    dfp1 = dsgn*min(dlim, abs(dcen))
 
                    ! df at i-1
@@ -75,7 +79,11 @@ contains
                    dcen = FOURTH * (dlftm1 + drgtm1)
                    dsgn = sign(ONE, dcen)
                    slop = min(abs(dlftm1), abs(drgtm1))
-                   dlim = merge(slop, ZERO, dlftm1*drgtm1 >= ZERO)
+                   if (dlftm1*drgtm1 >= ZERO) then
+                      dlim = slop
+                   else
+                      dlim = ZERO
+                   end if
                    dfm1 = dsgn*min(dlim, abs(dcen))
 
                    ! Now compute limited fourth order slopes at i
@@ -84,7 +92,11 @@ contains
                    dcen = FOURTH * (dlft + drgt)
                    dsgn = sign(ONE, dcen)
                    slop = min(abs(dlft), abs(drgt))
-                   dlim = merge(slop, ZERO, dlft*drgt >= ZERO)
+                   if (dlft*drgt >= ZERO) then
+                      dlim = slop
+                   else
+                      dlim = ZERO
+                   end if
 
                    dq1 = FOUR3RD*dcen - SIXTH*(dfp1 + dfm1)
                    dq(i,j,k,n) = flatn(i,j,k)*dsgn*min(dlim, abs(dq1))
@@ -109,7 +121,11 @@ contains
                    dcen = FOURTH * (dlftp1 + drgtp1)
                    dsgn = sign(ONE, dcen)
                    slop = min(abs(dlftp1), abs(drgtp1))
-                   dlim = merge(slop, ZERO, dlftp1*drgtp1 >= ZERO)
+                   if (dlftp1*drgtp1 >= ZERO) then
+                      dlim = slop
+                   else
+                      dlim = ZERO
+                   end if
                    dfp1 = dsgn*min(dlim, abs(dcen))
 
                    ! df at j-1
@@ -118,7 +134,11 @@ contains
                    dcen = FOURTH * (dlftm1 + drgtm1)
                    dsgn = sign(ONE, dcen)
                    slop = min(abs(dlftm1), abs(drgtm1))
-                   dlim = merge(slop, ZERO, dlftm1*drgtm1 >= ZERO)
+                   if (dlftm1*drgtm1 >= ZERO) then
+                      dlim = slop
+                   else
+                      dlim = ZERO
+                   end if
                    dfm1 = dsgn*min(dlim, abs(dcen))
 
                    ! Now compute limited fourth order slopes at j
@@ -127,7 +147,11 @@ contains
                    dcen = FOURTH * (dlft + drgt)
                    dsgn = sign(ONE, dcen)
                    slop = min(abs(dlft), abs(drgt))
-                   dlim = merge(slop, ZERO, dlft*drgt >= ZERO)
+                   if (dlft*drgt >= ZERO) then
+                      dlim = slop
+                   else
+                      dlim = ZERO
+                   end if
 
                    dq1 = FOUR3RD*dcen - SIXTH*(dfp1 + dfm1)
                    dq(i,j,k,n) = flatn(i,j,k)*dsgn*min(dlim, abs(dq1))
@@ -153,7 +177,11 @@ contains
                    dcen = FOURTH * (dlftp1 + drgtp1)
                    dsgn = sign(ONE, dcen)
                    slop = min(abs(dlftp1), abs(drgtp1))
-                   dlim = merge(slop, ZERO, dlftp1*drgtp1 >= ZERO)
+                   if (dlftp1*drgtp1 >= ZERO) then
+                      dlim = slop
+                   else
+                      dlim = ZERO
+                   end if
                    dfp1 = dsgn*min(dlim, abs(dcen))
 
                    ! df at k-1
@@ -162,7 +190,11 @@ contains
                    dcen = FOURTH * (dlftm1 + drgtm1)
                    dsgn = sign(ONE, dcen)
                    slop = min(abs(dlftm1), abs(drgtm1))
-                   dlim = merge(slop, ZERO, dlftm1*drgtm1 >= ZERO)
+                   if (dlftm1*drgtm1 >= ZERO) then
+                      dlim = slop
+                   else
+                      dlim = ZERO
+                   end if
                    dfm1 = dsgn*min(dlim, abs(dcen))
 
                    ! Now compute limited fourth order slopes at k
@@ -171,7 +203,11 @@ contains
                    dcen = FOURTH * (dlft + drgt)
                    dsgn = sign(ONE, dcen)
                    slop = min(abs(dlft), abs(drgt))
-                   dlim = merge(slop, ZERO, dlft*drgt >= ZERO)
+                   if (dlft*drgt >= ZERO) then
+                      dlim = slop
+                   else
+                      dlim = ZERO
+                   end if
 
                    dq1 = FOUR3RD*dcen - SIXTH*(dfp1 + dfm1)
                    dq(i,j,k,n) = flatn(i,j,k)*dsgn*min(dlim, abs(dq1))
@@ -256,7 +292,11 @@ contains
 
                    dcen = HALF*(dlftp1 + drgtp1)
                    dsgn = sign(ONE, dcen)
-                   dlim = merge(TWO * min(abs(dlftp1), abs(drgtp1)), ZERO, dlftp1*drgtp1 >= ZERO)
+                   if (dlftp1*drgtp1 >= ZERO) then
+                      dlim = TWO * min(abs(dlftp1), abs(drgtp1))
+                   else
+                      dlim = ZERO
+                   end if
                    dfp1 = dsgn*min(dlim, abs(dcen))
 
                    ! df at i-1
@@ -271,7 +311,11 @@ contains
 
                    dcen = HALF*(dlftm1 + drgtm1)
                    dsgn = sign(ONE, dcen)
-                   dlim = merge(TWO * min(abs(dlftm1), abs(drgtm1)), ZERO, dlftm1*drgtm1 >= ZERO)
+                   if (dlftm1*drgtm1 >= ZERO) then
+                      dlim = TWO * min(abs(dlftm1), abs(drgtm1))
+                   else
+                      dlim = ZERO
+                   end if
                    dfm1 = dsgn*min(dlim, abs(dcen))
 
                    ! Now limited fourth order slopes at i
@@ -279,7 +323,11 @@ contains
                    drgt = dlftp1
                    dcen = HALF*(dlft + drgt)
                    dsgn = sign(ONE, dcen)
-                   dlim = merge(TWO * min(abs(dlft), abs(drgt)), ZERO, dlft*drgt >= ZERO)
+                   if (dlft*drgt >= ZERO) then
+                      dlim = TWO * min(abs(dlft), abs(drgt))
+                   else
+                      dlim = ZERO
+                   end if
 
                    dp1 = FOUR3RD*dcen - SIXTH*(dfp1 + dfm1)
                    dq(i,j,k,QPRES) = flatn(i,j,k)*dsgn*min(dlim, abs(dp1))
@@ -311,7 +359,11 @@ contains
 
                    dcen = HALF*(dlftp1 + drgtp1)
                    dsgn = sign(ONE, dcen)
-                   dlim = merge(TWO * min(abs(dlftp1), abs(drgtp1)), ZERO, dlftp1*drgtp1 >= ZERO)
+                   if (dlftp1*drgtp1 >= ZERO) then
+                      dlim = TWO * min(abs(dlftp1), abs(drgtp1))
+                   else
+                      dlim = ZERO
+                   end if
                    dfp1 = dsgn*min(dlim, abs(dcen))
 
                    ! df at j-1
@@ -326,7 +378,11 @@ contains
 
                    dcen = HALF*(dlftm1 + drgtm1)
                    dsgn = sign(ONE, dcen)
-                   dlim = merge(TWO * min(abs(dlftm1), abs(drgtm1)), ZERO, dlftm1*drgtm1 >= ZERO)
+                   if (dlftm1*drgtm1 >= ZERO) then
+                      dlim = TWO * min(abs(dlftm1), abs(drgtm1))
+                   else
+                      dlim = ZERO
+                   end if
                    dfm1 = dsgn*min(dlim, abs(dcen))
 
                    ! Now limited fourth order slopes at j
@@ -335,7 +391,11 @@ contains
 
                    dcen = HALF*(dlft+drgt)
                    dsgn = sign(ONE, dcen)
-                   dlim = merge(TWO * min(abs(dlft), abs(drgt)), ZERO, dlft*drgt >= ZERO)
+                   if (dlft*drgt >= ZERO) then
+                      dlim = TWO * min(abs(dlft), abs(drgt))
+                   else
+                      dlim = ZERO
+                   end if
 
                    dp1 = FOUR3RD*dcen - SIXTH*(dfp1 + dfm1)
                    dq(i,j,k,QPRES) = flatn(i,j,k)*dsgn*min(dlim, abs(dp1))
@@ -367,7 +427,11 @@ contains
 
                    dcen = HALF*(dlftp1 + drgtp1)
                    dsgn = sign(ONE, dcen)
-                   dlim = merge(TWO * min(abs(dlftp1), abs(drgtp1)), ZERO, dlftp1*drgtp1 >= ZERO)
+                   if (dlftp1*drgtp1 >= ZERO) then
+                      dlim = TWO * min(abs(dlftp1), abs(drgtp1))
+                   else
+                      dlim = ZERO
+                   end if
                    dfp1 = dsgn*min(dlim, abs(dcen))
 
                    ! df at k-1
@@ -382,7 +446,11 @@ contains
 
                    dcen = HALF*(dlftm1 + drgtm1)
                    dsgn = sign(ONE, dcen)
-                   dlim = merge(TWO * min( abs(dlftm1), abs(drgtm1) ), ZERO, dlftm1*drgtm1 >= ZERO)
+                   if (dlftm1*drgtm1 >= ZERO) then
+                      dlim = TWO * min(abs(dlftm1), abs(drgtm1))
+                   else
+                      dlim = ZERO
+                   end if
                    dfm1 = dsgn*min(dlim, abs(dcen))
 
                    ! now limited fourth order slopes at k
@@ -391,7 +459,11 @@ contains
 
                    dcen = HALF*(dlft+drgt)
                    dsgn = sign(ONE, dcen)
-                   dlim = merge(TWO * min(abs(dlft), abs(drgt)), ZERO, dlft*drgt >= ZERO)
+                   if (dlft*drgt >= ZERO) then
+                      dlim = TWO * min(abs(dlft), abs(drgt))
+                   else
+                      dlim = ZERO
+                   end if
 
                    dp1 = FOUR3RD*dcen - SIXTH*(dfp1 + dfm1)
                    dq(i,j,k,QPRES) = flatn(i,j,k)*dsgn*min(dlim, abs(dp1))

--- a/Source/hydro/trace_plm.F90
+++ b/Source/hydro/trace_plm.F90
@@ -308,7 +308,11 @@ contains
                     (idir == 3 .and. k >= vlo(3))) then
 
                    un = q(i,j,k,QUN)
-                   spzero = merge(-ONE, un*dtdx, un >= ZERO)
+                   if (un >= ZERO) then
+                      spzero = -ONE
+                   else
+                      spzero = un*dtdx
+                   end if
                    acmprght = HALF*(-ONE - spzero)*dq(i,j,k,n)
                    qp(i,j,k,n) = q(i,j,k,n) + acmprght
                    if (n <= NQSRC) qp(i,j,k,n) = qp(i,j,k,n) + HALF*dt*srcQ(i,j,k,n)
@@ -316,7 +320,11 @@ contains
 
                 ! Left state
                 un = q(i,j,k,QUN)
-                spzero = merge(un*dtdx, ONE, un >= ZERO)
+                if (un >= ZERO) then
+                   spzero = un*dtdx
+                else
+                   spzero = ONE
+                end if
                 acmpleft = HALF*(ONE - spzero )*dq(i,j,k,n)
 
                 if (idir == 1 .and. i <= vhi(1)) then

--- a/Source/hydro/trace_ppm.F90
+++ b/Source/hydro/trace_ppm.F90
@@ -111,7 +111,11 @@ contains
                    ! wave, so no projection is needed.  Since we are not
                    ! projecting, the reference state doesn't matter
 
-                   qp(i,j,k,n) = merge(q(i,j,k,n), Im(i,j,k,2,n), un > ZERO)
+                   if (un > ZERO) then
+                      qp(i,j,k,n) = q(i,j,k,n)
+                   else
+                      qp(i,j,k,n) = Im(i,j,k,2,n)
+                   end if
                    if (n <= NQSRC) qp(i,j,k,n) = qp(i,j,k,n) + HALF*dt*Im_src(i,j,k,2,n)
 
                 end if
@@ -119,15 +123,27 @@ contains
                 ! Minus state on face i+1
                 if (idir == 1 .and. i <= vhi(1)) then
                    un = q(i,j,k,QU-1+idir)
-                   qm(i+1,j,k,n) = merge(Ip(i,j,k,2,n), q(i,j,k,n), un > ZERO)
+                   if (un > ZERO) then
+                      qm(i+1,j,k,n) = Ip(i,j,k,2,n)
+                   else
+                      qm(i+1,j,k,n) = q(i,j,k,n)
+                   end if
                    if (n <= NQSRC) qm(i+1,j,k,n) = qm(i+1,j,k,n) + HALF*dt*Ip_src(i,j,k,2,n)
                 else if (idir == 2 .and. j <= vhi(2)) then
                    un = q(i,j,k,QU-1+idir)
-                   qm(i,j+1,k,n) = merge(Ip(i,j,k,2,n), q(i,j,k,n), un > ZERO)
+                   if (un > ZERO) then
+                      qm(i,j+1,k,n) = Ip(i,j,k,2,n)
+                   else
+                      qm(i,j+1,k,n) = q(i,j,k,n)
+                   end if
                    if (n <= NQSRC) qm(i,j+1,k,n) = qm(i,j+1,k,n) + HALF*dt*Ip_src(i,j,k,2,n)
                 else if (idir == 3 .and. k <= vhi(3)) then
                    un = q(i,j,k,QU-1+idir)
-                   qm(i,j,k+1,n) = merge(Ip(i,j,k,2,n), q(i,j,k,n), un > ZERO)
+                   if (un > ZERO) then
+                      qm(i,j,k+1,n) = Ip(i,j,k,2,n)
+                   else
+                      qm(i,j,k+1,n) = q(i,j,k,n)
+                   end if
                    if (n <= NQSRC) qm(i,j,k+1,n) = qm(i,j,k+1,n) + HALF*dt*Ip_src(i,j,k,2,n)
                 end if
 
@@ -447,10 +463,29 @@ contains
                 alpha0r = drho - dptot/csq_ev
                 alpha0e_g = drhoe_g - dptot*h_g_ev  ! note h_g has a 1/c**2 in it
 
-                alpham = merge(ZERO, -alpham, un-cc > ZERO)
-                alphap = merge(ZERO, -alphap, un+cc > ZERO)
-                alpha0r = merge(ZERO, -alpha0r, un > ZERO)
-                alpha0e_g = merge(ZERO, -alpha0e_g, un > ZERO)
+                if (un-cc > ZERO) then
+                   alpham = ZERO
+                else
+                   alpham = -alpham
+                end if
+
+                if (un+cc > ZERO) then
+                   alphap = ZERO
+                else
+                   alphap = -alphap
+                end if
+
+                if (un > ZERO) then
+                   alpha0r = ZERO
+                else
+                   alpha0r = -alpha0r
+                end if
+
+                if (un > ZERO) then
+                   alpha0e_g = ZERO
+                else
+                   alpha0e_g = -alpha0e_g
+                end if
 
                 ! The final interface states are just
                 ! q_s = q_ref - sum(l . dq) r
@@ -537,10 +572,29 @@ contains
                 alpha0r = drho - dptot/csq_ev
                 alpha0e_g = drhoe_g - dptot*h_g_ev  ! h_g has a 1/c**2 in it
 
-                alpham = merge(-alpham, ZERO, un-cc > ZERO)
-                alphap = merge(-alphap, ZERO, un+cc > ZERO)
-                alpha0r = merge(-alpha0r, ZERO, un > ZERO)
-                alpha0e_g = merge(-alpha0e_g, ZERO, un > ZERO)
+                if (un-cc > ZERO) then
+                   alpham = -alpham
+                else
+                   alpham = ZERO
+                end if
+
+                if (un+cc > ZERO) then
+                   alphap = -alphap
+                else
+                   alphap = ZERO
+                end if
+
+                if (un > ZERO) then
+                   alpha0r = -alpha0r
+                else
+                   alpha0r = ZERO
+                end if
+
+                if (un > ZERO) then
+                   alpha0e_g = -alpha0e_g
+                else
+                   alpha0e_g = ZERO
+                end if
 
                 ! The final interface states are just
                 ! q_s = q_ref - sum (l . dq) r
@@ -874,10 +928,29 @@ contains
                 gfactor = (game - ONE)*(game - gam_g)
                 alpha0e_g = gfactor*dptot/(tau_ev*Clag_ev**2) + dge
 
-                alpham = merge(ZERO, -alpham, un-cc > ZERO)
-                alphap = merge(ZERO, -alphap, un+cc > ZERO)
-                alpha0r = merge(ZERO, -alpha0r, un > ZERO)
-                alpha0e_g = merge(ZERO, -alpha0e_g, un > ZERO)
+                if (un-cc > ZERO) then
+                   alpham = ZERO
+                else
+                   alpham = -alpham
+                end if
+
+                if (un+cc > ZERO) then
+                   alphap = ZERO
+                else
+                   alphap = -alphap
+                end if
+
+                if (un > ZERO) then
+                   alpha0r = ZERO
+                else
+                   alpha0r = -alpha0r
+                end if
+
+                if (un > ZERO) then
+                   alpha0e_g = ZERO
+                else
+                   alpha0e_g = -alpha0e_g
+                end if
 
                 ! The final interface states are just
                 ! q_s = q_ref - sum(l . dq) r
@@ -970,10 +1043,29 @@ contains
                 gfactor = (game - ONE)*(game - gam_g)
                 alpha0e_g = gfactor*dptot/(tau_ev*Clag_ev**2) + dge
 
-                alpham = merge(-alpham, ZERO, un-cc > ZERO)
-                alphap = merge(-alphap, ZERO, un+cc > ZERO)
-                alpha0r = merge(-alpha0r, ZERO, un > ZERO)
-                alpha0e_g = merge(-alpha0e_g, ZERO, un > ZERO)
+                if (un-cc > ZERO) then
+                   alpham = -alpham
+                else
+                   alpham = ZERO
+                end if
+
+                if (un+cc > ZERO) then
+                   alphap = -alphap
+                else
+                   alphap = ZERO
+                end if
+
+                if (un > ZERO) then
+                   alpha0r = -alpha0r
+                else
+                   alpha0r = ZERO
+                end if
+
+                if (un > ZERO) then
+                   alpha0e_g = -alpha0e_g
+                else
+                   alpha0e_g = ZERO
+                end if
 
 
                 ! The final interface states are just
@@ -1351,9 +1443,23 @@ contains
                 ! not used, but needed to prevent bad invalid ops
                 alpha0e_g = ZERO
 
-                alpham = merge(ZERO, -alpham, un-cc > ZERO)
-                alphap = merge(ZERO, -alphap, un+cc > ZERO)
-                alpha0r = merge(ZERO, -alpha0r, un > ZERO)
+                if (un-cc > ZERO) then
+                   alpham = ZERO
+                else
+                   alpham = -alpham
+                end if
+
+                if (un+cc > ZERO) then
+                   alphap = ZERO
+                else
+                   alphap = -alphap
+                end if
+
+                if (un > ZERO) then
+                   alpha0r = ZERO
+                else
+                   alpha0r = -alpha0r
+                end if
 
                 ! The final interface states are just
                 ! q_s = q_ref - sum(l . dq) r
@@ -1468,9 +1574,23 @@ contains
                 ! not used, but needed to prevent bad invalid ops
                 alpha0e_g = ZERO
 
-                alpham = merge(-alpham, ZERO, un-cc > ZERO)
-                alphap = merge(-alphap, ZERO, un+cc > ZERO)
-                alpha0r = merge(-alpha0r, ZERO, un > ZERO)
+                if (un-cc > ZERO) then
+                   alpham = -alpham
+                else
+                   alpham = ZERO
+                end if
+
+                if (un+cc > ZERO) then
+                   alphap = -alphap
+                else
+                   alphap = ZERO
+                end if
+
+                if (un > ZERO) then
+                   alpha0r = -alpha0r
+                else
+                   alpha0r = ZERO
+                end if
 
 
                 ! The final interface states are just

--- a/Source/radiation/trace_ppm_rad_nd.F90
+++ b/Source/radiation/trace_ppm_rad_nd.F90
@@ -327,7 +327,7 @@ contains
                 if (un > ZERO) then
                    alphar(:) = ZERO
                 else
-                   alphar(:) -alphar(:)
+                   alphar(:) = -alphar(:)
                 end if
 
                 if (un > ZERO) then

--- a/Source/radiation/trace_ppm_rad_nd.F90
+++ b/Source/radiation/trace_ppm_rad_nd.F90
@@ -306,11 +306,35 @@ contains
 
                 alphar(:) = der(:) - dptot/csq*hr
 
-                alpham = merge(ZERO, -alpham, un-cc > ZERO)
-                alphap = merge(ZERO, -alphap, un+cc > ZERO)
-                alpha0r = merge(ZERO, -alpha0r, un > ZERO)
-                alphar(:) = merge(ZERO, -alphar(:), un > ZERO)
-                alpha0e_g = merge(ZERO, -alpha0e_g, un > ZERO)
+                if (un-cc > ZERO) then
+                   alpham = ZERO
+                else
+                   alpham = -alpham
+                end if
+
+                if (un+cc > ZERO) then
+                   alphap = ZERO
+                else
+                   alphap = -alphap
+                end if
+
+                if (un > ZERO) then
+                   alpha0r = ZERO
+                else
+                   alpha0r = -alpha0r
+                end if
+
+                if (un > ZERO) then
+                   alphar(:) = ZERO
+                else
+                   alphar(:) -alphar(:)
+                end if
+
+                if (un > ZERO) then
+                   alpha0e_g = ZERO
+                else
+                   alpha0e_g = -alpha0e_g
+                end if
 
 
                 ! The final interface states are just
@@ -452,11 +476,35 @@ contains
 
                 alphar(:) = der(:) - dptot/csq*hr
 
-                alpham = merge(-alpham, ZERO, un-cc > ZERO)
-                alphap = merge(-alphap, ZERO, un+cc > ZERO)
-                alpha0r = merge(-alpha0r, ZERO, un > ZERO)
-                alphar(:) = merge(-alphar(:), ZERO, un > ZERO)
-                alpha0e_g = merge(-alpha0e_g, ZERO, un > ZERO)
+                if (un-cc > ZERO) then
+                   alpham = -alpham
+                else
+                   alpham = ZERO
+                end if
+
+                if (un+cc > ZERO) then
+                   alphap = -alphap
+                else
+                   alphap = ZERO
+                end if
+
+                if (un > ZERO) then
+                   alpha0r = -alpha0r
+                else
+                   alpha0r = ZERO
+                end if
+
+                if (un > ZERO) then
+                   alphar(:) = -alphar(:)
+                else
+                   alphar(:) = ZERO
+                end if
+
+                if (un > ZERO) then
+                   alpha0e_g = -alpha0e_g
+                else
+                   alpha0e_g = ZERO
+                end if
 
                 ! The final interface states are just
                 ! q_s = q_ref - sum (l . dq) r
@@ -678,22 +726,38 @@ contains
                    ! wave, so no projection is needed.  Since we are not
                    ! projecting, the reference state doesn't matter
 
-                   qp(i,j,k,n) = merge(q(i,j,k,n), Im(i,j,k,2,n), un > ZERO)
+                   if (un > ZERO) then
+                      qp(i,j,k,n) = q(i,j,k,n)
+                   else
+                      qp(i,j,k,n) = Im(i,j,k,2,n)
+                   end if
                    if (n <= NQSRC) qp(i,j,k,n) = qp(i,j,k,n) + HALF*dt*Im_src(i,j,k,2,n)
                 endif
 
                 ! Minus state on face i+1
                 if (idir == 1 .and. i <= vhi(1)) then
                    un = q(i,j,k,QUN)
-                   qm(i+1,j,k,n) = merge(Ip(i,j,k,2,n), q(i,j,k,n), un > ZERO)
+                   if (un > ZERO) then
+                      qm(i+1,j,k,n) = Ip(i,j,k,2,n)
+                   else
+                      qm(i+1,j,k,n) = q(i,j,k,n)
+                   end if
                    if (n <= NQSRC) qm(i+1,j,k,n) = qm(i+1,j,k,n) + HALF*dt*Ip_src(i,j,k,2,n)
                 else if (idir == 2 .and. j <= vhi(2)) then
                    un = q(i,j,k,QUN)
-                   qm(i,j+1,k,n) = merge(Ip(i,j,k,2,n), q(i,j,k,n), un > ZERO)
+                   if (un > ZERO) then
+                      qm(i,j+1,k,n) = Ip(i,j,k,2,n)
+                   else
+                      qm(i,j+1,k,n) = q(i,j,k,n)
+                   end if
                    if (n <= NQSRC) qm(i,j+1,k,n) = qm(i,j+1,k,n) + HALF*dt*Ip_src(i,j,k,2,n)
                 else if (idir == 3 .and. k <= vhi(3)) then
                    un = q(i,j,k,QUN)
-                   qm(i,j,k+1,n) = merge(Ip(i,j,k,2,n), q(i,j,k,n), un > ZERO)
+                   if (un > ZERO) then
+                      qm(i,j,k+1,n) = Ip(i,j,k,2,n)
+                   else
+                      qm(i,j,k+1,n) = q(i,j,k,n)
+                   end if
                    if (n <= NQSRC) qm(i,j,k+1,n) = qm(i,j,k+1,n) + HALF*dt*Ip_src(i,j,k,2,n)
                 endif
 


### PR DESCRIPTION
## PR summary

IBM's XL compiler seems to be unable to compile `merge` statements in CUDA Fortran device code. The `merge` statements are replaced with if/else.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
