### PR TITLE
Remove grav_source_type and rot_source_type parameters

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 # changes since the last release
 
+  -- The parameters castro.grav_source_type and castro.rot_source_type have
+     been removed, and the previous default values (4 in each case, corresponding
+     to the conservative energy formulation) are now the only choice.
+
   -- The runtime parameter castro.fix_mass_flux has been removed: it is not
      clear what the use case is, and it had no test suite coverage. (#572)
 

--- a/Exec/gravity_tests/evrard_collapse/inputs
+++ b/Exec/gravity_tests/evrard_collapse/inputs
@@ -21,7 +21,6 @@ castro.hi_bc       =  2   2   2
 castro.do_hydro = 1
 castro.do_grav  = 1
 castro.ppm_type = 0
-castro.grav_source_type = 4
 
 castro.small_dens = 1.0e-2
 castro.small_temp = 1.0e0

--- a/Exec/hydro_tests/rotating_torus/inputs_3d
+++ b/Exec/hydro_tests/rotating_torus/inputs_3d
@@ -30,9 +30,6 @@ castro.hybrid_hydro = 1
 
 castro.use_retry = 1
 
-castro.grav_source_type = 4
-castro.rot_source_type = 4
-
 # THERMODYNAMICS
 
 castro.dual_energy_eta1 = 1.0e-3

--- a/Exec/hydro_tests/rotating_torus/inputs_3d.test
+++ b/Exec/hydro_tests/rotating_torus/inputs_3d.test
@@ -30,9 +30,6 @@ castro.hybrid_hydro = 1
 
 castro.use_retry = 1
 
-castro.grav_source_type = 4
-castro.rot_source_type = 4
-
 # THERMODYNAMICS
 
 castro.dual_energy_eta1 = 1.0e-3

--- a/Exec/radiation_tests/RadFront/inputs2d
+++ b/Exec/radiation_tests/RadFront/inputs2d
@@ -59,11 +59,6 @@ castro.do_react       = 0       # reactions?
 castro.small_temp = 1.0e1
 castro.small_dens =1.0e-7 
 
-
-
-castro.grav_source_type = 4
-
-
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep

--- a/Exec/reacting_tests/reacting_bubble/inputs_2d
+++ b/Exec/reacting_tests/reacting_bubble/inputs_2d
@@ -26,7 +26,6 @@ castro.do_sponge = 1
 castro.small_temp = 1.e6
 
 castro.ppm_type = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e10

--- a/Exec/science/bwp-rad/inputs_2d
+++ b/Exec/science/bwp-rad/inputs_2d
@@ -52,8 +52,6 @@ castro.riemann_solver = 0
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.grav_source_type = 4
-
 castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor

--- a/Exec/science/bwp-rad/inputs_2d.test
+++ b/Exec/science/bwp-rad/inputs_2d.test
@@ -52,8 +52,6 @@ castro.riemann_solver = 0
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.grav_source_type = 4
-
 castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor

--- a/Exec/science/flame_wave/inputs.boost_10_10
+++ b/Exec/science/flame_wave/inputs.boost_10_10
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/inputs.boost_10_10.3d
+++ b/Exec/science/flame_wave/inputs.boost_10_10.3d
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/inputs.boost_25_4
+++ b/Exec/science/flame_wave/inputs.boost_25_4
@@ -36,7 +36,6 @@ castro.small_dens = 1.e-5
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
 castro.ppm_trace_sources = 1
-castro.grav_source_type = 2
 
 castro.allow_negative_energy = 0
 

--- a/Exec/science/flame_wave/inputs.boost_5_5
+++ b/Exec/science/flame_wave/inputs.boost_5_5
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 castro.limit_fluxes_on_small_dens = 1
 

--- a/Exec/science/flame_wave/inputs.noboost
+++ b/Exec/science/flame_wave/inputs.noboost
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/inputs.noboost.3d
+++ b/Exec/science/flame_wave/inputs.noboost.3d
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/inputs_2d.testsuite
+++ b/Exec/science/flame_wave/inputs_2d.testsuite
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/inputs_3d.testsuite
+++ b/Exec/science/flame_wave/inputs_3d.testsuite
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/job_scripts/aprox13/inputs_2d.boost.aprox13
+++ b/Exec/science/flame_wave/job_scripts/aprox13/inputs_2d.boost.aprox13
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/job_scripts/aprox13_test/inputs_2d.boost.aprox13
+++ b/Exec/science/flame_wave/job_scripts/aprox13_test/inputs_2d.boost.aprox13
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/old/inputs/inputs_2d
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d
@@ -33,7 +33,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -2.0e14

--- a/Exec/science/flame_wave/old/inputs/inputs_2d.boost
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d.boost
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -2.0e14

--- a/Exec/science/flame_wave/old/inputs/inputs_2d.boost.base
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d.boost.base
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -2.0e14

--- a/Exec/science/flame_wave/old/inputs/inputs_2d.boost.g
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d.boost.g
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/old/inputs/inputs_2d.boost.omega10
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d.boost.omega10
@@ -33,7 +33,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -2.0e14

--- a/Exec/science/flame_wave/old/inputs_2d.boost.aprox13.hires
+++ b/Exec/science/flame_wave/old/inputs_2d.boost.aprox13.hires
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/old/inputs_2d.boost.hires
+++ b/Exec/science/flame_wave/old/inputs_2d.boost.hires
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/flame_wave/old/inputs_2d.boost.wide
+++ b/Exec/science/flame_wave/old/inputs_2d.boost.wide
@@ -35,7 +35,6 @@ castro.small_dens = 1.e-5
 
 castro.ppm_type = 1
 castro.ppm_reference_eigenvectors = 1
-castro.grav_source_type = 2
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -1.5e14

--- a/Exec/science/wdmerger/tests/wdmerger_2D/inputs_test_wdmerger_2D
+++ b/Exec/science/wdmerger/tests/wdmerger_2D/inputs_test_wdmerger_2D
@@ -66,8 +66,6 @@ castro.implicit_rotation_update = 1                # Implicit rotation coupling
 castro.ppm_type = 1                                # Piecewise parabolic with the original limiters (0 is piecewise linear; 2 is new limiters)
 castro.ppm_reference_eigenvectors = 1              # Whether to evaluate eigenvectors using the reference state
 castro.ppm_temp_fix = 0                            # Use the EOS in calculation of the edge states going into the Riemann solver
-castro.grav_source_type = 4                        # How to include the gravity source term in the hydro equations
-castro.rot_source_type = 4                         # How to include the rotation source term in the hydro equations
 
 ############################################################################################
 # Thermodynamics

--- a/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
+++ b/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
@@ -68,8 +68,6 @@ castro.implicit_rotation_update = 1                # Implicit rotation coupling
 castro.ppm_type = 1                                # Piecewise parabolic with the original limiters (0 is piecewise linear; 2 is new limiters)
 castro.ppm_reference_eigenvectors = 1              # Whether to evaluate eigenvectors using the reference state
 castro.ppm_temp_fix = 0                            # Use the EOS in calculation of the edge states going into the Riemann solver
-castro.grav_source_type = 4                        # How to include the gravity source term in the hydro equations
-castro.rot_source_type = 4                         # How to include the rotation source term in the hydro equations
 
 # Explicitly limit fluxes to avoid hitting a negative density
 castro.limit_fluxes_on_small_dens = 1

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
@@ -68,8 +68,6 @@ castro.implicit_rotation_update = 1                # Implicit rotation coupling
 castro.ppm_type = 1                                # Piecewise parabolic with the original limiters (0 is piecewise linear; 2 is new limiters)
 castro.ppm_reference_eigenvectors = 1              # Whether to evaluate eigenvectors using the reference state
 castro.ppm_temp_fix = 0                            # Use the EOS in calculation of the edge states going into the Riemann solver
-castro.grav_source_type = 4                        # How to include the gravity source term in the hydro equations
-castro.rot_source_type = 4                         # How to include the rotation source term in the hydro equations
 
 ############################################################################################
 # Thermodynamics

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -382,10 +382,6 @@ do_grav                      int          -1                  y
 # to we recompute the center used for the multipole gravity solve each step?
 moving_center                int           0
 
-# determines how the gravitational source term is added to the momentum and
-# energy state variables.
-grav_source_type             int           4                  y
-
 # permits rotation calculation to be turned on and off
 do_rotation                  int          -1                  y
 
@@ -412,10 +408,6 @@ rotation_include_domegadt    int           1                  y        ROTATION
 # the state variables will be measured with respect to an observer fixed
 # in the inertial frame (but the frame will still rotate).
 state_in_rotating_frame      int           1                  y        ROTATION
-
-# determines how the rotation source terms are added to the momentum and
-# energy equations
-rot_source_type              int           4                  y        ROTATION
 
 # we can do a implicit solution of the rotation update to allow
 # for better coupling of the Coriolis terms

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -178,7 +178,6 @@ module meth_params_module
   real(rt), allocatable, save :: diffuse_cutoff_density_hi
   real(rt), allocatable, save :: diffuse_cond_scale_fac
   integer,  allocatable, save :: do_grav
-  integer,  allocatable, save :: grav_source_type
   integer,  allocatable, save :: do_rotation
   real(rt), allocatable, save :: rot_period
   real(rt), allocatable, save :: rot_period_dot
@@ -186,7 +185,6 @@ module meth_params_module
   integer,  allocatable, save :: rotation_include_coriolis
   integer,  allocatable, save :: rotation_include_domegadt
   integer,  allocatable, save :: state_in_rotating_frame
-  integer,  allocatable, save :: rot_source_type
   integer,  allocatable, save :: implicit_rotation_update
   integer,  allocatable, save :: rot_axis
   integer,  allocatable, save :: use_point_mass
@@ -271,7 +269,6 @@ attributes(managed) :: diffuse_cutoff_density_hi
 attributes(managed) :: diffuse_cond_scale_fac
 #endif
 attributes(managed) :: do_grav
-attributes(managed) :: grav_source_type
 attributes(managed) :: do_rotation
 #ifdef ROTATION
 attributes(managed) :: rot_period
@@ -290,9 +287,6 @@ attributes(managed) :: rotation_include_domegadt
 #endif
 #ifdef ROTATION
 attributes(managed) :: state_in_rotating_frame
-#endif
-#ifdef ROTATION
-attributes(managed) :: rot_source_type
 #endif
 #ifdef ROTATION
 attributes(managed) :: implicit_rotation_update
@@ -383,7 +377,6 @@ attributes(managed) :: get_g_from_phi
   !$acc create(diffuse_cond_scale_fac) &
 #endif
   !$acc create(do_grav) &
-  !$acc create(grav_source_type) &
   !$acc create(do_rotation) &
 #ifdef ROTATION
   !$acc create(rot_period) &
@@ -402,9 +395,6 @@ attributes(managed) :: get_g_from_phi
 #endif
 #ifdef ROTATION
   !$acc create(state_in_rotating_frame) &
-#endif
-#ifdef ROTATION
-  !$acc create(rot_source_type) &
 #endif
 #ifdef ROTATION
   !$acc create(implicit_rotation_update) &
@@ -493,8 +483,6 @@ contains
     rotation_include_domegadt = 1;
     allocate(state_in_rotating_frame)
     state_in_rotating_frame = 1;
-    allocate(rot_source_type)
-    rot_source_type = 4;
     allocate(implicit_rotation_update)
     implicit_rotation_update = 1;
     allocate(rot_axis)
@@ -624,8 +612,6 @@ contains
     T_guess = 1.d8;
     allocate(do_grav)
     do_grav = -1;
-    allocate(grav_source_type)
-    grav_source_type = 4;
     allocate(do_rotation)
     do_rotation = -1;
     allocate(do_acc)
@@ -656,7 +642,6 @@ contains
     call pp%query("rotation_include_coriolis", rotation_include_coriolis)
     call pp%query("rotation_include_domegadt", rotation_include_domegadt)
     call pp%query("state_in_rotating_frame", state_in_rotating_frame)
-    call pp%query("rot_source_type", rot_source_type)
     call pp%query("implicit_rotation_update", implicit_rotation_update)
     call pp%query("rot_axis", rot_axis)
 #endif
@@ -722,7 +707,6 @@ contains
     call pp%query("disable_shock_burning", disable_shock_burning)
     call pp%query("T_guess", T_guess)
     call pp%query("do_grav", do_grav)
-    call pp%query("grav_source_type", grav_source_type)
     call pp%query("do_rotation", do_rotation)
     call pp%query("do_acc", do_acc)
     call pp%query("grown_factor", grown_factor)
@@ -756,14 +740,12 @@ contains
     !$acc device(do_react, react_T_min, react_T_max) &
     !$acc device(react_rho_min, react_rho_max, disable_shock_burning) &
     !$acc device(T_guess, diffuse_cutoff_density, diffuse_cutoff_density_hi) &
-    !$acc device(diffuse_cond_scale_fac, do_grav, grav_source_type) &
-    !$acc device(do_rotation, rot_period, rot_period_dot) &
-    !$acc device(rotation_include_centrifugal, rotation_include_coriolis, rotation_include_domegadt) &
-    !$acc device(state_in_rotating_frame, rot_source_type, implicit_rotation_update) &
-    !$acc device(rot_axis, use_point_mass, point_mass) &
-    !$acc device(point_mass_fix_solution, do_acc, grown_factor) &
-    !$acc device(track_grid_losses, const_grav) &
-    !$acc device(get_g_from_phi)
+    !$acc device(diffuse_cond_scale_fac, do_grav, do_rotation) &
+    !$acc device(rot_period, rot_period_dot, rotation_include_centrifugal) &
+    !$acc device(rotation_include_coriolis, rotation_include_domegadt, state_in_rotating_frame) &
+    !$acc device(implicit_rotation_update, rot_axis, use_point_mass) &
+    !$acc device(point_mass, point_mass_fix_solution, do_acc) &
+    !$acc device(grown_factor, track_grid_losses, const_grav, get_g_from_phi)
 
 
 #ifdef GRAVITY
@@ -1056,9 +1038,6 @@ contains
     if (allocated(do_grav)) then
         deallocate(do_grav)
     end if
-    if (allocated(grav_source_type)) then
-        deallocate(grav_source_type)
-    end if
     if (allocated(do_rotation)) then
         deallocate(do_rotation)
     end if
@@ -1079,9 +1058,6 @@ contains
     end if
     if (allocated(state_in_rotating_frame)) then
         deallocate(state_in_rotating_frame)
-    end if
-    if (allocated(rot_source_type)) then
-        deallocate(rot_source_type)
     end if
     if (allocated(implicit_rotation_update)) then
         deallocate(implicit_rotation_update)

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -19,7 +19,6 @@ int         Castro::rotation_include_centrifugal = 1;
 int         Castro::rotation_include_coriolis = 1;
 int         Castro::rotation_include_domegadt = 1;
 int         Castro::state_in_rotating_frame = 1;
-int         Castro::rot_source_type = 4;
 int         Castro::implicit_rotation_update = 1;
 int         Castro::rot_axis = 3;
 #endif
@@ -109,7 +108,6 @@ int         Castro::disable_shock_burning = 0;
 amrex::Real Castro::T_guess = 1.e8;
 int         Castro::do_grav = -1;
 int         Castro::moving_center = 0;
-int         Castro::grav_source_type = 4;
 int         Castro::do_rotation = -1;
 int         Castro::do_acc = -1;
 int         Castro::bndry_func_thread_safe = 1;

--- a/Source/driver/param_includes/castro_job_info_tests.H
+++ b/Source/driver/param_includes/castro_job_info_tests.H
@@ -14,7 +14,6 @@ jobInfoFile << (Castro::rotation_include_centrifugal == 1 ? "    " : "[*] ") << 
 jobInfoFile << (Castro::rotation_include_coriolis == 1 ? "    " : "[*] ") << "castro.rotation_include_coriolis = " << Castro::rotation_include_coriolis << std::endl;
 jobInfoFile << (Castro::rotation_include_domegadt == 1 ? "    " : "[*] ") << "castro.rotation_include_domegadt = " << Castro::rotation_include_domegadt << std::endl;
 jobInfoFile << (Castro::state_in_rotating_frame == 1 ? "    " : "[*] ") << "castro.state_in_rotating_frame = " << Castro::state_in_rotating_frame << std::endl;
-jobInfoFile << (Castro::rot_source_type == 4 ? "    " : "[*] ") << "castro.rot_source_type = " << Castro::rot_source_type << std::endl;
 jobInfoFile << (Castro::implicit_rotation_update == 1 ? "    " : "[*] ") << "castro.implicit_rotation_update = " << Castro::implicit_rotation_update << std::endl;
 jobInfoFile << (Castro::rot_axis == 3 ? "    " : "[*] ") << "castro.rot_axis = " << Castro::rot_axis << std::endl;
 #endif
@@ -104,7 +103,6 @@ jobInfoFile << (Castro::disable_shock_burning == 0 ? "    " : "[*] ") << "castro
 jobInfoFile << (Castro::T_guess == 1.e8 ? "    " : "[*] ") << "castro.T_guess = " << Castro::T_guess << std::endl;
 jobInfoFile << (Castro::do_grav == -1 ? "    " : "[*] ") << "castro.do_grav = " << Castro::do_grav << std::endl;
 jobInfoFile << (Castro::moving_center == 0 ? "    " : "[*] ") << "castro.moving_center = " << Castro::moving_center << std::endl;
-jobInfoFile << (Castro::grav_source_type == 4 ? "    " : "[*] ") << "castro.grav_source_type = " << Castro::grav_source_type << std::endl;
 jobInfoFile << (Castro::do_rotation == -1 ? "    " : "[*] ") << "castro.do_rotation = " << Castro::do_rotation << std::endl;
 jobInfoFile << (Castro::do_acc == -1 ? "    " : "[*] ") << "castro.do_acc = " << Castro::do_acc << std::endl;
 jobInfoFile << (Castro::bndry_func_thread_safe == 1 ? "    " : "[*] ") << "castro.bndry_func_thread_safe = " << Castro::bndry_func_thread_safe << std::endl;

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -19,7 +19,6 @@ static int rotation_include_centrifugal;
 static int rotation_include_coriolis;
 static int rotation_include_domegadt;
 static int state_in_rotating_frame;
-static int rot_source_type;
 static int implicit_rotation_update;
 static int rot_axis;
 #endif
@@ -109,7 +108,6 @@ static int disable_shock_burning;
 static amrex::Real T_guess;
 static int do_grav;
 static int moving_center;
-static int grav_source_type;
 static int do_rotation;
 static int do_acc;
 static int bndry_func_thread_safe;

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -19,7 +19,6 @@ pp.query("rotation_include_centrifugal", rotation_include_centrifugal);
 pp.query("rotation_include_coriolis", rotation_include_coriolis);
 pp.query("rotation_include_domegadt", rotation_include_domegadt);
 pp.query("state_in_rotating_frame", state_in_rotating_frame);
-pp.query("rot_source_type", rot_source_type);
 pp.query("implicit_rotation_update", implicit_rotation_update);
 pp.query("rot_axis", rot_axis);
 #endif
@@ -109,7 +108,6 @@ pp.query("disable_shock_burning", disable_shock_burning);
 pp.query("T_guess", T_guess);
 pp.query("do_grav", do_grav);
 pp.query("moving_center", moving_center);
-pp.query("grav_source_type", grav_source_type);
 pp.query("do_rotation", do_rotation);
 pp.query("do_acc", do_acc);
 pp.query("bndry_func_thread_safe", bndry_func_thread_safe);

--- a/sphinx_docs/source/FlowChart.rst
+++ b/sphinx_docs/source/FlowChart.rst
@@ -370,9 +370,7 @@ In the code, the objective is to evolve the state from the old time,
          \gb^n = -\nabla\phi^n, \qquad
                \Delta\phi^n = 4\pi G\rho^n,
 
-      The construction of the form of the gravity source for the
-      momentum and energy equation is dependent on the parameter
-      ``castro.grav_source_type``. Full details of the gravity
+      Full details of the gravity
       solver are given in Chapter \ `[ch:gravity] <#ch:gravity>`__.
 
 
@@ -381,9 +379,7 @@ In the code, the objective is to evolve the state from the old time,
       We compute the rotational potential (for use in the energy update)
       and the rotational acceleration (for use in the momentum
       equation). This includes the Coriolis and centrifugal terms in a
-      constant-angular-velocity co-rotating frame. The form of the
-      rotational source that is constructed then depends on the
-      parameter ``castro.rot_source_type``. More details are
+      constant-angular-velocity co-rotating frame. More details are
       given in Chapter \ `[ch:rotation] <#ch:rotation>`__.
 
    The source terms here are evaluated using the post-burn state,

--- a/sphinx_docs/source/gravity.rst
+++ b/sphinx_docs/source/gravity.rst
@@ -583,47 +583,11 @@ where :math:`M_{enclosed}` has the same meaning as with the
 Hydrodynamics Source Terms
 ==========================
 
-There are several options to incorporate the effects of gravity into
-the hydrodynamics system. The main parameter here is
-``castro.grav_source_type``.
-
-- ``castro.grav_source_type`` = 1 : we use a standard
-  predictor-corrector formalism for updating the momentum and
-  energy. Specifically, our first update is equal to :math:`\Delta t
-  \times \mathbf{S}^n` , where :math:`\mathbf{S}^n` is the value of
-  the source terms at the old-time (which is usually called time-level
-  :math:`n`). At the end of the timestep, we do a corrector step where
-  we subtract off :math:`\Delta t / 2 \times \mathbf{S}^n` and add on
-  :math:`\Delta t / 2 \times \mathbf{S}^{n+1}`, so that at the end of
-  the timestep the source term is properly time centered.
-
-- ``castro.grav_source_type`` = 2 : we do something very similar
-  to 1. The major difference is that when evaluating the energy source
-  term at the new time (which is equal to :math:`\mathbf{u} \cdot
-  \mathbf{S}^{n+1}_{\rho \mathbf{u}}`, where the latter is the
-  momentum source term evaluated at the new time), we first update the
-  momentum, rather than using the value of :math:`\mathbf{u}` before
-  entering the gravity source terms. This permits a tighter coupling
-  between the momentum and energy update and we have seen that it
-  usually results in a more accurate evolution.
-
-- ``castro.grav_source_type`` = 3 : we do the same momentum update as
-  the previous two, but for the energy update, we put all of the work
-  into updating the kinetic energy alone. In particular, we explicitly
-  ensure that :math:`(rho e)` maintains the same, and update
-  :math:`(rho K)` with the work due to gravity, adding the new kinetic
-  energy to the old internal energy to determine the final total gas
-  energy. The physical motivation is that work should be done on the
-  velocity, and should not directly update the temperature—only
-  indirectly through things like shocks.
-
-- ``castro.grav_source_type`` = 4 : the energy update is done in a
-  “conservative” fashion. The previous methods all evaluate the value
-  of the source term at the cell center, but this method evaluates the
-  change in energy at cell edges, using the hydrodynamical mass
-  fluxes, permitting total energy to be conserved (excluding possible
-  losses at open domain boundaries). See
-  :cite:`katzthesis` for some more details.
+The momentum update is done using a standard cell-centered formulation.
+The energy update is done in a “conservative” fashion. We evaluate
+the change in energy at cell edges, using the hydrodynamical mass
+fluxes, permitting total energy to be conserved (excluding possible
+losses at open domain boundaries). See :cite:`katzthesis` for more details.
 
 .. [1]
    Note: The ``PrescribedGrav``


### PR DESCRIPTION
## PR summary

The current default values (4 for both; the conservative energy formulation) are now the only option.

Closes #156

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
