### PR TITLE
split source fill into its own routine

### DIFF
--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -8,6 +8,8 @@
 #include "Castro_bc_fill_nd.H"
 #include "Castro_generic_fill_F.H"
 #include "Castro_generic_fill.H"
+#include "Castro_source_fill_F.H"
+#include "Castro_source_fill.H"
 #include <Derive_F.H>
 #include "Derive.H"
 #ifdef RADIATION
@@ -573,7 +575,7 @@ Castro::variableSetUp ()
   }
 
   desc_lst.setComponent(Source_Type,Density,state_type_source_names,source_bcs,
-                        BndryFunc(ca_generic_single_fill,ca_generic_multi_fill));
+                        BndryFunc(ca_source_single_fill,ca_source_multi_fill));
 
 #ifdef REACTIONS
   std::string name_react;

--- a/Source/driver/Castro_source_fill.H
+++ b/Source/driver/Castro_source_fill.H
@@ -1,0 +1,60 @@
+#ifndef _Castro_source_fill_H_
+#define _Castro_source_fill_H_
+
+#include <AMReX_BLFort.H>
+#include <Castro.H>
+
+#ifdef AMREX_USE_CUDA
+#include <cuda_runtime_api.h>
+#include <AMReX_Arena.H>
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef AMREX_USE_CUDA
+    static void set_bc_launch_config()
+    {
+        amrex::Gpu::Device::setNumThreadsMin(Castro::minBCThreads(0), Castro::minBCThreads(1), Castro::minBCThreads(2));
+    }
+
+    static void clean_bc_launch_config()
+    {
+        amrex::Gpu::Device::setNumThreadsMin(1, 1, 1);
+    }
+
+    // Return a pointer to bc valid for use in Fortran. For the CPU this is a no-op.
+
+    static int* prepare_bc(const int* bc, const int nvar)
+    {
+        int* bc_f = (int*) amrex::The_Arena()->alloc(AMREX_SPACEDIM * 2 * nvar * sizeof(int));
+        AMREX_GPU_SAFE_CALL(cudaMemcpyAsync(bc_f, bc, AMREX_SPACEDIM * 2 * nvar * sizeof(int), cudaMemcpyHostToDevice, amrex::Gpu::Device::cudaStream()));
+        return bc_f;
+    }
+
+    static void clean_bc(int* bc_f)
+    {
+        amrex::Gpu::Device::streamSynchronize();
+        amrex::The_Arena()->free(bc_f);
+    }
+#endif
+
+    void ca_source_single_fill
+    (BL_FORT_FAB_ARG_3D(state),
+     const int* dlo, const int* dhi,
+     const amrex::Real* dx, const amrex::Real* glo,
+     const amrex::Real* time, const int* bc);
+
+    void ca_source_multi_fill
+    (BL_FORT_FAB_ARG_3D(state),
+     const int* dlo, const int* dhi,
+     const amrex::Real* dx, const amrex::Real* glo,
+     const amrex::Real* time, const int* bc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Source/driver/Castro_source_fill.cpp
+++ b/Source/driver/Castro_source_fill.cpp
@@ -1,0 +1,84 @@
+
+#include <AMReX_BLFort.H>
+#include <Castro.H>
+#include <Castro_source_fill.H>
+#include <Castro_source_fill_F.H>
+
+using namespace amrex;
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    // Note that these are called with dimension agnostic macros like
+    // AMREX_ZFILL and AMREX_INT_ANYD already, so we should expect that
+    // everything has three entries, not AMREX_SPACEDIM entries.
+    // We still choose to use the macros anyway below, for compatibility
+    // with the GPU pragma script.
+
+    void ca_source_single_fill(Real* adv, const int* adv_lo, const int* adv_hi,
+                                const int* domlo, const int* domhi, const Real* dx, const Real* xlo,
+                                const Real* time, const int* bc)
+    {
+        int lo[3] = {0};
+        int hi[3] = {0};
+
+        for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+            lo[i] = adv_lo[i];
+            hi[i] = adv_hi[i];
+        }
+
+#ifdef AMREX_USE_CUDA
+        int* bc_f = prepare_bc(bc, 1);
+        set_bc_launch_config();
+#else
+        const int* bc_f = bc;
+#endif
+
+#pragma gpu
+        source_single_fill(AMREX_INT_ANYD(lo), AMREX_INT_ANYD(hi),
+                           adv, AMREX_INT_ANYD(adv_lo), AMREX_INT_ANYD(adv_hi),
+                           AMREX_INT_ANYD(domlo), AMREX_INT_ANYD(domhi),
+                           AMREX_REAL_ANYD(dx), AMREX_REAL_ANYD(xlo), bc_f);
+
+#ifdef AMREX_USE_CUDA
+        clean_bc_launch_config();
+        clean_bc(bc_f);
+#endif
+    }
+
+    void ca_source_multi_fill(Real* adv, const int* adv_lo, const int* adv_hi,
+                               const int* domlo, const int* domhi, const Real* dx, const Real* xlo,
+                               const Real* time, const int* bc)
+    {
+        int lo[3] = {0};
+        int hi[3] = {0};
+
+        for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+            lo[i] = adv_lo[i];
+            hi[i] = adv_hi[i];
+        }
+
+#ifdef AMREX_USE_CUDA
+        int* bc_f = prepare_bc(bc, Castro::numState());
+        set_bc_launch_config();
+#else
+        const int* bc_f = bc;
+#endif
+
+#pragma gpu
+        source_multi_fill(AMREX_INT_ANYD(lo), AMREX_INT_ANYD(hi),
+                          adv, AMREX_INT_ANYD(adv_lo), AMREX_INT_ANYD(adv_hi),
+                          AMREX_INT_ANYD(domlo), AMREX_INT_ANYD(domhi),
+                          AMREX_REAL_ANYD(dx), AMREX_REAL_ANYD(xlo), bc_f);
+
+#ifdef AMREX_USE_CUDA
+        clean_bc_launch_config();
+        clean_bc(bc_f);
+#endif
+    }
+
+#ifdef __cplusplus
+}
+#endif

