### PR TITLE
Enforce a speed limit in the Riemann solver

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,12 @@
 # changes since the last release
 
+  -- The velocity calculated for the interface in the Riemann solve for
+     the CGF/CG Riemann solvers can no longer exceed the speed of light.
+     The parameter castro.riemann_speed_limit can be set to control the
+     speed limit applied in the Riemann solver -- this is useful for
+     preventing unphysically large velocities from being created at
+     shock fronts or near large density gradients.
+
   -- density_reset_method == 3 (which, in the event of a density reset,
      reset to the density at the beginning of the timestep) no longer
      exists. (#538)

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -129,6 +129,10 @@ cg_blend                     int           2                  y
 # thermodynamic consistency?
 use_eos_in_riemann           int           0                  y
 
+# Limit the Riemann velocity used for flux construction to
+# this speed limit.
+riemann_speed_limit          Real          2.99792458e10      y
+
 # flatten the reconstructed profiles around shocks to prevent them
 # from becoming too thin
 use_flattening               int           1                  y

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -134,6 +134,7 @@ module meth_params_module
   real(rt), allocatable, save :: cg_tol
   integer,  allocatable, save :: cg_blend
   integer,  allocatable, save :: use_eos_in_riemann
+  real(rt), allocatable, save :: riemann_speed_limit
   integer,  allocatable, save :: use_flattening
   integer,  allocatable, save :: transverse_use_eos
   integer,  allocatable, save :: transverse_reset_density
@@ -224,6 +225,7 @@ attributes(managed) :: cg_maxiter
 attributes(managed) :: cg_tol
 attributes(managed) :: cg_blend
 attributes(managed) :: use_eos_in_riemann
+attributes(managed) :: riemann_speed_limit
 attributes(managed) :: use_flattening
 attributes(managed) :: transverse_use_eos
 attributes(managed) :: transverse_reset_density
@@ -345,6 +347,7 @@ attributes(managed) :: get_g_from_phi
   !$acc create(cg_tol) &
   !$acc create(cg_blend) &
   !$acc create(use_eos_in_riemann) &
+  !$acc create(riemann_speed_limit) &
   !$acc create(use_flattening) &
   !$acc create(transverse_use_eos) &
   !$acc create(transverse_reset_density) &
@@ -551,6 +554,8 @@ contains
     cg_blend = 2;
     allocate(use_eos_in_riemann)
     use_eos_in_riemann = 0;
+    allocate(riemann_speed_limit)
+    riemann_speed_limit = 2.99792458d10;
     allocate(use_flattening)
     use_flattening = 1;
     allocate(transverse_use_eos)
@@ -696,6 +701,7 @@ contains
     call pp%query("cg_tol", cg_tol)
     call pp%query("cg_blend", cg_blend)
     call pp%query("use_eos_in_riemann", use_eos_in_riemann)
+    call pp%query("riemann_speed_limit", riemann_speed_limit)
     call pp%query("use_flattening", use_flattening)
     call pp%query("transverse_use_eos", transverse_use_eos)
     call pp%query("transverse_reset_density", transverse_reset_density)
@@ -762,27 +768,26 @@ contains
     !$acc device(ppm_predict_gammae, ppm_reference_eigenvectors, plm_iorder) &
     !$acc device(hybrid_riemann, riemann_solver, cg_maxiter) &
     !$acc device(cg_tol, cg_blend, use_eos_in_riemann) &
-    !$acc device(use_flattening, transverse_use_eos, transverse_reset_density) &
-    !$acc device(transverse_reset_rhoe, dual_energy_eta1, dual_energy_eta2) &
-    !$acc device(use_pslope, limit_fluxes_on_small_dens, density_reset_method) &
-    !$acc device(allow_small_energy, do_sponge, sponge_implicit) &
-    !$acc device(first_order_hydro, hse_zero_vels, hse_interp_temp) &
-    !$acc device(hse_reflect_vels, mol_order, sdc_order) &
-    !$acc device(sdc_solver, sdc_solver_tol_dens, sdc_solver_tol_spec) &
-    !$acc device(sdc_solver_tol_ener, sdc_solver_atol, sdc_solver_relax_factor) &
-    !$acc device(sdc_solve_for_rhoe, sdc_use_analytic_jac, cfl) &
-    !$acc device(dtnuc_e, dtnuc_X, dtnuc_X_threshold) &
-    !$acc device(do_react, react_T_min, react_T_max) &
-    !$acc device(react_rho_min, react_rho_max, disable_shock_burning) &
-    !$acc device(T_guess, diffuse_cutoff_density, diffuse_cutoff_density_hi) &
-    !$acc device(diffuse_cond_scale_fac, do_grav, grav_source_type) &
-    !$acc device(do_rotation, rot_period, rot_period_dot) &
-    !$acc device(rotation_include_centrifugal, rotation_include_coriolis, rotation_include_domegadt) &
-    !$acc device(state_in_rotating_frame, rot_source_type, implicit_rotation_update) &
-    !$acc device(rot_axis, use_point_mass, point_mass) &
-    !$acc device(point_mass_fix_solution, do_acc, grown_factor) &
-    !$acc device(track_grid_losses, const_grav) &
-    !$acc device(get_g_from_phi)
+    !$acc device(riemann_speed_limit, use_flattening, transverse_use_eos) &
+    !$acc device(transverse_reset_density, transverse_reset_rhoe, dual_energy_eta1) &
+    !$acc device(dual_energy_eta2, use_pslope, limit_fluxes_on_small_dens) &
+    !$acc device(density_reset_method, allow_small_energy, do_sponge) &
+    !$acc device(sponge_implicit, first_order_hydro, hse_zero_vels) &
+    !$acc device(hse_interp_temp, hse_reflect_vels, mol_order) &
+    !$acc device(sdc_order, sdc_solver, sdc_solver_tol_dens) &
+    !$acc device(sdc_solver_tol_spec, sdc_solver_tol_ener, sdc_solver_atol) &
+    !$acc device(sdc_solver_relax_factor, sdc_solve_for_rhoe, sdc_use_analytic_jac) &
+    !$acc device(cfl, dtnuc_e, dtnuc_X) &
+    !$acc device(dtnuc_X_threshold, do_react, react_T_min) &
+    !$acc device(react_T_max, react_rho_min, react_rho_max) &
+    !$acc device(disable_shock_burning, T_guess, diffuse_cutoff_density) &
+    !$acc device(diffuse_cutoff_density_hi, diffuse_cond_scale_fac, do_grav) &
+    !$acc device(grav_source_type, do_rotation, rot_period) &
+    !$acc device(rot_period_dot, rotation_include_centrifugal, rotation_include_coriolis) &
+    !$acc device(rotation_include_domegadt, state_in_rotating_frame, rot_source_type) &
+    !$acc device(implicit_rotation_update, rot_axis, use_point_mass) &
+    !$acc device(point_mass, point_mass_fix_solution, do_acc) &
+    !$acc device(grown_factor, track_grid_losses, const_grav, get_g_from_phi)
 
 
 #ifdef GRAVITY
@@ -942,6 +947,9 @@ contains
     end if
     if (allocated(use_eos_in_riemann)) then
         deallocate(use_eos_in_riemann)
+    end if
+    if (allocated(riemann_speed_limit)) then
+        deallocate(riemann_speed_limit)
     end if
     if (allocated(use_flattening)) then
         deallocate(use_flattening)

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -51,6 +51,7 @@ int         Castro::cg_maxiter = 12;
 amrex::Real Castro::cg_tol = 1.0e-5;
 int         Castro::cg_blend = 2;
 int         Castro::use_eos_in_riemann = 0;
+amrex::Real Castro::riemann_speed_limit = 2.99792458e10;
 int         Castro::use_flattening = 1;
 int         Castro::transverse_use_eos = 0;
 int         Castro::transverse_reset_density = 1;

--- a/Source/driver/param_includes/castro_job_info_tests.H
+++ b/Source/driver/param_includes/castro_job_info_tests.H
@@ -46,6 +46,7 @@ jobInfoFile << (Castro::cg_maxiter == 12 ? "    " : "[*] ") << "castro.cg_maxite
 jobInfoFile << (Castro::cg_tol == 1.0e-5 ? "    " : "[*] ") << "castro.cg_tol = " << Castro::cg_tol << std::endl;
 jobInfoFile << (Castro::cg_blend == 2 ? "    " : "[*] ") << "castro.cg_blend = " << Castro::cg_blend << std::endl;
 jobInfoFile << (Castro::use_eos_in_riemann == 0 ? "    " : "[*] ") << "castro.use_eos_in_riemann = " << Castro::use_eos_in_riemann << std::endl;
+jobInfoFile << (Castro::riemann_speed_limit == 2.99792458e10 ? "    " : "[*] ") << "castro.riemann_speed_limit = " << Castro::riemann_speed_limit << std::endl;
 jobInfoFile << (Castro::use_flattening == 1 ? "    " : "[*] ") << "castro.use_flattening = " << Castro::use_flattening << std::endl;
 jobInfoFile << (Castro::transverse_use_eos == 0 ? "    " : "[*] ") << "castro.transverse_use_eos = " << Castro::transverse_use_eos << std::endl;
 jobInfoFile << (Castro::transverse_reset_density == 1 ? "    " : "[*] ") << "castro.transverse_reset_density = " << Castro::transverse_reset_density << std::endl;

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -51,6 +51,7 @@ static int cg_maxiter;
 static amrex::Real cg_tol;
 static int cg_blend;
 static int use_eos_in_riemann;
+static amrex::Real riemann_speed_limit;
 static int use_flattening;
 static int transverse_use_eos;
 static int transverse_reset_density;

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -51,6 +51,7 @@ pp.query("cg_maxiter", cg_maxiter);
 pp.query("cg_tol", cg_tol);
 pp.query("cg_blend", cg_blend);
 pp.query("use_eos_in_riemann", use_eos_in_riemann);
+pp.query("riemann_speed_limit", riemann_speed_limit);
 pp.query("use_flattening", use_flattening);
 pp.query("transverse_use_eos", transverse_use_eos);
 pp.query("transverse_reset_density", transverse_reset_density);

--- a/Source/hydro/riemann_nd.F90
+++ b/Source/hydro/riemann_nd.F90
@@ -481,7 +481,7 @@ contains
     use network, only : nspec, naux
     use eos_type_module
     use eos_module
-    use meth_params_module, only : cg_maxiter, cg_tol, cg_blend
+    use meth_params_module, only : cg_maxiter, cg_tol, cg_blend, riemann_speed_limit
 #ifndef AMREX_USE_CUDA
     use riemann_util_module, only : pstar_bisection
 #endif
@@ -1036,6 +1036,9 @@ contains
              ! Compute fluxes, order as conserved state (not q)
              qint(i,j,k,iu) = u_adv
 
+             ! Enforce that the velocity should not exceed a given limit.
+             qint(i,j,k,iu) = min(abs(qint(i,j,k,iu)), riemann_speed_limit) * sign(ONE, qint(i,j,k,iu))
+
              ! compute the total energy from the internal, p/(gamma - 1), and the kinetic
              qint(i,j,k,QREINT) = qint(i,j,k,QPRES)/(qint(i,j,k,QGAME) - ONE)
 
@@ -1086,7 +1089,7 @@ contains
     use eos_type_module, only : eos_t, eos_input_rp
     use eos_module, only : eos
     use network, only : nspec
-    use meth_params_module, only: T_guess
+    use meth_params_module, only: T_guess, riemann_speed_limit
 
     implicit none
 
@@ -1600,6 +1603,9 @@ contains
              u_adv = u_adv * bnd_fac_x*bnd_fac_y*bnd_fac_z
 
              qint(i,j,k,iu) = u_adv
+
+             ! Enforce that the velocity should not exceed a given limit.
+             qint(i,j,k,iu) = min(abs(qint(i,j,k,iu)), riemann_speed_limit) * sign(ONE, qint(i,j,k,iu))
 
              ! passively advected quantities
              do ipassive = 1, npassive


### PR DESCRIPTION
## PR summary

Castro is a Newtonian hydrodynamics code and has no knowledge of special relativity. This means that spuriously large, unphysical velocities can be generated. This commonly occurs in the wdmerger problem at poorly resolved density gradients near the edge of the stars. Although a proper solution to this problem involves adding SR to the code, a simple approach to improving the situation is to enforce a speed limit in the Riemann solve. By default this speed limit is c, but the user can lower it (for example, to a value like 0.1c which is still in the relativistic regime where Castro results should be distrusted) if they know the range of realistic values taken by the velocity for their problem.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
