### PR TITLE
fixes the potential negative dens/rhoe from converting averages -> centers

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3367,7 +3367,11 @@ Castro::computeTemp(MultiFab& State, Real time, int ng)
   }
 
   if (mol_order == 4 || sdc_order == 4) {
-    reset_internal_energy(Stemp, ng);
+    // we need to enforce minimum density here, since the conversion
+    // from cell-average to centers could have made rho < 0 near steep
+    // gradients
+    enforce_min_density(Stemp, Stemp.nGrow());
+    reset_internal_energy(Stemp, Stemp.nGrow());
   } else {
     reset_internal_energy(State, ng);
   }

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -159,6 +159,18 @@ Castro::cons_to_prim_fourth(const Real time)
                           BL_TO_FORTRAN_FAB(Sborder[mfi]),
                           BL_TO_FORTRAN_FAB(U_cc));
 
+      // enforce the minimum density on the new cell-centered state
+      Real dens_change = 1.e0;
+      ca_enforce_minimum_density
+        (AMREX_ARLIM_ANYD(qbxm1.loVect()), AMREX_ARLIM_ANYD(qbxm1.hiVect()),
+         BL_TO_FORTRAN_ANYD(U_cc),
+         &dens_change, verbose);
+
+      // and ensure that the internal energy is positive
+      ca_reset_internal_e(AMREX_INT_ANYD(qbxm1.loVect()), AMREX_INT_ANYD(qbxm1.hiVect()),
+                          BL_TO_FORTRAN_ANYD(U_cc),
+                          print_fortran_warnings);
+
       // convert U_avg to q_bar -- this will be done on all NUM_GROW
       // ghost cells.
       ca_ctoprim(BL_TO_FORTRAN_BOX(qbx),


### PR DESCRIPTION
This adds a reset_internal_energy and enforce_min_density call after we convert from cell averages to centers in the computeTemp and cons_to_prim parts of the code.  This addresses #506

We are still fourth order accurate with this change (according to acoustic_pulse_general)

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
