### PR TITLE
Skip old-time gravity solve for uniform grid runs

### DIFF
--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -28,8 +28,10 @@ Castro::construct_old_gravity(int amr_iteration, int amr_ncycle, Real time)
 
     // Do level solve at beginning of time step in order to compute the
     // difference between the multilevel and the single level solutions.
+    // Note that we don't need to do this solve for single-level runs,
+    // since the solution at the end of the last timestep won't have changed.
 
-    if (gravity->get_gravity_type() == "PoissonGrav")
+    if (gravity->get_gravity_type() == "PoissonGrav" && parent->finestLevel() > 0)
     {
 
 	// Create a copy of the current (composite) data on this level.


### PR DESCRIPTION
## PR summary

Non-AMR simulations have no reason to do the Poisson solve at the old time, because it will be the same solution as the Poisson solve at the new time from the last timestep (and Strang reactions don't change density). This optimization should not qualitatively change answers, though it might change answers to the level of tolerance in the gravity solve for MPI runs.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