--- a/Source/driver/Castro_source_fill_F.H
+++ b/Source/driver/Castro_source_fill_F.H
@@ -1,0 +1,27 @@
+#ifndef _Castro_source_fill_F_H
+#define _Castro_source_fill_F_H
+
+#include <AMReX_BLFort.H>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  void source_single_fill
+    (const int* lo, const int* hi,
+     BL_FORT_FAB_ARG_3D(state),
+     const int* dlo, const int* dhi,
+     const amrex::Real* dx, const amrex::Real* glo, const int* bc);
+
+  void source_multi_fill
+    (const int* lo, const int* hi,
+     BL_FORT_FAB_ARG_3D(state),
+     const int* dlo, const int* dhi,
+     const amrex::Real* dx, const amrex::Real* glo, const int* bc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Source/driver/Make.package
+++ b/Source/driver/Make.package
@@ -38,6 +38,11 @@ CEXE_sources += Castro_generic_fill.cpp
 FEXE_headers += Castro_generic_fill_F.H
 ca_F90EXE_sources += generic_fill.F90
 
+CEXE_headers += Castro_source_fill.H
+CEXE_sources += Castro_source_fill.cpp
+FEXE_headers += Castro_source_fill_F.H
+ca_F90EXE_sources += source_fill.F90
+
 ca_F90EXE_sources += Castro_nd.F90
 ca_F90EXE_sources += Castro_util.F90
 ca_F90EXE_sources += Derive_nd.F90

--- a/Source/driver/source_fill.F90
+++ b/Source/driver/source_fill.F90
@@ -1,4 +1,4 @@
-module generic_fill_module
+module source_fill_module
 
   use amrex_fort_module, only: rt => amrex_real
   use meth_params_module, only: NVAR
@@ -10,8 +10,8 @@ module generic_fill_module
 contains
 
 
-  subroutine generic_single_fill(lo, hi, state, s_lo, s_hi, domlo, domhi, delta, xlo, bc) bind(C, name="generic_single_fill")
-    ! Used for a generic fill of any StateData.
+  subroutine source_single_fill(lo, hi, state, s_lo, s_hi, domlo, domhi, delta, xlo, bc) bind(C, name="source_single_fill")
+    ! Used for a source fill of any StateData.
 
     use amrex_filcc_module, only: amrex_filccn
 
@@ -44,11 +44,11 @@ contains
 
     call amrex_filccn(lo, hi, state, s_lo, s_hi, 1, domlo, domhi, delta, xlo, bc_temp)
 
-  end subroutine generic_single_fill
+  end subroutine source_single_fill
 
 
 
-  subroutine generic_multi_fill(lo, hi, state, s_lo, s_hi, domlo, domhi, delta, xlo, bc) bind(C, name="generic_multi_fill")
+  subroutine source_multi_fill(lo, hi, state, s_lo, s_hi, domlo, domhi, delta, xlo, bc) bind(C, name="source_multi_fill")
 
     use amrex_filcc_module, only: amrex_filccn
 
@@ -83,6 +83,6 @@ contains
 
     call amrex_filccn(lo, hi, state, s_lo, s_hi, NVAR, domlo, domhi, delta, xlo, bc_temp)
 
-  end subroutine generic_multi_fill
+  end subroutine source_multi_fill
 
-end module generic_fill_module
+end module source_fill_module

--- a/Source/problems/Castro_bc_fill_nd.H
+++ b/Source/problems/Castro_bc_fill_nd.H
@@ -79,7 +79,6 @@ extern "C"
      const int* dlo, const int* dhi,
      const amrex::Real* dx, const amrex::Real* glo,
      const amrex::Real* time, const int* bc);
-
 #endif
 
 #ifdef ROTATION

--- a/Source/problems/bc_ext_fill_nd.F90
+++ b/Source/problems/bc_ext_fill_nd.F90
@@ -1098,7 +1098,7 @@ contains
 
   end subroutine ext_denfill
 
-
+#ifdef GRAVITY
   subroutine ext_gravxfill(lo, hi, grav, grav_lo, grav_hi, &
                            domlo, domhi, delta, xlo, time, bc) &
                            bind(C, name="ext_gravxfill")
@@ -1169,5 +1169,6 @@ contains
     ! this is currently a stub
 
   end subroutine ext_gravzfill
+#endif
 
 end module bc_ext_fill_module


### PR DESCRIPTION
and we now use the source for ... sources!  This makes it
easier to override them.  Also, add checks for external BCs
and set to outflow for all quantities.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

We were using the `generic_fill` stuff for filling the source terms,  But this is potentially bad, since we also use those routines for other state data.  This makes source filling its own set of routines.  I've also added checks on EXT_DIR and set to first-order extrapolate there to be sure we handle that case, e.g., with HSE BCs.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
