### PR TITLE
Hydro source mf

### DIFF
--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -492,9 +492,9 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
     }
 
     // This array holds the hydrodynamics update.
-
-    hydro_source.define(grids,dmap,NUM_STATE,0);
-
+    if (time_integration_method == CornerTransportUpwind || time_integration_method == SimplifiedSpectralDeferredCorrections) {
+      hydro_source.define(grids,dmap,NUM_STATE,0);
+    }
 
 
     // Allocate space for the primitive variables.
@@ -606,7 +606,9 @@ Castro::finalize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
 
     Real cur_time = state[State_Type].curTime();
 
-    hydro_source.clear();
+    if (time_integration_method == CornerTransportUpwind || time_integration_method == SimplifiedSpectralDeferredCorrections) {
+      hydro_source.clear();
+    }
 
     q.clear();
     qaux.clear();

--- a/Source/hydro/Castro_fourth_order.F90
+++ b/Source/hydro/Castro_fourth_order.F90
@@ -1,7 +1,6 @@
 ! advection routines in support of method of lines integration
 !
 subroutine ca_fourth_single_stage(lo, hi, time, domlo, domhi, &
-                                  stage_weight, &
                                   uin, uin_lo, uin_hi, &
                                   uout, uout_lo, uout_hi, &
                                   q, q_lo, q_hi, &
@@ -10,28 +9,27 @@ subroutine ca_fourth_single_stage(lo, hi, time, domlo, domhi, &
                                   qaux_bar, qa_bar_lo, qa_bar_hi, &
                                   srcU, srU_lo, srU_hi, &
                                   update, updt_lo, updt_hi, &
-                                  update_flux, uf_lo, uf_hi, &
                                   dx, dt, &
                                   flx, flx_lo, flx_hi, &
 #if AMREX_SPACEDIM >= 2
-     fly, fly_lo, fly_hi, &
+                                  fly, fly_lo, fly_hi, &
 #endif
 #if AMREX_SPACEDIM == 3
-     flz, flz_lo, flz_hi, &
+                                  flz, flz_lo, flz_hi, &
 #endif
-     area1, area1_lo, area1_hi, &
+                                  area1, area1_lo, area1_hi, &
 #if AMREX_SPACEDIM >= 2
-     area2, area2_lo, area2_hi, &
+                                  area2, area2_lo, area2_hi, &
 #endif
 #if AMREX_SPACEDIM == 3
-     area3, area3_lo, area3_hi, &
+                                  area3, area3_lo, area3_hi, &
 #endif
 #if AMREX_SPACEDIM < 3
-     pradial, p_lo, p_hi, &
-     dloga, dloga_lo, dloga_hi, &
+                                  pradial, p_lo, p_hi, &
+                                  dloga, dloga_lo, dloga_hi, &
 #endif
-     vol, vol_lo, vol_hi, &
-     verbose) bind(C, name="ca_fourth_single_stage")
+                                  vol, vol_lo, vol_hi, &
+                                  verbose) bind(C, name="ca_fourth_single_stage")
 
   use amrex_mempool_module, only : bl_allocate, bl_deallocate
   use meth_params_module, only : NQ, NVAR, NGDNV, NQAUX, GDPRES, &
@@ -63,7 +61,6 @@ subroutine ca_fourth_single_stage(lo, hi, time, domlo, domhi, &
 
   integer, intent(in) :: lo(3), hi(3), verbose
   integer, intent(in) ::  domlo(3), domhi(3)
-  real(rt), intent(in) :: stage_weight
   integer, intent(in) :: uin_lo(3), uin_hi(3)
   integer, intent(in) :: uout_lo(3), uout_hi(3)
   integer, intent(in) :: q_lo(3), q_hi(3)
@@ -72,7 +69,6 @@ subroutine ca_fourth_single_stage(lo, hi, time, domlo, domhi, &
   integer, intent(in) :: qa_bar_lo(3), qa_bar_hi(3)
   integer, intent(in) :: srU_lo(3), srU_hi(3)
   integer, intent(in) :: updt_lo(3), updt_hi(3)
-  integer, intent(in) :: uf_lo(3), uf_hi(3)
   integer, intent(in) :: flx_lo(3), flx_hi(3)
   integer, intent(in) :: area1_lo(3), area1_hi(3)
 #if AMREX_SPACEDIM >= 2
@@ -97,7 +93,6 @@ subroutine ca_fourth_single_stage(lo, hi, time, domlo, domhi, &
   real(rt), intent(inout) :: qaux_bar(qa_bar_lo(1):qa_bar_hi(1), qa_bar_lo(2):qa_bar_hi(2), qa_bar_lo(3):qa_bar_hi(3), NQAUX)
   real(rt), intent(in) :: srcU(srU_lo(1):srU_hi(1), srU_lo(2):srU_hi(2), srU_lo(3):srU_hi(3), NVAR)
   real(rt), intent(inout) :: update(updt_lo(1):updt_hi(1), updt_lo(2):updt_hi(2), updt_lo(3):updt_hi(3), NVAR)
-  real(rt), intent(inout) :: update_flux(uf_lo(1):uf_hi(1), uf_lo(2):uf_hi(2), uf_lo(3):uf_hi(3), NVAR)
   real(rt), intent(inout) :: flx(flx_lo(1):flx_hi(1), flx_lo(2):flx_hi(2), flx_lo(3):flx_hi(3), NVAR)
   real(rt), intent(in) :: area1(area1_lo(1):area1_hi(1), area1_lo(2):area1_hi(2), area1_lo(3):area1_hi(3))
 #if AMREX_SPACEDIM >= 2
@@ -658,10 +653,6 @@ subroutine ca_fourth_single_stage(lo, hi, time, domlo, domhi, &
                  endif
               endif
 #endif
-
-              ! for storage
-              update_flux(i,j,k,n) = update_flux(i,j,k,n) + &
-                   stage_weight * update(i,j,k,n)
 
               update(i,j,k,n) = update(i,j,k,n) + srcU(i,j,k,n)
 

--- a/Source/hydro/Castro_hydro_F.H
+++ b/Source/hydro/Castro_hydro_F.H
@@ -432,12 +432,10 @@ extern "C"
 
   void ca_mol_consup
     (const int* lo, const int* hi,
-     const amrex::Real stage_weight,
      const BL_FORT_FAB_ARG_3D(statein),
      BL_FORT_FAB_ARG_3D(stateout),
      const BL_FORT_FAB_ARG_3D(srcU),
      BL_FORT_FAB_ARG_3D(update),
-     BL_FORT_FAB_ARG_3D(update_flux),
      const amrex::Real* dx, const amrex::Real dt,
      BL_FORT_FAB_ARG_3D(flux1),
 #if AMREX_SPACEDIM >= 2
@@ -466,7 +464,6 @@ extern "C"
     (const int* lo, const int* hi,
      const amrex::Real* time,
      const int* domlo, const int* domhi,
-     const amrex::Real *stage_weight,
      const BL_FORT_FAB_ARG_3D(statein),
      BL_FORT_FAB_ARG_3D(stateout),
      BL_FORT_FAB_ARG_3D(q),
@@ -475,7 +472,6 @@ extern "C"
      BL_FORT_FAB_ARG_3D(qaux_bar),
      const BL_FORT_FAB_ARG_3D(srcU),
      BL_FORT_FAB_ARG_3D(update),
-     BL_FORT_FAB_ARG_3D(update_flux),
      const amrex::Real* dx, const amrex::Real* dt,
      BL_FORT_FAB_ARG_3D(flux1),
 #if AMREX_SPACEDIM >= 2

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -31,13 +31,6 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
     }
   }
 
-  // we'll add each stage's contribution to -div{F(U)} as we compute them
-  // (I don't think we need hydro_source anymore)
-  if ((time_integration_method == MethodOfLines && mol_iteration == 0) ||
-      (time_integration_method == SpectralDeferredCorrections && current_sdc_node == 0)) {
-    hydro_source.setVal(0.0);
-  }
-
 
   const Real *dx = geom.CellSize();
 
@@ -86,7 +79,6 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 
 	// the output of this will be stored in the correct stage MF
 	FArrayBox &source_out = A_update[mfi];
-	FArrayBox &source_hydro_only = hydro_source[mfi];
 
 	FArrayBox& vol = volume[mfi];
 
@@ -115,7 +107,6 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
           ca_fourth_single_stage
             (AMREX_INT_ANYD(lo), AMREX_INT_ANYD(hi), &time,
              ARLIM_3D(domain_lo), ARLIM_3D(domain_hi),
-             &stage_weight,
              BL_TO_FORTRAN_ANYD(statein),
              BL_TO_FORTRAN_ANYD(stateout),
              BL_TO_FORTRAN_ANYD(q[mfi]),
@@ -124,7 +115,6 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
              BL_TO_FORTRAN_ANYD(qaux_bar[mfi]),
              BL_TO_FORTRAN_ANYD(source_in),
              BL_TO_FORTRAN_ANYD(source_out),
-             BL_TO_FORTRAN_ANYD(source_hydro_only),
              ZFILL(dx), &dt,
              BL_TO_FORTRAN_ANYD(flux[0]),
 #if AMREX_SPACEDIM >= 2
@@ -340,12 +330,10 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 #pragma gpu
           ca_mol_consup
             (AMREX_INT_ANYD(lo), AMREX_INT_ANYD(hi),
-             stage_weight,
              BL_TO_FORTRAN_ANYD(statein),
              BL_TO_FORTRAN_ANYD(stateout),
              BL_TO_FORTRAN_ANYD(source_in),
              BL_TO_FORTRAN_ANYD(source_out),
-             BL_TO_FORTRAN_ANYD(source_hydro_only),
              AMREX_REAL_ANYD(dx), dt,
              BL_TO_FORTRAN_ANYD(flux[0]),
 #if AMREX_SPACEDIM >= 2

--- a/Source/hydro/Castro_mol_nd.F90
+++ b/Source/hydro/Castro_mol_nd.F90
@@ -280,12 +280,10 @@ subroutine ca_mol_ppm_reconstruct(lo, hi, &
 end subroutine ca_mol_ppm_reconstruct
 
 subroutine ca_mol_consup(lo, hi, &
-                         stage_weight, &
                          uin, uin_lo, uin_hi, &
                          uout, uout_lo, uout_hi, &
                          srcU, srU_lo, srU_hi, &
                          update, updt_lo, updt_hi, &
-                         update_flux, uf_lo, uf_hi, &
                          dx, dt, &
                          flux1, flux1_lo, flux1_hi, &
 #if AMREX_SPACEDIM >= 2
@@ -330,12 +328,10 @@ subroutine ca_mol_consup(lo, hi, &
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
-  real(rt), intent(in), value :: stage_weight
   integer, intent(in) :: uin_lo(3), uin_hi(3)
   integer, intent(in) :: uout_lo(3), uout_hi(3)
   integer, intent(in) :: srU_lo(3), srU_hi(3)
   integer, intent(in) :: updt_lo(3), updt_hi(3)
-  integer, intent(in) :: uf_lo(3), uf_hi(3)
   integer, intent(in) :: flux1_lo(3), flux1_hi(3)
   integer, intent(in) :: area1_lo(3), area1_hi(3)
   integer, intent(in) :: q1_lo(3), q1_hi(3)
@@ -356,7 +352,6 @@ subroutine ca_mol_consup(lo, hi, &
   real(rt), intent(inout) :: uout(uout_lo(1):uout_hi(1), uout_lo(2):uout_hi(2), uout_lo(3):uout_hi(3), NVAR)
   real(rt), intent(in) :: srcU(srU_lo(1):srU_hi(1), srU_lo(2):srU_hi(2), srU_lo(3):srU_hi(3), NVAR)
   real(rt), intent(inout) :: update(updt_lo(1):updt_hi(1), updt_lo(2):updt_hi(2), updt_lo(3):updt_hi(3), NVAR)
-  real(rt), intent(inout) :: update_flux(uf_lo(1):uf_hi(1), uf_lo(2):uf_hi(2), uf_lo(3):uf_hi(3), NVAR)
 
   real(rt), intent(inout) :: flux1(flux1_lo(1):flux1_hi(1), flux1_lo(2):flux1_hi(2), flux1_lo(3):flux1_hi(3), NVAR)
   real(rt), intent(in) :: area1(area1_lo(1):area1_hi(1), area1_lo(2):area1_hi(2), area1_lo(3):area1_hi(3))
@@ -422,9 +417,6 @@ subroutine ca_mol_consup(lo, hi, &
 #endif
 
               ! for storage
-              update_flux(i,j,k,n) = update_flux(i,j,k,n) + &
-                   stage_weight * update(i,j,k,n)
-
               update(i,j,k,n) = update(i,j,k,n) + srcU(i,j,k,n)
 
            enddo


### PR DESCRIPTION
## PR summary

This gets rid of the `hydro_source` MF in MOL and SDC integration -- it is not used.
Closes #584 

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
