### PR TITLE
Castro error  wrapper

### DIFF
--- a/Exec/gravity_tests/DustCollapse/Prob_nd.F90
+++ b/Exec/gravity_tests/DustCollapse/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   use amrex_fort_module, only: rt => amrex_real
   use amrex_constants_module, only: ZERO, ONE
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use probdata_module, only: rho_0, T_0, X_0, p_0, rho_ambient, T_ambient, &
                              r_old, r_old_s, r_0, smooth_delta, r_offset, offset_smooth_delta, &
                              center_x, center_y, center_z, nsub
@@ -30,7 +30,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   character :: probin*(maxlen)
 
   if (namlen > maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen
@@ -76,9 +76,9 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 #endif
 #endif
 
-  if (problo(1) /= ZERO) call amrex_error("ERROR: xmin should be 0!")
-  if (problo(2) /= ZERO) call amrex_error("ERROR: ymin should be 0!")
-  if (problo(3) /= ZERO) call amrex_error("ERROR: zmin should be 0!")
+  if (problo(1) /= ZERO) call castro_error("ERROR: xmin should be 0!")
+  if (problo(2) /= ZERO) call castro_error("ERROR: ymin should be 0!")
+  if (problo(3) /= ZERO) call castro_error("ERROR: zmin should be 0!")
 
   ! set the composition to be uniform
   allocate(X_0(nspec))

--- a/Exec/gravity_tests/DustCollapse/bc_fill_nd.F90
+++ b/Exec/gravity_tests/DustCollapse/bc_fill_nd.F90
@@ -15,7 +15,7 @@ contains
     use amrex_filcc_module, only: amrex_filccn
     use amrex_constants_module, only: HALF
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use meth_params_module, only: NVAR,UMX,UMY,UMZ
     use prob_params_module, only: center
@@ -46,7 +46,7 @@ contains
     if ( (bc(1,1,1) == EXT_DIR .or. bc(1,2,1) == EXT_DIR) .or.  &
          (bc(2,1,1) == EXT_DIR .or. bc(2,2,1) == EXT_DIR) .or. &
          (bc(3,1,1) == EXT_DIR .or. bc(3,2,1) == EXT_DIR) ) then
-       call amrex_error("NOT SET UP FOR EXT_DIR BCs IN HYPFILL")
+       call castro_error("NOT SET UP FOR EXT_DIR BCs IN HYPFILL")
     end if
 #endif
 

--- a/Exec/gravity_tests/DustCollapse/update_sponge_params.f90
+++ b/Exec/gravity_tests/DustCollapse/update_sponge_params.f90
@@ -2,7 +2,7 @@ subroutine update_sponge_params(time) bind(C)
 
   use sponge_module
   use probdata_module, only: r_old_s
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 
   use amrex_fort_module, only : rt => amrex_real
   implicit none    
@@ -40,7 +40,7 @@ subroutine update_sponge_params(time) bind(C)
   enddo
     
   if (.not. converged) then
-     call amrex_error("Newton iterations failed to converge in update_sponge_params.")
+     call castro_error("Newton iterations failed to converge in update_sponge_params.")
   endif
   
   sponge_lower_radius = r + 2.5e7_rt

--- a/Exec/gravity_tests/StarGrav/Prob_nd.F90
+++ b/Exec/gravity_tests/StarGrav/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
   use prob_params_module, only : center
 
   use amrex_fort_module, only : rt => amrex_real
@@ -22,7 +22,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/gravity_tests/evrard_collapse/probdata.F90
+++ b/Exec/gravity_tests/evrard_collapse/probdata.F90
@@ -27,7 +27,7 @@ contains
   subroutine initialize(name, namlen)
 
     use amrex_constants_module, only: ZERO
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 
     use amrex_fort_module, only : rt => amrex_real
     implicit none

--- a/Exec/gravity_tests/hydrostatic_adjust/Prob_nd.F90
+++ b/Exec/gravity_tests/hydrostatic_adjust/Prob_nd.F90
@@ -1,7 +1,7 @@
 subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
 
   use amrex_constants_module
-  use amrex_error_module
+  use castro_error_module
   use probdata_module
   use prob_params_module, only: center
   use eos_module
@@ -35,7 +35,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   character (len=256) :: header_line
 
   if (namlen > maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen
@@ -83,7 +83,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   xmax = probhi(1)
 
   if (xmin /= 0.e0_rt) then
-     call amrex_error("ERROR: xmin should be 0!")
+     call castro_error("ERROR: xmin should be 0!")
   endif
 
   ymin = ZERO
@@ -94,7 +94,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
 #elif AMREX_SPACEDIM == 2
   xmin = problo(1)
   if (xmin /= 0.e0_rt) then
-     call amrex_error("ERROR: xmin should be 0!")
+     call castro_error("ERROR: xmin should be 0!")
   endif
 
   xmax = probhi(1)

--- a/Exec/gravity_tests/uniform_cube_sphere/Prob_nd.F90
+++ b/Exec/gravity_tests/uniform_cube_sphere/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module
   use probdata_module
   use amrex_constants_module
-  use amrex_error_module
+  use castro_error_module
   use fundamental_constants_module
   use eos_module
 
@@ -25,7 +25,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
 
   ! Build "probin" filename -- the name of file containing fortin namelist.
   if (namlen > maxlen) then
-     call amrex_error("ERROR: probin file name too long")
+     call castro_error("ERROR: probin file name too long")
   end if
 
   do i = 1, namlen
@@ -74,7 +74,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
                        delta, xlo, xhi)
 
   use amrex_constants_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
 
   use probdata_module
@@ -125,7 +125,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
 
            else
 
-              call amrex_error("Problem not defined.")
+              call castro_error("Problem not defined.")
 
            endif
 

--- a/Exec/hydro_tests/HCBubble/Prob_nd.F90
+++ b/Exec/hydro_tests/HCBubble/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
 
   use eos_module, only: eos
   use eos_type_module, only: eos_input_rt, eos_input_rp, eos_t
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use network, only: nspec
   use probdata_module, only: p_l, u_l, rho_l, p_r, u_r, rho_r, rhoe_l, rhoe_r, T_l, T_r, &
                              frac, idir, use_Tinit, xcloud, cldradius, split
@@ -26,7 +26,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   character :: probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen
@@ -60,7 +60,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   close(unit=untin)
 
   if (idir /= 1) then
-     call amrex_error('invalid idir')
+     call castro_error('invalid idir')
   end if
 
   split(:) = frac * (problo(:) + probhi(:))

--- a/Exec/hydro_tests/KH/Prob_nd.F90
+++ b/Exec/hydro_tests/KH/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
    use probdata_module
    use amrex_constants_module
-   use amrex_error_module
+   use castro_error_module
    use fundamental_constants_module
    use meth_params_module, only: small_temp, small_pres, small_dens
    
@@ -28,7 +28,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
    ! Build "probin" filename -- the name of file containing fortin namelist.
    if (namlen .gt. maxlen) then
-      call amrex_error("ERROR: probin file name too long")
+      call castro_error("ERROR: probin file name too long")
    end if
 
    do i = 1, namlen
@@ -87,7 +87,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
                        delta,xlo,xhi)
 
    use amrex_constants_module
-   use amrex_error_module
+   use castro_error_module
 
    use eos_module, only : eos
    use eos_type_module, only: eos_t, eos_input_rp
@@ -218,7 +218,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               
            else
 
-              call amrex_error("Error: This problem choice is undefined.")
+              call castro_error("Error: This problem choice is undefined.")
 
            endif
 

--- a/Exec/hydro_tests/RT/Prob_nd.F90
+++ b/Exec/hydro_tests/RT/Prob_nd.F90
@@ -1,7 +1,7 @@
 subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use probdata_module, only: frac, rho_1, rho_2, p0_base, split, L_x
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only : rt => amrex_real
 
   implicit none
@@ -19,7 +19,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   end if
 
   do i = 1, namlen

--- a/Exec/hydro_tests/Sedov/Prob_nd.F90
+++ b/Exec/hydro_tests/Sedov/Prob_nd.F90
@@ -5,7 +5,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use probdata_module, only: p_ambient, dens_ambient, exp_energy, temp_ambient, e_ambient, &
                              xn_zone, r_init, nsub, e_exp
   use prob_params_module, only: center, coord_type
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use eos_type_module, only: eos_t, eos_input_rt, eos_input_rp
   use eos_module, only: eos
   use network, only: nspec
@@ -30,7 +30,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character :: probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   end if
 
   do i = 1, namlen
@@ -103,7 +103,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 #if AMREX_SPACEDIM == 1
 
 #ifndef AMREX_USE_CUDA
-     call amrex_error("Sedov problem unsupported in 1D Cartesian geometry.")
+     call castro_error("Sedov problem unsupported in 1D Cartesian geometry.")
 #endif
 
 #elif AMREX_SPACEDIM == 2
@@ -133,7 +133,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 #else
 
 #ifndef AMREX_USE_CUDA
-     call amrex_error("Sedov problem unsupported in 3D axisymmetric geometry.")
+     call castro_error("Sedov problem unsupported in 3D axisymmetric geometry.")
 #endif
 
 #endif

--- a/Exec/hydro_tests/Sod/Prob_nd.F90
+++ b/Exec/hydro_tests/Sod/Prob_nd.F90
@@ -118,7 +118,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
                        state, s_lo, s_hi, &
                        dx, xlo, xhi)
 
-  use castro_error_module, only: amrex_abort
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only: rt => amrex_real
   use network, only: nspec
   use probdata_module
@@ -202,7 +202,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
               endif
               
            else
-              call amrex_abort('invalid idir')
+              call castro_error('invalid idir')
            endif
  
            state(i,j,k,UFS:UFS-1+nspec) = 0.0e0_rt

--- a/Exec/hydro_tests/Sod/Prob_nd.F90
+++ b/Exec/hydro_tests/Sod/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use eos_module
   use eos_type_module
-  use amrex_error_module 
+  use castro_error_module 
   use network
   use probdata_module
 
@@ -29,7 +29,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen
@@ -118,7 +118,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
                        state, s_lo, s_hi, &
                        dx, xlo, xhi)
 
-  use amrex_error_module, only: amrex_abort
+  use castro_error_module, only: amrex_abort
   use amrex_fort_module, only: rt => amrex_real
   use network, only: nspec
   use probdata_module

--- a/Exec/hydro_tests/Sod_stellar/Prob_nd.F90
+++ b/Exec/hydro_tests/Sod_stellar/Prob_nd.F90
@@ -120,7 +120,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   use probdata_module
   use meth_params_module, only: NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP, UFS
   use amrex_fort_module, only: rt => amrex_real
-  use castro_error_module, only: amrex_abort
+  use castro_error_module, only: castro_error
 
   implicit none
 
@@ -200,7 +200,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
               endif
               
            else
-              call amrex_abort('invalid idir')
+              call castro_error('invalid idir')
            endif
  
            state(i,j,k,UFS:UFS-1+nspec) = 0.0e0_rt

--- a/Exec/hydro_tests/Sod_stellar/Prob_nd.F90
+++ b/Exec/hydro_tests/Sod_stellar/Prob_nd.F90
@@ -2,11 +2,11 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use eos_module
   use eos_type_module
-  use amrex_error_module 
+  use castro_error_module 
   use network
   use probdata_module
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 
   implicit none
 
@@ -29,7 +29,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen
@@ -120,7 +120,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   use probdata_module
   use meth_params_module, only: NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP, UFS
   use amrex_fort_module, only: rt => amrex_real
-  use amrex_error_module, only: amrex_abort
+  use castro_error_module, only: amrex_abort
 
   implicit none
 

--- a/Exec/hydro_tests/Vortices_LWAcoustics/Prob_nd.F90
+++ b/Exec/hydro_tests/Vortices_LWAcoustics/Prob_nd.F90
@@ -1,6 +1,6 @@
 subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_constants_module
   use probdata_module
   use actual_eos_module, only : gamma_const
@@ -20,7 +20,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   integer, parameter :: maxlen = 256
   character probin*(maxlen)
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/hydro_tests/acoustic_pulse/Prob_nd.F90
+++ b/Exec/hydro_tests/acoustic_pulse/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module, only: ZERO, HALF, ONE
   use probdata_module, only: rho0, drho0, xn_zone
   use prob_params_module, only: center
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only: rt => amrex_real
 
   implicit none
@@ -21,7 +21,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character :: probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   end if
 
   do i = 1, namlen

--- a/Exec/hydro_tests/acoustic_pulse_general/Prob_nd.F90
+++ b/Exec/hydro_tests/acoustic_pulse_general/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module
   use probdata_module
   use prob_params_module, only : center
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   use eos_type_module, only : eos_t, eos_input_rt
   use eos_module, only : eos
@@ -25,7 +25,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character :: probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   end if
 
   do i = 1, namlen

--- a/Exec/hydro_tests/double_bubble/Prob_nd.F90
+++ b/Exec/hydro_tests/double_bubble/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use prob_params_module, only: center
   use probdata_module
-  use amrex_error_module
+  use castro_error_module
 
   use amrex_fort_module, only : rt => amrex_real
   implicit none
@@ -27,7 +27,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   single = .false.
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen
@@ -142,7 +142,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   if (.not. single) then
 
 #if AMREX_SPACEDIM == 1
-     call amrex_error("Error: 1-d not supported")
+     call castro_error("Error: 1-d not supported")
 
 #elif AMREX_SPACEDIM == 2
      x1 = left_bubble_x_center
@@ -223,7 +223,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   else
 
 #if AMREX_SPACEDIM == 1
-     call amrex_error("Error: 1-d not supported")
+     call castro_error("Error: 1-d not supported")
 #elif AMREX_SPACEDIM == 2
      x1 = left_bubble_x_center
      y1 = r_pert_center

--- a/Exec/hydro_tests/double_bubble/bc_ext_fill_nd.F90
+++ b/Exec/hydro_tests/double_bubble/bc_ext_fill_nd.F90
@@ -8,7 +8,7 @@ module bc_ext_fill_module
 
   use amrex_constants_module, only: ZERO, HALF, ONE, TWO
 #ifndef AMREX_USE_CUDA
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 #endif
   use amrex_fort_module, only: rt => amrex_real
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, &
@@ -28,7 +28,7 @@ contains
 
     use prob_params_module, only : problo, dim, center
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use network, only: nspec
     use probdata_module
@@ -75,11 +75,11 @@ contains
 
 #ifndef AMREX_USE_CUDA
     if (bc(1,1,n) == EXT_DIR .and. lo(1) < domlo(1)) then
-       call amrex_error("ERROR: HSE boundaries not implemented for -x BC")
+       call castro_error("ERROR: HSE boundaries not implemented for -x BC")
     endif
 
     if (bc(1,2,n) == EXT_DIR .and. hi(1) > domhi(1)) then
-       call amrex_error("ERROR: HSE boundaries not implemented for +x BC, d")
+       call castro_error("ERROR: HSE boundaries not implemented for +x BC, d")
     end if
 #endif
 
@@ -279,7 +279,7 @@ contains
 
     use prob_params_module, only: problo, center
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use probdata_module
     use model_module
@@ -330,11 +330,11 @@ contains
 
 #ifndef AMREX_USE_CUDA
     if (bc(1,1) == EXT_DIR .and. lo(1) < domlo(1)) then
-       call amrex_error("ERROR: HSE boundaries not implemented for -x BC")
+       call castro_error("ERROR: HSE boundaries not implemented for -x BC")
     endif
 
     if (bc(1,2) == EXT_DIR .and. hi(1) > domhi(1)) then
-       call amrex_error("ERROR: HSE boundaries not implemented for +x BC, d")
+       call castro_error("ERROR: HSE boundaries not implemented for +x BC, d")
     end if
 #endif
 

--- a/Exec/hydro_tests/double_mach_reflection/Prob_nd.F90
+++ b/Exec/hydro_tests/double_mach_reflection/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use eos_module
   use eos_type_module
-  use amrex_error_module
+  use castro_error_module
   use network
   use probdata_module
 
@@ -29,7 +29,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen
@@ -158,7 +158,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   integer  :: i, j, k, ii,jj
 
 #if AMREX_SPACEDIM == 1 || AMREX_SPACEDIM == 3
-  call amrex_error("ERROR: this problem only works for 2-d")
+  call castro_error("ERROR: this problem only works for 2-d")
 #endif
 
   do k = lo(3), hi(3)

--- a/Exec/hydro_tests/double_mach_reflection/bc_ext_fill_nd.F90
+++ b/Exec/hydro_tests/double_mach_reflection/bc_ext_fill_nd.F90
@@ -8,7 +8,7 @@ module bc_ext_fill_module
 
   use amrex_constants_module, only: ZERO, HALF, THREE, M_PI, FOURTH, SIXTH
 #ifndef AMREX_USE_CUDA
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 #endif
   use amrex_fort_module, only: rt => amrex_real
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, &
@@ -89,7 +89,7 @@ contains
     endif
 
     if (bc(1,2,1) == EXT_DIR .and. hi(1) > domhi(1)) then
-       call amrex_error("ERROR: special boundary not defined at +x")
+       call castro_error("ERROR: special boundary not defined at +x")
     end if
 
 #if AMREX_SPACEDIM >= 2
@@ -214,12 +214,12 @@ contains
 
     ! ZLO
     if (bc(3,1,1) == EXT_DIR .and. lo(3) < domlo(3)) then
-       call amrex_error("ERROR: -z special BCs not implemented")
+       call castro_error("ERROR: -z special BCs not implemented")
     endif
 
     ! ZHI
     if (bc(3,2,1) == EXT_DIR .and. hi(3) > domhi(3)) then
-       call amrex_error("ERROR: +z special BCs not implemented")
+       call castro_error("ERROR: +z special BCs not implemented")
     end if
 #endif
 
@@ -235,7 +235,7 @@ contains
     use prob_params_module, only: problo
     use model_parser_module, only: npts_model, model_r, model_state, idens_model
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use amrex_filcc_module, only: amrex_filccn
 
@@ -292,7 +292,7 @@ contains
     endif
 
     if (bc(1,2) == EXT_DIR .and. hi(1) > domhi(1)) then
-       call amrex_error("ERROR: special boundary not defined at +x")
+       call castro_error("ERROR: special boundary not defined at +x")
     end if
 
 #if AMREX_SPACEDIM >= 2
@@ -384,12 +384,12 @@ contains
 
     ! ZLO
     if (bc(3,1) == EXT_DIR .and. lo(3) < domlo(3)) then
-       call amrex_error("ERROR: -z special BCs not implemented")
+       call castro_error("ERROR: -z special BCs not implemented")
     endif
 
     ! ZHI
     if (bc(3,2) == EXT_DIR .and. hi(3) > domhi(3)) then
-       call amrex_error("ERROR: +z special BCs not implemented")
+       call castro_error("ERROR: +z special BCs not implemented")
     end if
 #endif
 

--- a/Exec/hydro_tests/gamma_law_bubble/Prob_nd.F90
+++ b/Exec/hydro_tests/gamma_law_bubble/Prob_nd.F90
@@ -1,6 +1,6 @@
 subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
-  use amrex_error_module
+  use castro_error_module
   use probdata_module
   use prob_params_module, only: center
 
@@ -22,7 +22,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/hydro_tests/gamma_law_bubble/bc_ext_fill_nd.F90
+++ b/Exec/hydro_tests/gamma_law_bubble/bc_ext_fill_nd.F90
@@ -8,7 +8,7 @@ module bc_ext_fill_module
 
   use amrex_constants_module, only: ZERO, HALF, ONE, TWO
 #ifndef AMREX_USE_CUDA
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 #endif
   use amrex_fort_module, only: rt => amrex_real
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, &
@@ -28,7 +28,7 @@ contains
 
     use prob_params_module, only : problo, dim, center
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use eos_module, only: eos
     use eos_type_module, only: eos_t, eos_input_rp
@@ -144,11 +144,11 @@ contains
 
 #ifndef AMREX_USE_CUDA
        if (bc(1,1,n) == EXT_DIR .and. lo(1) < domlo(1)) then
-          call amrex_error("ERROR: HSE boundaries not implemented for -x BC")
+          call castro_error("ERROR: HSE boundaries not implemented for -x BC")
        endif
 
        if (bc(1,2,n) == EXT_DIR .and. hi(1) > domhi(1)) then
-          call amrex_error("ERROR: HSE boundaries not implemented for +x BC, d")
+          call castro_error("ERROR: HSE boundaries not implemented for +x BC, d")
        end if
 #endif
 
@@ -365,7 +365,7 @@ contains
 
     use prob_params_module, only: problo, center
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use probdata_module
     use actual_eos_module, only : gamma_const
@@ -439,11 +439,11 @@ contains
 
 #ifndef AMREX_USE_CUDA
     if (bc(1,1) == EXT_DIR .and. lo(1) < domlo(1)) then
-       call amrex_error("ERROR: HSE boundaries not implemented for -x BC")
+       call castro_error("ERROR: HSE boundaries not implemented for -x BC")
     endif
 
     if (bc(1,2) == EXT_DIR .and. hi(1) > domhi(1)) then
-       call amrex_error("ERROR: HSE boundaries not implemented for +x BC, d")
+       call castro_error("ERROR: HSE boundaries not implemented for +x BC, d")
     end if
 #endif
 

--- a/Exec/hydro_tests/gresho_vortex/Prob_nd.F90
+++ b/Exec/hydro_tests/gresho_vortex/Prob_nd.F90
@@ -9,7 +9,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   use probdata_module, only: p0, rho0, t_r, nsub, x_r, q_r
   use prob_params_module, only: center
   use amrex_constants_module, only: M_pi
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only: rt => amrex_real
 
   implicit none
@@ -27,7 +27,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   character :: probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   end if
 
   do i = 1, namlen

--- a/Exec/hydro_tests/oddeven/Prob_nd.F90
+++ b/Exec/hydro_tests/oddeven/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
 
   use prob_params_module, only: center
   use probdata_module, only: p_ambient, dens_ambient, dens_pert_factor, vel_pert
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only: rt => amrex_real
 
   implicit none
@@ -20,7 +20,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   integer, parameter :: maxlen = 256
   character probin*(maxlen)
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/hydro_tests/riemann_test_zone/Prob_nd.F90
+++ b/Exec/hydro_tests/riemann_test_zone/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use amrex_mempool_module, only : bl_allocate, bl_deallocate
   use probdata_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_constants_module
   use riemann_module
   use meth_params_module
@@ -32,7 +32,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character :: probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   end if
 
   do i = 1, namlen
@@ -106,7 +106,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
                  [lo(1)-1, lo(2)-1, 0], [hi(1)+1, hi(2)+1, 0])
 
   ! we're done -- abort the code
-  call amrex_error("done with Riemann")
+  call castro_error("done with Riemann")
 
 end subroutine amrex_probinit
 

--- a/Exec/hydro_tests/symmetry/Prob_nd.F90
+++ b/Exec/hydro_tests/symmetry/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   use amrex_constants_module, only: HALF
   use probdata_module, only: rho_ambient, rho_peak, t_ambient, sigma
   use prob_params_module, only: center
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only : rt => amrex_real
 
   implicit none
@@ -21,7 +21,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   character :: probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   end if
 
   do i = 1, namlen

--- a/Exec/hydro_tests/test_convect/Prob_nd.F90
+++ b/Exec/hydro_tests/test_convect/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_paralleldescriptor_module, only: parallel_IOProcessor => amrex_pd_ioprocessor
 
   use amrex_fort_module, only : rt => amrex_real
@@ -25,7 +25,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   ! the name of file containing fortin namelist.
 
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))
@@ -98,7 +98,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UFS, UTEMP
   use network, only: nspec
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
@@ -116,7 +116,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   type (eos_t) :: eos_state
 
 #if AMREX_SPACEDIM == 3
-  call amrex_error("Error: 3-d initialization not implemented")
+  call castro_error("Error: 3-d initialization not implemented")
 #endif
 
   do k = lo(3), hi(3)

--- a/Exec/hydro_tests/toy_convect/Prob_nd.F90
+++ b/Exec/hydro_tests/toy_convect/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   use amrex_paralleldescriptor_module, only: parallel_IOProcessor => amrex_pd_ioprocessor
 
@@ -25,7 +25,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   ! Build "probin" filename from C++ land --
   ! the name of file containing fortin namelist.
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/radiation_tests/Rad2Tshock/Prob_nd.F90
+++ b/Exec/radiation_tests/Rad2Tshock/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   use probdata_module
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use eos_module
   use eos_type_module
 
@@ -20,7 +20,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   integer, parameter ::  maxlen = 256
   character probin*(maxlen)
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))
@@ -93,7 +93,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   use network, only : nspec, naux
   use eos_module, only : eos
   use eos_type_module, only : eos_t, eos_input_rt
-  use amrex_error_module
+  use castro_error_module
 
   use amrex_fort_module, only : rt => amrex_real
 
@@ -124,7 +124,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
            else if (idir == 3) then
               length_cell = zmin + delta(3) * (dble(k) + 0.5e0_rt)
            else
-              call amrex_error("Invalid direction please input idir = [1,3]")
+              call castro_error("Invalid direction please input idir = [1,3]")
            endif
 
 
@@ -211,7 +211,7 @@ subroutine ca_initrad(level, time, lo, hi, nrad, &
   use fundamental_constants_module, only: a_rad
   use rad_params_module, only : xnu
   use blackbody_module, only : BGroup
-  use amrex_error_module
+  use castro_error_module
 
   use amrex_fort_module, only : rt => amrex_real
 
@@ -243,7 +243,7 @@ subroutine ca_initrad(level, time, lo, hi, nrad, &
            else if (idir == 3) then
               length_cell = zmin + delta(3) * (dble(k) + 0.5e0_rt)
            else
-              call amrex_error("Invalid direction please input idir = [1,3]")
+              call castro_error("Invalid direction please input idir = [1,3]")
            endif
 
            if (length_cell < 0.e0_rt) then

--- a/Exec/radiation_tests/RadBreakout/Prob_nd.F90
+++ b/Exec/radiation_tests/RadBreakout/Prob_nd.F90
@@ -1,7 +1,7 @@
 subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amrex_probinit")
 
   use probdata_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
 
   implicit none
@@ -22,7 +22,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   end if
 
   do i = 1, namlen
@@ -56,7 +56,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   read(untin,*) npts_model
   read(untin,*) dummy
   if (npts_model > npts_max) then
-     call amrex_error('npts_max in probdata.f90 is too small')
+     call castro_error('npts_max in probdata.f90 is too small')
   end if
 
   do i = 1, npts_model
@@ -122,11 +122,11 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   type(eos_t) :: eos_state
 
   if (naux .ne. 2) then
-     call amrex_error("naux in network is not equal to 2")
+     call castro_error("naux in network is not equal to 2")
   end if
 
   if (nspec .ne. 1) then
-     call amrex_error("nspec in network is not equal to 1")
+     call castro_error("nspec in network is not equal to 1")
   end if
 
   dx_sub = delta(1) / dble(nsub)

--- a/Exec/radiation_tests/RadFront/Prob_nd.F90
+++ b/Exec/radiation_tests/RadFront/Prob_nd.F90
@@ -23,7 +23,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/radiation_tests/RadShestakovBolstad/Prob_nd.F90
+++ b/Exec/radiation_tests/RadShestakovBolstad/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   use probdata_module
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module
+  use castro_error_module
 
   implicit none
 
@@ -20,7 +20,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/radiation_tests/RadSlope/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSlope/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   use probdata_module
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module
+  use castro_error_module
 
   implicit none
 
@@ -19,7 +19,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/radiation_tests/RadSourceTest/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSourceTest/Prob_nd.F90
@@ -6,7 +6,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   use eos_type_module, only: eos_t, eos_input_re
   use network, only : nspec
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module, only : amrex_error
+  use castro_error_module, only : castro_error
 
   implicit none
 
@@ -27,7 +27,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/radiation_tests/RadSphere/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSphere/Prob_nd.F90
@@ -4,7 +4,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(C, name="amrex_pr
   use eos_module
   use eos_type_module, only : eos_t, eos_input_rt
   use network, only : nspec
-  use amrex_error_module
+  use castro_error_module
 
   use amrex_fort_module, only : rt => amrex_real
   implicit none
@@ -24,7 +24,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(C, name="amrex_pr
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   use probdata_module
   use actual_eos_module, only : gamma_const
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module
+  use castro_error_module
 
   implicit none
 
@@ -21,7 +21,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/radiation_tests/RadSuOlsonMG/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSuOlsonMG/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   use probdata_module
   use fundamental_constants_module, only : c_light, a_rad
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module
+  use castro_error_module
 
   implicit none
 
@@ -21,7 +21,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/radiation_tests/RadThermalWave/Prob_nd.F90
+++ b/Exec/radiation_tests/RadThermalWave/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module
   use probdata_module
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module
+  use castro_error_module
 
   implicit none
 
@@ -21,7 +21,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/reacting_tests/bubble_convergence/Prob_nd.F90
+++ b/Exec/reacting_tests/bubble_convergence/Prob_nd.F90
@@ -1,7 +1,7 @@
 subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use probdata_module
-  use amrex_error_module
+  use castro_error_module
   use initial_model_module, only : generate_initial_model, model_t
   use network, only : nspec, network_species_index
   use amrex_constants_module, only : ONE, HALF, ZERO
@@ -29,13 +29,13 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   ihe4 = network_species_index("helium-4")
   if (ihe4 < 0) then
-     call amrex_error("Error: helium-4 not present")
+     call castro_error("Error: helium-4 not present")
   end if
 
   ! Build "probin" filename from C++ land --
   ! the name of file containing fortin namelist.
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/reacting_tests/bubble_convergence/bc_ext_fill_nd.F90
+++ b/Exec/reacting_tests/bubble_convergence/bc_ext_fill_nd.F90
@@ -8,7 +8,7 @@ module bc_ext_fill_module
 
   use amrex_constants_module, only: ZERO, HALF, ONE, TWO
 #ifndef AMREX_USE_CUDA
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 #endif
   use amrex_fort_module, only: rt => amrex_real
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, &
@@ -67,13 +67,13 @@ contains
 
     ! XLO
     if (bc(1,1,1) == EXT_DIR .and. lo(1) < domlo(1)) then
-       call amrex_error("BCs not implemented for -X")
+       call castro_error("BCs not implemented for -X")
     endif
 
 
     ! XHI
     if (bc(1,2,1) == EXT_DIR .and. hi(1) > domhi(1)) then
-       call amrex_error("BCs not implemented for +X")
+       call castro_error("BCs not implemented for +X")
     endif
 
 
@@ -282,12 +282,12 @@ contains
 
     ! ZLO
     if (bc(3,1,1) == EXT_DIR .and. lo(3) < domlo(3)) then
-       call amrex_error("BCs not implemented for -Z")
+       call castro_error("BCs not implemented for -Z")
     endif
 
     ! ZHI
     if (bc(3,2,1) == EXT_DIR .and. hi(3) > domhi(3)) then
-       call amrex_error("BCs not implemented for +Z")
+       call castro_error("BCs not implemented for +Z")
     end if
 #endif
 
@@ -301,7 +301,7 @@ contains
     use prob_params_module, only: problo
     use model_parser_module, only: npts_model, model_r, model_state, idens_model
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use interpolate_module, only: interpolate_sub
     use amrex_filcc_module, only: amrex_filccn
@@ -331,12 +331,12 @@ contains
 #ifndef AMREX_USE_CUDA
     ! XLO
     if ( bc(1,1) == EXT_DIR .and. lo(1) < domlo(1)) then
-       call amrex_error("We should not be here (xlo denfill)")
+       call castro_error("We should not be here (xlo denfill)")
     end if
 
     ! XHI
     if ( bc(1,2) == EXT_DIR .and. hi(1) > domhi(1)) then
-       call amrex_error("We should not be here (xhi denfill)")
+       call castro_error("We should not be here (xhi denfill)")
     endif
 #endif
 

--- a/Exec/reacting_tests/bubble_convergence/initial_model.F90
+++ b/Exec/reacting_tests/bubble_convergence/initial_model.F90
@@ -23,7 +23,7 @@ contains
   subroutine generate_initial_model(nx, xmin, xmax, model_params, nbuf)
 
     use amrex_constants_module
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
 
     use eos_module, only: eos

--- a/Exec/reacting_tests/nse_test/Prob_nd.F90
+++ b/Exec/reacting_tests/nse_test/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module
   use probdata_module, only: T_min, T_max, rho_ambient, width, xn, fortin, cfrac, ofrac
   use network, only: network_species_index, nspec
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only: rt => amrex_real
   use eos_type_module, only: eos_t, eos_input_rt
   use eos_module, only: eos
@@ -28,7 +28,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   real(rt) :: smallx
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))
@@ -57,22 +57,22 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   io16 = network_species_index("oxygen-16")
 
   if (ihe4 < 0 .or. ic12 < 0 .or. io16 < 0) then
-     call amrex_error("ERROR: species indices not found")
+     call castro_error("ERROR: species indices not found")
   endif
 
   ! make sure that the carbon fraction falls between 0 and 1
   if (cfrac > 1.e0_rt .or. cfrac < 0.e0_rt) then
-     call amrex_error("ERROR: cfrac must fall between 0 and 1")
+     call castro_error("ERROR: cfrac must fall between 0 and 1")
   endif
 
   ! make sure that the oxygen fraction falls between 0 and 1
   if (ofrac > 1.e0_rt .or. cfrac < 0.e0_rt) then
-     call amrex_error("ERROR: ofrac must fall between 0 and 1")
+     call castro_error("ERROR: ofrac must fall between 0 and 1")
   endif
 
   ! make sure that the C/O fraction sums to no more than 1
   if (cfrac + ofrac > 1.e0_rt) then
-     call amrex_error("ERROR: cfrac + ofrac cannot exceed 1.")
+     call castro_error("ERROR: cfrac + ofrac cannot exceed 1.")
   end if
 
   ! set the default mass fractions

--- a/Exec/reacting_tests/reacting_bubble/Prob_nd.F90
+++ b/Exec/reacting_tests/reacting_bubble/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
 
   use amrex_fort_module, only : rt => amrex_real
   implicit none
@@ -21,7 +21,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   ! Build "probin" filename from C++ land --
   ! the name of file containing fortin namelist.
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/reacting_tests/reacting_bubble/initdata_others.f90
+++ b/Exec/reacting_tests/reacting_bubble/initdata_others.f90
@@ -385,7 +385,7 @@ subroutine ca_initdata_makemodel(model,model_size,MAESTRO_npts_model, &
            print *, dens_zone, temp_zone
            print *, p_want, entropy_want, entropy
            print *, drho, dtemp
-           call amrex_error('Error: HSE non-convergence')
+           call castro_error('Error: HSE non-convergence')
 
         endif
 

--- a/Exec/reacting_tests/reacting_convergence/Prob_nd.F90
+++ b/Exec/reacting_tests/reacting_convergence/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module
   use probdata_module
   use prob_params_module, only : center
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   use eos_type_module, only : eos_t, eos_input_rt
   use eos_module, only : eos
@@ -26,7 +26,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character :: probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   end if
 
   do i = 1, namlen

--- a/Exec/reacting_tests/toy_flame/Prob_nd.F90
+++ b/Exec/reacting_tests/toy_flame/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   use eos_module, only: eos
   use eos_type_module, only: eos_t, eos_input_rt
-  use amrex_error_module
+  use castro_error_module
   use network, only: nspec
   use probdata_module
   use extern_probin_module
@@ -30,7 +30,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/scf_tests/single_star/Prob_nd.F90
+++ b/Exec/scf_tests/single_star/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module
   use probdata_module
   use amrex_constants_module
-  use amrex_error_module
+  use castro_error_module
   use fundamental_constants_module
   use eos_module
 
@@ -25,7 +25,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
 
   ! Build "probin" filename -- the name of file containing fortin namelist.
   if (namlen > maxlen) then
-     call amrex_error("ERROR: probin file name too long")
+     call castro_error("ERROR: probin file name too long")
   end if
 
   do i = 1, namlen

--- a/Exec/science/Detonation/Prob_nd.F90
+++ b/Exec/science/Detonation/Prob_nd.F90
@@ -4,7 +4,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
                              xn, ihe4, ic12, io16, smallx, vel, fill_ambient_bc, &
                              ambient_dens, ambient_temp, ambient_comp, ambient_e_l, ambient_e_r
   use network, only: network_species_index, nspec
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only: rt => amrex_real
   use eos_type_module, only: eos_t, eos_input_rt
   use eos_module, only: eos
@@ -26,7 +26,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   integer, parameter :: maxlen = 256
   character :: probin*(maxlen)
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))
@@ -67,22 +67,22 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   io16 = network_species_index("oxygen-16")
 
   if (ihe4 < 0 .or. ic12 < 0 .or. io16 < 0) then
-     call amrex_error("ERROR: species indices not found")
+     call castro_error("ERROR: species indices not found")
   endif
 
   ! make sure that the carbon fraction falls between 0 and 1
   if (cfrac > 1.e0_rt .or. cfrac < 0.e0_rt) then
-     call amrex_error("ERROR: cfrac must fall between 0 and 1")
+     call castro_error("ERROR: cfrac must fall between 0 and 1")
   endif
 
   ! make sure that the oxygen fraction falls between 0 and 1
   if (ofrac > 1.e0_rt .or. cfrac < 0.e0_rt) then
-     call amrex_error("ERROR: ofrac must fall between 0 and 1")
+     call castro_error("ERROR: ofrac must fall between 0 and 1")
   endif
 
   ! make sure that the C/O fraction sums to no more than 1
   if (cfrac + ofrac > 1.e0_rt) then
-     call amrex_error("ERROR: cfrac + ofrac cannot exceed 1.")
+     call castro_error("ERROR: cfrac + ofrac cannot exceed 1.")
   end if
 
   ! set the default mass fractions

--- a/Exec/science/bwp-rad/Prob_nd.F90
+++ b/Exec/science/bwp-rad/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
   use prob_params_module, only : center
 
   use amrex_fort_module, only : rt => amrex_real
@@ -23,7 +23,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   character probin*(maxlen)
   character model*(maxlen)
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/science/convective_flame/Prob_nd.F90
+++ b/Exec/science/convective_flame/Prob_nd.F90
@@ -1,7 +1,7 @@
 subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   use amrex_constants_module
-  use amrex_error_module
+  use castro_error_module
   use initial_model_module
   use model_parser_module, only : model_r, model_state, npts_model, model_initialized
   use probdata_module
@@ -38,7 +38,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   real(rt) :: dx_model
   integer :: ng
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))
@@ -121,7 +121,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   if (.not. species_defined) then
      print *, ifuel1, ifuel2, ifuel3
      print *, iash1, iash2, iash3
-     call amrex_error("ERROR: species not defined")
+     call castro_error("ERROR: species not defined")
   endif
 
 
@@ -139,11 +139,11 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   ! check if they sum to 1
   if (abs(sum(model_params % xn_star) - ONE) > nspec*smallx) then
-     call amrex_error("ERROR: ash mass fractions don't sum to 1")
+     call castro_error("ERROR: ash mass fractions don't sum to 1")
   endif
 
   if (abs(sum(model_params % xn_base) - ONE) > nspec*smallx) then
-     call amrex_error("ERROR: fuel mass fractions don't sum to 1")
+     call castro_error("ERROR: fuel mass fractions don't sum to 1")
   endif
 
   ! we are going to generate an initial model from problo(2) to
@@ -266,7 +266,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
               r = sqrt(x**2 + y**2)
               height = z
            else
-              call amrex_error("ERROR: problem not setup for 1D")
+              call castro_error("ERROR: problem not setup for 1D")
            end if
 
            if (r < x_half_max) then

--- a/Exec/science/convective_flame/initial_model.f90
+++ b/Exec/science/convective_flame/initial_model.f90
@@ -112,7 +112,7 @@ contains
   subroutine init_1d_tanh(nx, xmin, xmax, model_params, model_num)
 
     use amrex_constants_module
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
 
     use eos_module, only: eos
@@ -192,7 +192,7 @@ contains
 
     if (index_base == -1) then
        print *, 'ERROR: base_height not found on grid'
-       call amrex_error('ERROR: invalid base_height')
+       call castro_error('ERROR: invalid base_height')
     endif
 
 
@@ -443,7 +443,7 @@ contains
              print *, dens_zone, temp_zone
              print *, p_want, entropy_base, entropy
              print *, drho, dtemp
-             call amrex_error('Error: HSE non-convergence')
+             call castro_error('Error: HSE non-convergence')
 
           endif
 
@@ -548,7 +548,7 @@ contains
           print *, dens_zone, temp_zone
           print *, p_want
           print *, drho
-          call amrex_error('Error: HSE non-convergence')
+          call castro_error('Error: HSE non-convergence')
 
        endif
 

--- a/Exec/science/flame/Prob_nd.F90
+++ b/Exec/science/flame/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   use eos_module
   use eos_type_module
-  use amrex_error_module
+  use castro_error_module
   use network
   use probdata_module
   use extern_probin_module
@@ -37,7 +37,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   character probin*(maxlen)
 
   if (namlen .gt. maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   end if
 
   do i = 1, namlen
@@ -101,7 +101,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   iash4 = network_species_index(ash4_name)
 
   if (iash1 < 0 .and. iash2 < 0 .and. iash3 < 0 .and. iash4 < 0) then
-     call amrex_error("no valid ash state defined")
+     call castro_error("no valid ash state defined")
   endif
 
   ! fuel state
@@ -208,7 +208,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   use eos_type_module
   use eos_module
   use amrex_constants_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   use conservative_map_module, only : interpolate_conservative, interpolate_avg_to_center
 

--- a/Exec/science/flame_wave/Prob_nd.F90
+++ b/Exec/science/flame_wave/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
 
   use amrex_fort_module, only: rt => amrex_real
   use amrex_constants_module, only: ZERO, ONE, HALF
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use model_parser_module, only: model_parser_init
   use initial_model_module, only: model_t, init_model_data, gen_model_r, gen_model_state, init_1d_tanh
   use probdata_module, only: dx_model, dtemp, x_half_max, x_half_width, &
@@ -49,7 +49,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   integer :: nx_model
   integer :: ng
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))
@@ -115,7 +115,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   ! check to make sure that small_dens is less than low_density_cutoff
   ! if not, funny things can happen above the atmosphere
   if (small_dens >= 0.99_rt * low_density_cutoff) then
-     call amrex_error("ERROR: small_dens should be set lower than low_density_cutoff")
+     call castro_error("ERROR: small_dens should be set lower than low_density_cutoff")
   end if
 
   ! get the species indices
@@ -149,7 +149,7 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   if (.not. species_defined) then
      print *, ifuel1, ifuel2, ifuel3
      print *, iash1, iash2, iash3
-     call amrex_error("ERROR: species not defined")
+     call castro_error("ERROR: species not defined")
   endif
 
 
@@ -167,11 +167,11 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
 
   ! check if they sum to 1
   if (abs(sum(model_params % xn_star) - ONE) > nspec*smallx) then
-     call amrex_error("ERROR: ash mass fractions don't sum to 1")
+     call castro_error("ERROR: ash mass fractions don't sum to 1")
   endif
 
   if (abs(sum(model_params % xn_base) - ONE) > nspec*smallx) then
-     call amrex_error("ERROR: fuel mass fractions don't sum to 1")
+     call castro_error("ERROR: fuel mass fractions don't sum to 1")
   endif
 
   ! we are going to generate an initial model from problo(2) to
@@ -231,7 +231,7 @@ subroutine ca_initdata(lo, hi, &
   use amrex_fort_module, only: rt => amrex_real
   use amrex_constants_module, only: ZERO, HALF, ONE
 #ifndef AMREX_USE_CUDA
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 #endif
   use probdata_module, only: x_half_width, x_half_max
   use eos_module, only: eos
@@ -277,7 +277,7 @@ subroutine ca_initdata(lo, hi, &
               height = z
 #ifndef AMREX_USE_CUDA
            else
-              call amrex_error("ERROR: problem not setup for 1D")
+              call castro_error("ERROR: problem not setup for 1D")
 #endif
            end if
 

--- a/Exec/science/flame_wave/initial_model.F90
+++ b/Exec/science/flame_wave/initial_model.F90
@@ -118,7 +118,7 @@ contains
   subroutine init_1d_tanh(nx, xmin, xmax, model_params, model_num)
 
     use amrex_constants_module
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
 
     use eos_module, only: eos
@@ -194,7 +194,7 @@ contains
 
     if (index_base == -1) then
        print *, 'ERROR: base_height not found on grid'
-       call amrex_error('ERROR: invalid base_height')
+       call castro_error('ERROR: invalid base_height')
     endif
 
 
@@ -443,7 +443,7 @@ contains
              print *, dens_zone, temp_zone
              print *, p_want, entropy_base, entropy
              print *, drho, dtemp
-             call amrex_error('Error: HSE non-convergence')
+             call castro_error('Error: HSE non-convergence')
 
           endif
 
@@ -548,7 +548,7 @@ contains
           print *, dens_zone, temp_zone
           print *, p_want
           print *, drho
-          call amrex_error('Error: HSE non-convergence')
+          call castro_error('Error: HSE non-convergence')
 
        endif
 

--- a/Exec/science/nova/Prob_nd.F90
+++ b/Exec/science/nova/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
 
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_paralleldescriptor_module, only: parallel_IOProcessor => amrex_pd_ioprocessor
 
   use amrex_fort_module, only : rt => amrex_real
@@ -25,7 +25,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   ! the name of file containing fortin namelist.
 
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/science/planet/Prob_nd.F90
+++ b/Exec/science/planet/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use amrex_paralleldescriptor_module, only: parallel_IOProcessor => amrex_pd_ioprocessor
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_constants_module
 
   use amrex_fort_module, only : rt => amrex_real
@@ -32,7 +32,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   ! the name of file containing fortin namelist.
 
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/science/rotating_star/Prob_nd.F90
+++ b/Exec/science/rotating_star/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C)
 
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
   use prob_params_module, only : center
   use amrex_constants_module, only : ZERO, HALF
   use amrex_fort_module, only : rt => amrex_real
@@ -25,7 +25,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C)
   character probin*(maxlen)
   character model*(maxlen)
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/science/subchandra/Prob_nd.F90
+++ b/Exec/science/subchandra/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C)
 
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
   use prob_params_module, only : center
   use amrex_constants_module, only : ZERO, HALF
   use amrex_fort_module, only : rt => amrex_real
@@ -25,7 +25,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C)
   character probin*(maxlen)
   character model*(maxlen)
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/science/wdmerger/Problem.f90
+++ b/Exec/science/wdmerger/Problem.f90
@@ -5,7 +5,7 @@ subroutine problem_checkpoint(int_dir_name, len) bind(C, name="problem_checkpoin
   ! called by the IO processor during checkpoint
 
   use amrex_IO_module
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use probdata_module, only: com_P, com_S, vel_P, vel_S, mass_P, mass_S, t_ff_P, t_ff_S, &
                              T_global_max, rho_global_max, ts_te_global_max
   use prob_params_module, only: center
@@ -120,7 +120,7 @@ subroutine problem_restart(int_dir_name, len) bind(C, name="problem_restart")
   use problem_io_module, only: ioproc
   use prob_params_module, only: center
   use meth_params_module, only: rot_period
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 
   implicit none
 
@@ -236,7 +236,7 @@ subroutine problem_restart(int_dir_name, len) bind(C, name="problem_restart")
   else
 
      if (problem == 1) then
-        call amrex_error("Error: no Relaxation file found in the checkpoint.")
+        call castro_error("Error: no Relaxation file found in the checkpoint.")
      endif
 
   endif

--- a/Exec/science/wdmerger/binary.f90
+++ b/Exec/science/wdmerger/binary.f90
@@ -117,7 +117,7 @@ contains
   subroutine lagrange_iterate(r, mass_1, mass_2, r1, r2, a, r_min, r_max)
 
     use amrex_constants_module, only: ZERO, HALF
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
     
     implicit none
 
@@ -138,7 +138,7 @@ contains
     integer  :: i
 
     if (.not. (present(r_min) .or. present(r_max))) then
-       call amrex_error("Lagrange point iteration must have at least one bound provided.")
+       call castro_error("Lagrange point iteration must have at least one bound provided.")
     else if (present(r_min) .and. present(r_max)) then
        rm = r_min
        rp = r_max

--- a/Exec/science/wdmerger/initial_model.F90
+++ b/Exec/science/wdmerger/initial_model.F90
@@ -6,7 +6,7 @@ module initial_model_module
 
   use amrex_fort_module, only: rt => amrex_real
   use amrex_constants_module
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use eos_type_module, only: eos_t, eos_input_rt
   use network, only: nspec
   use model_parser_module, only: itemp_model, idens_model, ipres_model, ispec_model
@@ -149,7 +149,7 @@ contains
     ! Check to make sure we've specified at least one of them.
 
     if (model % mass < ZERO .and. model % central_density < ZERO) then
-       call amrex_error('Error: Must specify either mass or central density in the initial model generator.')
+       call castro_error('Error: Must specify either mass or central density in the initial model generator.')
     endif
 
     ! If we are specifying the mass, then we don't know what WD central density
@@ -180,7 +180,7 @@ contains
     ! Check to make sure the initial temperature makes sense.
 
     if (model % central_temp < small_temp) then
-       call amrex_error("Error: WD central temperature is less than small_temp. Aborting.")
+       call castro_error("Error: WD central temperature is less than small_temp. Aborting.")
     endif
 
     mass_converged = .false.
@@ -286,7 +286,7 @@ contains
              print *, rho(i), T(i)
              print *, p_want, model % state(i) % p
              print *, drho, model % hse_tol * rho(i)
-             call amrex_error('Error: HSE non-convergence.')
+             call castro_error('Error: HSE non-convergence.')
 
           endif
 
@@ -336,7 +336,7 @@ contains
     enddo  ! End mass constraint loop
 
     if (.not. mass_converged .and. max_mass_iter .gt. 1) then
-       call amrex_error("ERROR: WD mass did not converge.")
+       call castro_error("ERROR: WD mass did not converge.")
     endif
 
     model % central_density = rho(1)

--- a/Exec/science/wdmerger/wdmerger_util.F90
+++ b/Exec/science/wdmerger/wdmerger_util.F90
@@ -12,7 +12,7 @@ contains
 
   subroutine initialize_problem(init_in)
 
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
     use prob_params_module, only: dim
 
     implicit none
@@ -46,7 +46,7 @@ contains
     use meth_params_module
     use prob_params_module, only: dim, coord_type
     use problem_io_module, only: probin
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
     use network, only: nspec
     use fundamental_constants_module, only: M_solar
 
@@ -330,7 +330,7 @@ contains
     if (dim .eq. 2) then
 
        if (coord_type .ne. 1) then
-          call amrex_error("We only support cylindrical coordinates in two dimensions. Set coord_type == 1.")
+          call castro_error("We only support cylindrical coordinates in two dimensions. Set coord_type == 1.")
        endif
 
        axis_1 = 2
@@ -342,35 +342,35 @@ contains
     ! Make sure we have a sensible collision impact parameter.
 
     if (collision_impact_parameter > 1.0) then
-       call amrex_error("Impact parameter must be less than one in our specified units.")
+       call castro_error("Impact parameter must be less than one in our specified units.")
     endif
 
     ! Safety check: we can't run most problems in one dimension.
 
     if (dim .eq. 1 .and. problem /= 0) then
-       call amrex_error("Can only run a collision or freefall in 1D. Exiting.")
+       call castro_error("Can only run a collision or freefall in 1D. Exiting.")
     endif
 
     ! Don't do a collision, free-fall, or TDE in a rotating reference frame.
 
     if (problem .eq. 0 .and. do_rotation .eq. 1) then
-       call amrex_error("The free-fall/collision problem does not make sense in a rotating reference frame.")
+       call castro_error("The free-fall/collision problem does not make sense in a rotating reference frame.")
     endif
 
     if (problem .eq. 2 .and. do_rotation .eq. 1) then
-       call amrex_error("The TDE problem does not make sense in a rotating reference frame.")
+       call castro_error("The TDE problem does not make sense in a rotating reference frame.")
     end if
 
     ! Make sure we have a sensible eccentricity.
 
     if (orbital_eccentricity >= 1.0) then
-       call amrex_error("Orbital eccentricity cannot be larger than one.")
+       call castro_error("Orbital eccentricity cannot be larger than one.")
     endif
 
     ! Make sure we have a sensible angle. Then convert it to radians.
 
     if (orbital_angle < 0.0 .or. orbital_angle > 360.0) then
-       call amrex_error("Orbital angle must be between 0 and 360 degrees.")
+       call castro_error("Orbital angle must be between 0 and 360 degrees.")
     endif
 
     orbital_angle = orbital_angle * M_PI / 180.0
@@ -390,7 +390,7 @@ contains
 
        if (point_mass <= ZERO) then
 
-          call amrex_error("No point mass specified for the TDE problem.")
+          call castro_error("No point mass specified for the TDE problem.")
 
        end if
 
@@ -398,7 +398,7 @@ contains
 
        if (mass_S >= ZERO) then
 
-          call amrex_error("TDE problem cannot have a secondary WD.")
+          call castro_error("TDE problem cannot have a secondary WD.")
 
        end if
 
@@ -406,7 +406,7 @@ contains
 
        if (tde_beta <= ZERO) then
 
-          call amrex_error("TDE beta must be positive.")
+          call castro_error("TDE beta must be positive.")
 
        end if
 
@@ -414,7 +414,7 @@ contains
 
        if (tde_separation <= ZERO) then
 
-          call amrex_error("TDE separation must be positive.")
+          call castro_error("TDE separation must be positive.")
 
        end if
 
@@ -484,7 +484,7 @@ contains
 
     use extern_probin_module, only: small_x
     use network, only: network_species_index
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
     use amrex_constants_module, only: ZERO, ONE
 
     implicit none
@@ -508,7 +508,7 @@ contains
 
     if (model % mass > ZERO .and. model % mass < max_he_wd_mass) then
 
-       if (iHe4 < 0) call amrex_error("Must have He4 in the nuclear network.")
+       if (iHe4 < 0) call castro_error("Must have He4 in the nuclear network.")
 
        model % core_comp(iHe4) = ONE
 
@@ -516,8 +516,8 @@ contains
 
     else if (model % mass >= max_he_wd_mass .and. model % mass < max_hybrid_wd_mass) then
 
-       if (iC12 < 0) call amrex_error("Must have C12 in the nuclear network.")
-       if (iO16 < 0) call amrex_error("Must have O16 in the nuclear network.")
+       if (iC12 < 0) call castro_error("Must have C12 in the nuclear network.")
+       if (iO16 < 0) call castro_error("Must have O16 in the nuclear network.")
 
        model % core_comp(iC12) = hybrid_wd_c_frac
        model % core_comp(iO16) = hybrid_wd_o_frac
@@ -525,7 +525,7 @@ contains
        model % envelope_mass = hybrid_wd_he_shell_mass
 
        if (model % envelope_mass > ZERO) then
-          if (iHe4 < 0) call amrex_error("Must have He4 in the nuclear network.")
+          if (iHe4 < 0) call castro_error("Must have He4 in the nuclear network.")
           model % envelope_comp(iHe4) = ONE
        else
           model % envelope_comp = model % core_comp
@@ -533,8 +533,8 @@ contains
 
     else if (model % mass >= max_hybrid_wd_mass .and. model % mass < max_co_wd_mass) then
 
-       if (iC12 < 0) call amrex_error("Must have C12 in the nuclear network.")
-       if (iO16 < 0) call amrex_error("Must have O16 in the nuclear network.")
+       if (iC12 < 0) call castro_error("Must have C12 in the nuclear network.")
+       if (iO16 < 0) call castro_error("Must have O16 in the nuclear network.")
 
        model % core_comp(iC12) = co_wd_c_frac
        model % core_comp(iO16) = co_wd_o_frac
@@ -542,7 +542,7 @@ contains
        model % envelope_mass = co_wd_he_shell_mass
 
        if (model % envelope_mass > ZERO) then
-          if (iHe4 < 0) call amrex_error("Must have He4 in the nuclear network.")
+          if (iHe4 < 0) call castro_error("Must have He4 in the nuclear network.")
           model % envelope_comp(iHe4) = ONE
        else
           model % envelope_comp = model % core_comp
@@ -550,9 +550,9 @@ contains
 
     else if (model % mass > max_co_wd_mass) then
 
-       if (iO16 < 0) call amrex_error("Must have O16 in the nuclear network.")
-       if (iNe20 < 0) call amrex_error("Must have Ne20 in the nuclear network.")
-       if (iMg24 < 0) call amrex_error("Must have Mg24 in the nuclear network.")
+       if (iO16 < 0) call castro_error("Must have O16 in the nuclear network.")
+       if (iNe20 < 0) call castro_error("Must have Ne20 in the nuclear network.")
+       if (iMg24 < 0) call castro_error("Must have Mg24 in the nuclear network.")
 
        model % core_comp(iO16)  = onemg_wd_o_frac
        model % core_comp(iNe20) = onemg_wd_ne_frac
@@ -708,7 +708,7 @@ contains
     use math_module, only: cross_product
     use binary_module, only: get_roche_radii
     use problem_io_module, only: ioproc
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
     use fundamental_constants_module, only: Gconst, c_light, AU, M_solar
     use amrex_constants_module, only: ZERO, THIRD, HALF, ONE, TWO
 
@@ -789,7 +789,7 @@ contains
 
     else
 
-       call amrex_error("Must specify either a positive primary mass or a positive primary central density.")
+       call castro_error("Must specify either a positive primary mass or a positive primary central density.")
 
     endif
 
@@ -817,7 +817,7 @@ contains
 
        else
 
-          call amrex_error("If we are doing a binary calculation, we must specify either a " // &
+          call castro_error("If we are doing a binary calculation, we must specify either a " // &
                            "positive secondary mass or a positive secondary central density.")
 
        endif
@@ -963,7 +963,7 @@ contains
 
        else
 
-          call amrex_error("Error: Unknown problem choice.")
+          call castro_error("Error: Unknown problem choice.")
 
        endif
 
@@ -1078,7 +1078,7 @@ contains
     use sponge_module, only: sponge_lower_radius
     use meth_params_module, only: do_sponge
     use fundamental_constants_module, only: Gconst
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 
     implicit none
 
@@ -1112,7 +1112,7 @@ contains
 
     else
 
-       call amrex_error("Error: overspecified Kepler's third law calculation.")
+       call castro_error("Error: overspecified Kepler's third law calculation.")
 
     endif
 
@@ -1151,7 +1151,7 @@ contains
     end if
 
     if (length > (probhi(axis_1)-problo(axis_1))) then
-       call amrex_error("ERROR: The domain width is too small to include the binary orbit.")
+       call castro_error("ERROR: The domain width is too small to include the binary orbit.")
     endif
 
     ! We want to do a similar check to make sure that no part of the stars
@@ -1160,18 +1160,18 @@ contains
     if (do_sponge .eq. 1 .and. sponge_lower_radius > ZERO) then
 
        if (abs(r_1) + radius_1 .ge. sponge_lower_radius) then
-          call amrex_error("ERROR: Primary contains material inside the sponge region.")
+          call castro_error("ERROR: Primary contains material inside the sponge region.")
        endif
 
        if (abs(r_2) + radius_2 .ge. sponge_lower_radius) then
-          call amrex_error("ERROR: Secondary contains material inside the sponge region.")
+          call castro_error("ERROR: Secondary contains material inside the sponge region.")
        endif
 
     endif
 
     ! Make sure the stars are not touching.
     if (radius_1 + radius_2 > a) then
-       call amrex_error("ERROR: Stars are touching!")
+       call castro_error("ERROR: Stars are touching!")
     endif
 
   end subroutine kepler_third_law
@@ -2189,7 +2189,7 @@ contains
   subroutine update_center(time) bind(C,name='update_center')
 
     use amrex_constants_module, only: ZERO
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
     use probdata_module, only: bulk_velx, bulk_vely, bulk_velz, &
                                center_fracx, center_fracy, center_fracz
     use prob_params_module, only: center, problo, probhi, dim
@@ -2220,7 +2220,7 @@ contains
 
     else
 
-       call amrex_error("Error: unknown dim in subroutine update_center.")
+       call castro_error("Error: unknown dim in subroutine update_center.")
 
     endif
 

--- a/Exec/science/xrb_mixed/Prob_nd.F90
+++ b/Exec/science/xrb_mixed/Prob_nd.F90
@@ -3,7 +3,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module
   use probdata_module
   use model_parser_module
-  use amrex_error_module
+  use castro_error_module
 
   use amrex_fort_module, only : rt => amrex_real
   implicit none
@@ -25,7 +25,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   ! Build "probin" filename from C++ land --
   ! the name of file containing fortin namelist.
 
-  if (namlen .gt. maxlen) call amrex_error("probin file name too long")
+  if (namlen .gt. maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))
@@ -131,7 +131,7 @@ subroutine ca_initdata(level,time, lo, hi, nscal, &
 #elif AMREX_SPACEDIM == 3
            height = z
 #else
-           call amrex_error("invalid dimensionality")
+           call castro_error("invalid dimensionality")
 #endif
 
            call interpolate_sub(state(i,j,k,URHO), height, idens_model)

--- a/Exec/unit_tests/diffusion_test/Prob_nd.F90
+++ b/Exec/unit_tests/diffusion_test/Prob_nd.F90
@@ -1,7 +1,7 @@
 subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
 
   use amrex_constants_module, only: ZERO, HALF
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only : rt => amrex_real
   use prob_params_module, only: center, coord_type
   use probdata_module
@@ -29,7 +29,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/unit_tests/particles_test/Prob_nd.F90
+++ b/Exec/unit_tests/particles_test/Prob_nd.F90
@@ -1,7 +1,7 @@
 subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
 
   use amrex_constants_module, only: ZERO, HALF
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
 
   use prob_params_module, only: center, coord_type
@@ -22,7 +22,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   integer, parameter :: maxlen = 256
   character probin*(maxlen)
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))

--- a/Exec/unit_tests/reactions_driver_test/Prob_nd.F90
+++ b/Exec/unit_tests/reactions_driver_test/Prob_nd.F90
@@ -1,6 +1,6 @@
 subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   use model_parser_module, only: read_model_file
   use probdata_module
@@ -18,7 +18,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   integer, parameter :: maxlen = 256
   character (len=maxlen) :: probin
 
-  if (namlen > maxlen) call amrex_error("probin file name too long")
+  if (namlen > maxlen) call castro_error("probin file name too long")
 
   do i = 1, namlen
      probin(i:i) = char(name(i))
@@ -39,7 +39,7 @@ subroutine ca_initdata(level,time,lo,hi,nvar, &
      state,state_lo,state_hi, &
      dx,xlo,xhi) 
 
-  use amrex_error_module
+  use castro_error_module
 
   use amrex_fort_module, only : rt => amrex_real
   use amrex_constants_module, only: ZERO
@@ -63,7 +63,7 @@ subroutine ca_initdata(level,time,lo,hi,nvar, &
   ! Check to make sure model is initialized
   if (.not. model_initialized) then
 #if !(defined(CUDA) || defined(ACC))
-     call amrex_error("Model has not been initialized")
+     call castro_error("Model has not been initialized")
 #endif
   endif
 

--- a/Microphysics/EOS/eos.F90
+++ b/Microphysics/EOS/eos.F90
@@ -14,7 +14,7 @@ contains
   subroutine eos_init(small_temp, small_dens)
 
     use amrex_fort_module, only: rt => amrex_real
-    use amrex_error_module
+    use castro_error_module
     use amrex_paralleldescriptor_module, only : amrex_pd_ioprocessor
     use eos_type_module, only: mintemp, mindens, maxtemp, maxdens, &
                                minx, maxx, minye, maxye, mine, maxe, &
@@ -126,7 +126,7 @@ contains
     use actual_eos_module, only: actual_eos
     use eos_override_module, only: eos_override
 #if (!(defined(AMREX_USE_CUDA) || defined(AMREX_USE_ACC)))
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
 
     implicit none
@@ -143,7 +143,7 @@ contains
     ! Local variables
 
 #if (!(defined(AMREX_USE_CUDA) || defined(AMREX_USE_ACC)))
-    if (.not. initialized) call amrex_error('EOS: not initialized')
+    if (.not. initialized) call castro_error('EOS: not initialized')
 #endif
 
     ! Get abar, zbar, etc.
@@ -383,7 +383,7 @@ contains
 #if (!(defined(AMREX_USE_CUDA) || defined(AMREX_USE_ACC)))
   subroutine check_inputs(input, state)
 
-    use amrex_error_module
+    use castro_error_module
     use network, only: nspec
     use eos_type_module, only: eos_t, print_state, minx, maxx, minye, maxye, &
                                eos_input_rt, eos_input_re, eos_input_rp, eos_input_rh, &
@@ -401,19 +401,19 @@ contains
     do n = 1, nspec
        if (state % xn(n) .lt. minx) then
           call print_state(state)
-          call amrex_error('EOS: mass fraction less than minimum possible mass fraction.')
+          call castro_error('EOS: mass fraction less than minimum possible mass fraction.')
        else if (state % xn(n) .gt. maxx) then
           call print_state(state)
-          call amrex_error('EOS: mass fraction more than maximum possible mass fraction.')
+          call castro_error('EOS: mass fraction more than maximum possible mass fraction.')
        endif
     enddo
 
     if (state % y_e .lt. minye) then
        call print_state(state)
-       call amrex_error('EOS: y_e less than minimum possible electron fraction.')
+       call castro_error('EOS: y_e less than minimum possible electron fraction.')
     else if (state % y_e .gt. maxye) then
        call print_state(state)
-       call amrex_error('EOS: y_e greater than maximum possible electron fraction.')
+       call castro_error('EOS: y_e greater than maximum possible electron fraction.')
     endif
 
     if (input .eq. eos_input_rt) then
@@ -464,7 +464,7 @@ contains
 
   subroutine check_rho(state)
 
-    use amrex_error_module
+    use castro_error_module
     use eos_type_module, only: eos_t, mindens, maxdens, print_state
 
     implicit none
@@ -473,10 +473,10 @@ contains
 
     if (state % rho .lt. mindens) then
        call print_state(state)
-       call amrex_error('EOS: rho smaller than mindens.')
+       call castro_error('EOS: rho smaller than mindens.')
     else if (state % rho .gt. maxdens) then
        call print_state(state)
-       call amrex_error('EOS: rho greater than maxdens.')
+       call castro_error('EOS: rho greater than maxdens.')
     endif
 
   end subroutine check_rho
@@ -485,7 +485,7 @@ contains
 
   subroutine check_T(state)
 
-    use amrex_error_module
+    use castro_error_module
     use eos_type_module, only: eos_t, mintemp, maxtemp, print_state
 
     implicit none
@@ -494,10 +494,10 @@ contains
 
     if (state % T .lt. mintemp) then
        call print_state(state)
-       call amrex_error('EOS: T smaller than mintemp.')
+       call castro_error('EOS: T smaller than mintemp.')
     else if (state % T .gt. maxtemp) then
        call print_state(state)
-       call amrex_error('EOS: T greater than maxtemp.')
+       call castro_error('EOS: T greater than maxtemp.')
     endif
 
   end subroutine check_T
@@ -506,7 +506,7 @@ contains
 
   subroutine check_e(state)
 
-    use amrex_error_module
+    use castro_error_module
     use eos_type_module, only: eos_t, mine, maxe, print_state
 
     implicit none
@@ -515,10 +515,10 @@ contains
 
     if (state % e .lt. mine) then
        call print_state(state)
-       call amrex_error('EOS: e smaller than mine.')
+       call castro_error('EOS: e smaller than mine.')
     else if (state % e .gt. maxe) then
        call print_state(state)
-       call amrex_error('EOS: e greater than maxe.')
+       call castro_error('EOS: e greater than maxe.')
     endif
 
   end subroutine check_e
@@ -527,7 +527,7 @@ contains
 
   subroutine check_h(state)
 
-    use amrex_error_module
+    use castro_error_module
     use eos_type_module, only: eos_t, minh, maxh, print_state
 
     implicit none
@@ -536,10 +536,10 @@ contains
 
     if (state % h .lt. minh) then
        call print_state(state)
-       call amrex_error('EOS: h smaller than minh.')
+       call castro_error('EOS: h smaller than minh.')
     else if (state % h .gt. maxh) then
        call print_state(state)
-       call amrex_error('EOS: h greater than maxh.')
+       call castro_error('EOS: h greater than maxh.')
     endif
 
   end subroutine check_h
@@ -548,7 +548,7 @@ contains
 
   subroutine check_s(state)
 
-    use amrex_error_module
+    use castro_error_module
     use eos_type_module, only: eos_t, mins, maxs, print_state
 
     implicit none
@@ -557,10 +557,10 @@ contains
 
     if (state % s .lt. mins) then
        call print_state(state)
-       call amrex_error('EOS: s smaller than mins.')
+       call castro_error('EOS: s smaller than mins.')
     else if (state % s .gt. maxs) then
        call print_state(state)
-       call amrex_error('EOS: s greater than maxs.')
+       call castro_error('EOS: s greater than maxs.')
     endif
 
   end subroutine check_s
@@ -569,7 +569,7 @@ contains
 
   subroutine check_p(state)
 
-    use amrex_error_module
+    use castro_error_module
     use eos_type_module, only: eos_t, minp, maxp, print_state
 
     implicit none
@@ -578,10 +578,10 @@ contains
 
     if (state % p .lt. minp) then
        call print_state(state)
-       call amrex_error('EOS: p smaller than minp.')
+       call castro_error('EOS: p smaller than minp.')
     else if (state % p .gt. maxp) then
        call print_state(state)
-       call amrex_error('EOS: p greater than maxp.')
+       call castro_error('EOS: p greater than maxp.')
     endif
 
   end subroutine check_p

--- a/Microphysics/EOS/eos_type.F90
+++ b/Microphysics/EOS/eos_type.F90
@@ -1,6 +1,6 @@
 module eos_type_module
 
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only : rt => amrex_real
   use network, only: nspec, naux
 
@@ -492,7 +492,7 @@ contains
     case default
 
 #ifndef AMREX_USE_CUDA
-       call amrex_error("EOS: invalid independent variable")
+       call castro_error("EOS: invalid independent variable")
 #endif
 
     end select

--- a/Microphysics/EOS/gamma_law/gamma_law.F90
+++ b/Microphysics/EOS/gamma_law/gamma_law.F90
@@ -6,7 +6,7 @@
 module actual_eos_module
 
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module
+  use castro_error_module
   use amrex_constants_module
   use eos_type_module
 
@@ -37,7 +37,7 @@ contains
     if (eos_gamma .gt. 0.d0) then
        gamma_const = eos_gamma
     else
-       call amrex_error("gamma_const cannot be < 0")
+       call castro_error("gamma_const cannot be < 0")
     end if
 
     assume_neutral = eos_assume_neutral
@@ -89,7 +89,7 @@ contains
        ! dens, enthalpy, and xmass are inputs
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call amrex_error('EOS: eos_input_rh is not supported in this EOS.')
+       call castro_error('EOS: eos_input_rh is not supported in this EOS.')
 #endif
 
     case (eos_input_tp)
@@ -97,7 +97,7 @@ contains
        ! temp, pres, and xmass are inputs
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call amrex_error('EOS: eos_input_tp is not supported in this EOS.')
+       call castro_error('EOS: eos_input_tp is not supported in this EOS.')
 #endif
 
     case (eos_input_rp)
@@ -134,7 +134,7 @@ contains
        ! pressure entropy, and xmass are inputs
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call amrex_error('EOS: eos_input_ps is not supported in this EOS.')
+       call castro_error('EOS: eos_input_ps is not supported in this EOS.')
 #endif
 
     case (eos_input_ph)
@@ -142,7 +142,7 @@ contains
        ! pressure, enthalpy and xmass are inputs
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call amrex_error('EOS: eos_input_ph is not supported in this EOS.')
+       call castro_error('EOS: eos_input_ph is not supported in this EOS.')
 #endif
 
     case (eos_input_th)
@@ -152,13 +152,13 @@ contains
        ! This system is underconstrained.
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call amrex_error('EOS: eos_input_th is not a valid input for the gamma law EOS.')
+       call castro_error('EOS: eos_input_th is not a valid input for the gamma law EOS.')
 #endif
 
     case default
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call amrex_error('EOS: invalid input.')
+       call castro_error('EOS: invalid input.')
 #endif
 
     end select

--- a/Microphysics/networks/burner.F90
+++ b/Microphysics/networks/burner.F90
@@ -60,7 +60,7 @@ contains
 
     !$gpu
 
-    use amrex_error_module
+    use castro_error_module
 
     implicit none
 
@@ -72,11 +72,11 @@ contains
 
 #if !(defined(ACC)||defined(AMREX_USE_CUDA))
     if (.NOT. network_initialized) then
-       call amrex_error("ERROR in burner: must initialize network first.")
+       call castro_error("ERROR in burner: must initialize network first.")
     endif
 
     if (.NOT. burner_initialized) then
-       call amrex_error("ERROR in burner: must initialize burner first.")
+       call castro_error("ERROR in burner: must initialize burner first.")
     endif
 #endif
 

--- a/Microphysics/networks/network.F90
+++ b/Microphysics/networks/network.F90
@@ -41,7 +41,7 @@ contains
 
   subroutine network_init()
 
-    use amrex_error_module, only : amrex_error
+    use castro_error_module, only : castro_error
     use amrex_constants_module, only : ONE
 
     implicit none
@@ -59,11 +59,11 @@ contains
     ! Check to make sure, and if not, throw an error.
 
     if ( nspec .le. 0 ) then
-       call amrex_error("Network cannot have a negative number of species.")
+       call castro_error("Network cannot have a negative number of species.")
     endif
 
     if ( naux .lt. 0 ) then
-       call amrex_error("Network cannot have a negative number of auxiliary variables.")
+       call castro_error("Network cannot have a negative number of auxiliary variables.")
     endif
 
     aion_inv(:) = ONE/aion(:)

--- a/Source/driver/Castro_error.F90
+++ b/Source/driver/Castro_error.F90
@@ -1,0 +1,15 @@
+module castro_error_module
+
+  use amrex_error_module
+
+contains
+
+  subroutine castro_error(message)
+    ! report an error and abort
+
+    character(len=*), intent(in) :: message
+    call amrex_error(message)
+  end subroutine castro_error
+
+end module castro_error_module
+

--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -482,7 +482,7 @@ subroutine swap_outflow_data() bind(C, name="swap_outflow_data")
 
   use meth_params_module, only: outflow_data_new, outflow_data_new_time, &
        outflow_data_old, outflow_data_old_time
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only: rt => amrex_real
 
   implicit none
@@ -501,7 +501,7 @@ subroutine swap_outflow_data() bind(C, name="swap_outflow_data")
 #ifndef AMREX_USE_CUDA
   if (size(outflow_data_old,dim=2) .ne. size(outflow_data_new,dim=2)) then
      print *,'size of old and new dont match in swap_outflow_data '
-     call amrex_error("Error:: Castro_nd.f90 :: swap_outflow_data")
+     call castro_error("Error:: Castro_nd.f90 :: swap_outflow_data")
   end if
 #endif
 
@@ -627,7 +627,7 @@ subroutine ca_set_method_params(dm, Density_in, Xmom_in, &
   ! sanity check
 #ifndef AMREX_USE_CUDA
   if ((QU /= GDU) .or. (QV /= GDV) .or. (QW /= GDW)) then
-     call amrex_error("ERROR: velocity components for godunov and primitive state are not aligned")
+     call castro_error("ERROR: velocity components for godunov and primitive state are not aligned")
   endif
 #endif
 
@@ -755,7 +755,7 @@ subroutine ca_set_problem_params(dm,physbc_lo_in,physbc_hi_in,&
      ! Binds to C function `ca_set_problem_params`
 
   use amrex_constants_module, only: ZERO
-  use amrex_error_module
+  use castro_error_module
   use prob_params_module
   use meth_params_module, only: UMX, UMY, UMZ
 #ifdef ROTATION
@@ -836,7 +836,7 @@ subroutine ca_set_problem_params(dm,physbc_lo_in,physbc_hi_in,&
   ! sanity check on our allocations
 #ifndef AMREX_USE_CUDA
   if (UMZ > MAX_MOM_INDEX) then
-     call amrex_error("ERROR: not enough space in comp in mom_flux_has_p")
+     call castro_error("ERROR: not enough space in comp in mom_flux_has_p")
   endif
 #endif
 
@@ -946,7 +946,7 @@ subroutine ca_get_tagging_params(name, namlen) &
      ! Binds to C function `ca_get_tagging_params`
 
   use tagging_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only: rt => amrex_real
 
   implicit none
@@ -1061,7 +1061,7 @@ subroutine ca_get_tagging_params(name, namlen) &
   ! create the filename
 #ifndef AMREX_USE_CUDA
   if (namlen > maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   endif
 #endif
 
@@ -1081,7 +1081,7 @@ subroutine ca_get_tagging_params(name, namlen) &
   else if (status > 0) then
      ! some problem in the namelist
 #ifndef AMREX_USE_CUDA
-     call amrex_error('ERROR: problem in the tagging namelist')
+     call castro_error('ERROR: problem in the tagging namelist')
 #endif
   endif
 
@@ -1102,7 +1102,7 @@ subroutine ca_get_sponge_params(name, namlen) bind(C, name="ca_get_sponge_params
     ! Binds to C function `ca_get_sponge_params`
 
   use sponge_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only: rt => amrex_real
 
   implicit none
@@ -1152,7 +1152,7 @@ subroutine ca_get_sponge_params(name, namlen) bind(C, name="ca_get_sponge_params
   ! create the filename
 #ifndef AMREX_USE_CUDA
   if (namlen > maxlen) then
-     call amrex_error('probin file name too long')
+     call castro_error('probin file name too long')
   endif
 #endif
 
@@ -1172,7 +1172,7 @@ subroutine ca_get_sponge_params(name, namlen) bind(C, name="ca_get_sponge_params
   else if (status > 0) then
      ! some problem in the namelist
 #ifndef AMREX_USE_CUDA
-     call amrex_error('ERROR: problem in the sponge namelist')
+     call castro_error('ERROR: problem in the sponge namelist')
 #endif
   endif
 
@@ -1186,11 +1186,11 @@ subroutine ca_get_sponge_params(name, namlen) bind(C, name="ca_get_sponge_params
 
 #ifndef AMREX_USE_CUDA
   if (sponge_lower_factor < 0.e0_rt .or. sponge_lower_factor > 1.e0_rt) then
-     call amrex_error('ERROR: sponge_lower_factor cannot be outside of [0, 1].')
+     call castro_error('ERROR: sponge_lower_factor cannot be outside of [0, 1].')
   endif
 
   if (sponge_upper_factor < 0.e0_rt .or. sponge_upper_factor > 1.e0_rt) then
-     call amrex_error('ERROR: sponge_upper_factor cannot be outside of [0, 1].')
+     call castro_error('ERROR: sponge_upper_factor cannot be outside of [0, 1].')
   endif
 #endif
 

--- a/Source/driver/Castro_util.F90
+++ b/Source/driver/Castro_util.F90
@@ -359,7 +359,7 @@ contains
     use meth_params_module, only: NVAR, URHO, UEINT, UTEMP, &
          UFS, UFX
     use amrex_constants_module, only: ZERO, ONE
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only: rt => amrex_real
 
     implicit none
@@ -387,7 +387,7 @@ contains
                 print *,'>>> Error: Castro_util.F90::ca_compute_temp ',i,j,k
                 print *,'>>> ... negative density ',state(i,j,k,URHO)
                 print *,'    '
-                call amrex_error("Error:: compute_temp_nd.f90")
+                call castro_error("Error:: compute_temp_nd.f90")
              end if
 
              if (state(i,j,k,UEINT) <= ZERO) then
@@ -395,7 +395,7 @@ contains
                 print *,'>>> Warning: Castro_util.F90::ca_compute_temp ',i,j,k
                 print *,'>>> ... negative (rho e) ',state(i,j,k,UEINT)
                 print *,'   '
-                call amrex_error("Error:: compute_temp_nd.f90")
+                call castro_error("Error:: compute_temp_nd.f90")
              end if
 
           enddo
@@ -432,7 +432,7 @@ contains
     use network           , only: nspec
     use meth_params_module, only: NVAR, URHO, UFS
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use amrex_fort_module, only: rt => amrex_real
 
@@ -458,7 +458,7 @@ contains
              if (abs(state(i,j,k,URHO)-spec_sum) .gt. 1.e-8_rt * state(i,j,k,URHO)) then
 
                 print *,'Sum of (rho X)_i vs rho at (i,j,k): ',i,j,k,spec_sum,state(i,j,k,URHO)
-                call amrex_error("Error:: Failed check of initial species summing to 1")
+                call castro_error("Error:: Failed check of initial species summing to 1")
 
              end if
 #endif
@@ -545,7 +545,7 @@ contains
     use amrinfo_module, only: amr_level
     use amrex_constants_module, only: ZERO, ONE, TWO, M_PI, FOUR
     use prob_params_module, only: dim, coord_type, dx_level
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only: rt => amrex_real
 
     implicit none
@@ -632,7 +632,7 @@ contains
 #ifndef AMREX_USE_CUDA
        else
 
-          call amrex_error("Cylindrical coordinates only supported in 2D.")
+          call castro_error("Cylindrical coordinates only supported in 2D.")
 #endif
 
        endif
@@ -659,7 +659,7 @@ contains
 #ifndef AMREX_USE_CUDA
        else
 
-          call amrex_error("Spherical coordinates only supported in 1D.")
+          call castro_error("Spherical coordinates only supported in 1D.")
 #endif
 
        endif
@@ -679,7 +679,7 @@ contains
     ! in 2D, and Spherical in 1D.
 
     use amrinfo_module, only: amr_level
-    use amrex_error_module
+    use castro_error_module
     use amrex_constants_module, only: ZERO, HALF, FOUR3RD, TWO, M_PI
     use prob_params_module, only: dim, coord_type, dx_level
     use amrex_fort_module, only: rt => amrex_real
@@ -728,7 +728,7 @@ contains
 #ifndef AMREX_USE_CUDA
        else
 
-          call amrex_error("Cylindrical coordinates only supported in 2D.")
+          call castro_error("Cylindrical coordinates only supported in 2D.")
 #endif
 
        endif
@@ -749,7 +749,7 @@ contains
 #ifndef AMREX_USE_CUDA
        else
 
-          call amrex_error("Spherical coordinates only supported in 1D.")
+          call castro_error("Spherical coordinates only supported in 1D.")
 #endif
 
        endif
@@ -918,7 +918,7 @@ contains
     use meth_params_module, only: URHO, UMX, UMY, UMZ
     use prob_params_module, only: center, dim
     use amrex_constants_module, only: HALF
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only: rt => amrex_real
 
     implicit none
@@ -941,7 +941,7 @@ contains
     real(rt) :: x_mom,y_mom,z_mom,radial_mom
 
 #ifndef AMREX_USE_CUDA
-    if (dim .eq. 1) call amrex_error("Error: cannot do ca_compute_avgstate in 1D.")
+    if (dim .eq. 1) call castro_error("Error: cannot do ca_compute_avgstate in 1D.")
 #endif
 
     !
@@ -960,7 +960,7 @@ contains
                 print *,'COMPUTE_AVGSTATE: INDEX TOO BIG ',index,' > ',numpts_1d-1
                 print *,'AT (i,j,k) ',i,j,k
                 print *,'R / DR ',r,dr
-                call amrex_error("Error:: Castro_util.F90 :: ca_compute_avgstate")
+                call castro_error("Error:: Castro_util.F90 :: ca_compute_avgstate")
              end if
 #endif
              radial_state(URHO,index) = radial_state(URHO,index) &

--- a/Source/driver/Derive_nd.F90
+++ b/Source/driver/Derive_nd.F90
@@ -2,7 +2,7 @@ module derive_module
     ! All subroutines in this file must be threadsafe because they are called
     ! inside OpenMP parallel regions.
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
 
   implicit none
@@ -40,7 +40,7 @@ contains
 #ifndef AMREX_USE_CUDA
     if (nv .ne. 3) then
        print *,'... confusion in derstate ... nv should be 3 but is ',nv
-       call amrex_error('Error:: Derive_nd.f90 :: derstate')
+       call castro_error('Error:: Derive_nd.f90 :: derstate')
     end if
 #endif
 

--- a/Source/driver/MGutils_nd.F90
+++ b/Source/driver/MGutils_nd.F90
@@ -1,6 +1,6 @@
 module MGutils_2D_module
 
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
   use amrex_fort_module, only: rt => amrex_real
 
   implicit none
@@ -88,7 +88,7 @@ contains
     else
 
        print *,'Bogus coord_type in apply_metric ' ,coord_type
-       call amrex_error("Error:: MGutils_2d.f90 :: ca_apply_metric")
+       call castro_error("Error:: MGutils_2d.f90 :: ca_apply_metric")
 #endif
 
     end if
@@ -133,7 +133,7 @@ contains
     else
 
        print *,'Bogus coord_type in weight_cc ' ,coord_type
-       call amrex_error("Error:: MGutils_2d.f90 :: ca_weight_cc")
+       call castro_error("Error:: MGutils_2d.f90 :: ca_weight_cc")
 #endif
 
     end if
@@ -178,7 +178,7 @@ contains
     else
 
        print *,'Bogus coord_type in unweight_cc ' ,coord_type
-       call amrex_error("Error:: MGutils_2d.f90 :: ca_unweight_cc")
+       call castro_error("Error:: MGutils_2d.f90 :: ca_unweight_cc")
 #endif
 
     end if
@@ -241,7 +241,7 @@ contains
     else
 
        print *,'Bogus coord_type in unweight_edges ' ,coord_type
-       call amrex_error("Error:: MGutils_2d.f90 :: ca_unweight_edges")
+       call castro_error("Error:: MGutils_2d.f90 :: ca_unweight_edges")
 #endif
 
     end if

--- a/Source/driver/Make.package
+++ b/Source/driver/Make.package
@@ -1,6 +1,7 @@
 # these are the files that should be needed for any Castro build
 
 ca_F90EXE_sources += amrinfo.F90
+ca_F90EXE_sources += Castro_error.F90
 ca_F90EXE_sources += filcc_nd.F90
 
 CEXE_sources += Castro.cpp

--- a/Source/driver/check_for_nan.f90
+++ b/Source/driver/check_for_nan.f90
@@ -1,6 +1,6 @@
 module nan_check
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
 
   implicit none
@@ -21,7 +21,7 @@ contains
 
              if (isnan(s(i,j,k,comp))) then
                 print *, "NaN: ", i, j, k, comp
-                call amrex_error("NaN")
+                call castro_error("NaN")
              endif
           end do
        end do

--- a/Source/driver/extern_probin.template
+++ b/Source/driver/extern_probin.template
@@ -20,7 +20,7 @@ end module extern_probin_module
 subroutine runtime_init(name, namlen)
 
   use extern_probin_module
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 
   implicit none
 
@@ -42,7 +42,7 @@ subroutine runtime_init(name, namlen)
 
   ! create the filename
   if (namlen > maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   endif
 
   do i = 1, namlen
@@ -61,7 +61,7 @@ subroutine runtime_init(name, namlen)
 
   else if (status > 0) then
      ! some problem in the namelist
-     call amrex_error("ERROR: problem in the extern namelist")
+     call castro_error("ERROR: problem in the extern namelist")
   endif
 
   close (unit=un)
@@ -74,7 +74,7 @@ subroutine runtime_pretty_print(name, namlen) bind(C, name="runtime_pretty_print
 
   use amrex_constants_module
   use extern_probin_module
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 
   implicit none
 
@@ -89,7 +89,7 @@ subroutine runtime_pretty_print(name, namlen) bind(C, name="runtime_pretty_print
   character (len=maxlen) :: probin
 
   if (namlen > maxlen) then
-     call amrex_error("probin file name too long")
+     call castro_error("probin file name too long")
   endif
 
   do i = 1, namlen

--- a/Source/driver/interpolate.F90
+++ b/Source/driver/interpolate.F90
@@ -89,7 +89,7 @@ contains
     ! this is stricly interpolation, so if the point (x,y,z) is outside
     ! the bounds of model_x,model_y,model_z, then we abort
 
-    use amrex_error_module
+    use castro_error_module
     use amrex_constants_module, only: ONE
     use amrex_fort_module, only : rt => amrex_real
     real(rt)        , intent(in   ) :: x,y,z

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -819,8 +819,6 @@ contains
        gravity_type_int = 1
     else if (gravity_type == "PoissonGrav") then
        gravity_type_int = 2
-    else if (gravity_type == "PrescribedGrav") then
-       gravity_type_int = 3
     else
        call castro_error("Unknown gravity type")
     end if
@@ -1206,7 +1204,8 @@ contains
 
 #ifndef AMREX_USE_GPU
     if (fsp_type_in .ne. 1 .and. fsp_type_in .ne. 2) then
-       call castro_error("Unknown fspace_type", fspace_type)
+       print *, "fspace_type = ", fspace_type
+       call castro_error("Unknown fspace_type")
     end if
 #endif
 
@@ -1218,7 +1217,7 @@ contains
        comoving = .false.
     else
 #ifndef AMREX_USE_GPU
-       call castro_error("Wrong value for comoving", fspace_type)
+       call castro_error("Wrong value for comoving")
 #endif
     end if
 

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -12,7 +12,7 @@
 
 module meth_params_module
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only: rt => amrex_real
   use state_sizes_module, only : nadv, NQAUX, NVAR, NGDNV, NQ, NQSRC
 
@@ -822,7 +822,7 @@ contains
     else if (gravity_type == "PrescribedGrav") then
        gravity_type_int = 3
     else
-       call amrex_error("Unknown gravity type")
+       call castro_error("Unknown gravity type")
     end if
 #endif
 
@@ -1206,7 +1206,7 @@ contains
 
 #ifndef AMREX_USE_GPU
     if (fsp_type_in .ne. 1 .and. fsp_type_in .ne. 2) then
-       call amrex_error("Unknown fspace_type", fspace_type)
+       call castro_error("Unknown fspace_type", fspace_type)
     end if
 #endif
 
@@ -1218,7 +1218,7 @@ contains
        comoving = .false.
     else
 #ifndef AMREX_USE_GPU
-       call amrex_error("Wrong value for comoving", fspace_type)
+       call castro_error("Wrong value for comoving", fspace_type)
 #endif
     end if
 

--- a/Source/driver/meth_params.template
+++ b/Source/driver/meth_params.template
@@ -1,4 +1,4 @@
-! This module stores the runtime parameters and integer names for 
+! This module stores the runtime parameters and integer names for
 ! indexing arrays.
 !
 ! The Fortran-specific parameters are initialized in set_method_params(),
@@ -65,8 +65,8 @@ module meth_params_module
   ! these flags are for interpreting the EXT_DIR BCs
   integer, parameter :: EXT_UNDEFINED = -1
   integer, parameter :: EXT_HSE = 1
-  integer, parameter :: EXT_INTERP = 2 
-  
+  integer, parameter :: EXT_INTERP = 2
+
   integer, allocatable, save :: xl_ext, yl_ext, zl_ext, xr_ext, yr_ext, zr_ext
 
   ! Create versions of these variables on the GPU
@@ -164,7 +164,7 @@ contains
     select case (xl_ext_bc_type)
     case ("hse", "HSE")
        xl_ext = EXT_HSE
-    case ("interp", "INTERP")       
+    case ("interp", "INTERP")
        xl_ext = EXT_INTERP
     case default
        xl_ext = EXT_UNDEFINED
@@ -173,7 +173,7 @@ contains
     select case (yl_ext_bc_type)
     case ("hse", "HSE")
        yl_ext = EXT_HSE
-    case ("interp", "INTERP")       
+    case ("interp", "INTERP")
        yl_ext = EXT_INTERP
     case default
        yl_ext = EXT_UNDEFINED
@@ -182,7 +182,7 @@ contains
     select case (zl_ext_bc_type)
     case ("hse", "HSE")
        zl_ext = EXT_HSE
-    case ("interp", "INTERP")       
+    case ("interp", "INTERP")
        zl_ext = EXT_INTERP
     case default
        zl_ext = EXT_UNDEFINED
@@ -191,7 +191,7 @@ contains
     select case (xr_ext_bc_type)
     case ("hse", "HSE")
        xr_ext = EXT_HSE
-    case ("interp", "INTERP")       
+    case ("interp", "INTERP")
        xr_ext = EXT_INTERP
     case default
        xr_ext = EXT_UNDEFINED
@@ -200,7 +200,7 @@ contains
     select case (yr_ext_bc_type)
     case ("hse", "HSE")
        yr_ext = EXT_HSE
-    case ("interp", "INTERP")       
+    case ("interp", "INTERP")
        yr_ext = EXT_INTERP
     case default
        yr_ext = EXT_UNDEFINED
@@ -209,7 +209,7 @@ contains
     select case (zr_ext_bc_type)
     case ("hse", "HSE")
        zr_ext = EXT_HSE
-    case ("interp", "INTERP")       
+    case ("interp", "INTERP")
        zr_ext = EXT_INTERP
     case default
        zr_ext = EXT_UNDEFINED
@@ -240,7 +240,7 @@ contains
 #endif
 
     @@free_castro_params@@
-    
+
   end subroutine ca_finalize_meth_params
 
 
@@ -266,24 +266,25 @@ contains
 
 #ifndef AMREX_USE_GPU
     if (fsp_type_in .ne. 1 .and. fsp_type_in .ne. 2) then
-       call castro_error("Unknown fspace_type", fspace_type)
+       print *, "fspace_type = ", fspace_type
+       call castro_error("Unknown fspace_type")
     end if
 #endif
-    
+
     do_inelastic_scattering = (do_is_in .ne. 0)
-    
+
     if (com_in .eq. 1) then
        comoving = .true.
     else if (com_in .eq. 0) then
        comoving = .false.
     else
 #ifndef AMREX_USE_GPU
-       call castro_error("Wrong value for comoving", fspace_type)
+       call castro_error("Wrong value for comoving")
 #endif
     end if
-    
+
     flatten_pp_threshold = fppt
-    
+
     !$acc update &
     !$acc device(QRAD, QRADHI, QPTOT, QREITOT) &
     !$acc device(fspace_type) &

--- a/Source/driver/meth_params.template
+++ b/Source/driver/meth_params.template
@@ -7,7 +7,7 @@
 
 module meth_params_module
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only: rt => amrex_real
   use state_sizes_module, only : nadv, NQAUX, NVAR, NGDNV, NQ, NQSRC
 
@@ -156,7 +156,7 @@ contains
     else if (gravity_type == "PoissonGrav") then
        gravity_type_int = 2
     else
-       call amrex_error("Unknown gravity type")
+       call castro_error("Unknown gravity type")
     end if
 #endif
 
@@ -266,7 +266,7 @@ contains
 
 #ifndef AMREX_USE_GPU
     if (fsp_type_in .ne. 1 .and. fsp_type_in .ne. 2) then
-       call amrex_error("Unknown fspace_type", fspace_type)
+       call castro_error("Unknown fspace_type", fspace_type)
     end if
 #endif
     
@@ -278,7 +278,7 @@ contains
        comoving = .false.
     else
 #ifndef AMREX_USE_GPU
-       call amrex_error("Wrong value for comoving", fspace_type)
+       call castro_error("Wrong value for comoving", fspace_type)
 #endif
     end if
     

--- a/Source/driver/sdc_util.F90
+++ b/Source/driver/sdc_util.F90
@@ -43,7 +43,7 @@ end module rpar_sdc_module
 module sdc_util
 
   use amrex_fort_module, only : rt => amrex_real
-  use amrex_error_module, only : amrex_error
+  use castro_error_module, only : castro_error
 
   implicit none
 
@@ -83,7 +83,7 @@ contains
 
        ! failing?
        if (ierr /= NEWTON_SUCCESS) then
-          call amrex_error("Newton subcycling failed in sdc_solve")
+          call castro_error("Newton subcycling failed in sdc_solve")
        end if
 
     else if (sdc_solver == VODE_SOLVE) then
@@ -103,7 +103,7 @@ contains
 
        ! failing?
        if (ierr /= NEWTON_SUCCESS) then
-          call amrex_error("Newton failure in sdc_solve")
+          call castro_error("Newton failure in sdc_solve")
        end if
     end if
 
@@ -510,7 +510,7 @@ contains
                1, istate, iopt, rwork, lrw, iwork, liw, jac_ode, imode, rpar, ipar)
 
     if (istate < 0) then
-       call amrex_error("vode termination poorly, istate = ", istate)
+       call castro_error("vode termination poorly, istate = ", istate)
     endif
 #endif
 
@@ -964,7 +964,7 @@ contains
        enddo
 
     else
-       call amrex_error("error in ca_sdc_update_advection_o4 -- should not be here")
+       call castro_error("error in ca_sdc_update_advection_o4 -- should not be here")
     endif
 
   end subroutine ca_sdc_update_advection_o4
@@ -1033,7 +1033,7 @@ contains
                 C(i,j,k,:) = (A_m(i,j,k,:) - A_1_old(i,j,k,:)) - R_2_old(i,j,k,:) + integral
 
              else
-                call amrex_error("error in ca_sdc_compute_C4 -- should not be here")
+                call castro_error("error in ca_sdc_compute_C4 -- should not be here")
              endif
 
           enddo

--- a/Source/driver/sdc_util.F90
+++ b/Source/driver/sdc_util.F90
@@ -510,7 +510,8 @@ contains
                1, istate, iopt, rwork, lrw, iwork, liw, jac_ode, imode, rpar, ipar)
 
     if (istate < 0) then
-       call castro_error("vode termination poorly, istate = ", istate)
+       print *, "VODE error, istate = ", istate
+       call castro_error("vode termination poorly")
     endif
 #endif
 

--- a/Source/driver/set_variables.py
+++ b/Source/driver/set_variables.py
@@ -34,7 +34,7 @@ HEADER = """
 CHECK_EQUAL = """
 subroutine check_equal(index1, index2)
 
-  use amrex_error_module
+  use castro_error_module
 
   implicit none
 
@@ -42,7 +42,7 @@ subroutine check_equal(index1, index2)
 
 #ifndef AMREX_USE_CUDA
   if (index1 /= index2) then
-    call amrex_error("ERROR: mismatch of indices")
+    call castro_error("ERROR: mismatch of indices")
   endif
 #endif
 

--- a/Source/gravity/GR_Gravity_1d.f90
+++ b/Source/gravity/GR_Gravity_1d.f90
@@ -12,7 +12,7 @@
       use eos_type_module, only : eos_input_re, eos_t
       use network, only : nspec, naux
       use amrex_constants_module, only: HALF, FOUR3RD, M_PI
-      use amrex_error_module
+      use castro_error_module
 
       use amrex_fort_module, only : rt => amrex_real
       implicit none
@@ -36,11 +36,11 @@
       type (eos_t) :: eos_state
 
       if (physbc_lo(1) .ne. Symmetry) then
-         call amrex_error("Error: GR_Gravity_1d.f90 :: 1D gravity assumes symmetric lower boundary.")
+         call castro_error("Error: GR_Gravity_1d.f90 :: 1D gravity assumes symmetric lower boundary.")
       endif
 
       if (coord_type .ne. 2) then
-         call amrex_error("Error: GR_Gravity_1d.f90 :: 1D gravity assumes spherical coordinates.")
+         call castro_error("Error: GR_Gravity_1d.f90 :: 1D gravity assumes spherical coordinates.")
       endif
 
       fac  = dble(drdxfac)
@@ -60,7 +60,7 @@
                print *,'>>> ... index too big: ', index,' > ',n1d-1
                print *,'>>> ... at i     : ',i
                print *,'    '
-               call amrex_error("Error:: GR_Gravity_1d.f90 :: ca_compute_avgpres")
+               call castro_error("Error:: GR_Gravity_1d.f90 :: ca_compute_avgpres")
             end if
 
          else

--- a/Source/gravity/GR_Gravity_2d.f90
+++ b/Source/gravity/GR_Gravity_2d.f90
@@ -11,7 +11,7 @@
       use eos_module
       use network, only : nspec, naux
       use amrex_constants_module
-      use amrex_error_module
+      use castro_error_module
 
       use amrex_fort_module, only : rt => amrex_real
       implicit none
@@ -55,7 +55,7 @@
                   print *,'>>> ... index too big: ', index,' > ',n1d-1
                   print *,'>>> ... at (i,j)     : ',i,j
                   print *,'    '
-                  call amrex_error("Error:: Gravity_2d.f90 :: ca_compute_avgpres")
+                  call castro_error("Error:: Gravity_2d.f90 :: ca_compute_avgpres")
                end if
 
             else

--- a/Source/gravity/GR_Gravity_3d.f90
+++ b/Source/gravity/GR_Gravity_3d.f90
@@ -11,7 +11,7 @@
       use eos_module
       use network, only : nspec, naux
       use amrex_constants_module
-      use amrex_error_module
+      use castro_error_module
 
       use amrex_fort_module, only : rt => amrex_real
       implicit none
@@ -60,7 +60,7 @@
                      print *,'>>> Error: Gravity_3d::ca_compute_avgpres ',i,j,k
                      print *,'>>> ... index too big: ', index,' > ',n1d-1
                      print *,'>>> ... at (i,j,k)   : ',i,j,k
-                     call amrex_error("Error:: Gravity_3d.f90 :: ca_compute_avgpres")
+                     call castro_error("Error:: Gravity_3d.f90 :: ca_compute_avgpres")
                   end if
 
                else

--- a/Source/gravity/Gravity_1d.f90
+++ b/Source/gravity/Gravity_1d.f90
@@ -1,6 +1,6 @@
 module gravity_1D_module
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
@@ -62,7 +62,7 @@ contains
 
     else
        print *,'Bogus coord_type in test_residual ' ,coord_type
-       call amrex_error("Error:: Gravity_1d.f90 :: ca_test_residual")
+       call castro_error("Error:: Gravity_1d.f90 :: ca_test_residual")
     end if
 
   end subroutine ca_test_residual
@@ -99,11 +99,11 @@ contains
     real(rt)         :: lo_i, rlo, rhi
 
     if (physbc_lo(1) .ne. Symmetry) then
-       call amrex_error("Error: Gravity_1d.f90 :: 1D gravity assumes symmetric lower boundary.")
+       call castro_error("Error: Gravity_1d.f90 :: 1D gravity assumes symmetric lower boundary.")
     endif
 
     if (coord_type .ne. 2) then
-       call amrex_error("Error: Gravity_1d.f90 :: 1D gravity assumes spherical coordinates.")
+       call castro_error("Error: Gravity_1d.f90 :: 1D gravity assumes spherical coordinates.")
     endif
 
     fac = dble(drdxfac)
@@ -123,7 +123,7 @@ contains
              print *,'>>> ... index too big: ', index,' > ',n1d-1
              print *,'>>> ... at i     : ', i
              print *,'    '
-             call amrex_error("Error:: Gravity_1d.f90 :: ca_compute_radial_mass")
+             call castro_error("Error:: Gravity_1d.f90 :: ca_compute_radial_mass")
           end if
 
        else
@@ -214,7 +214,7 @@ contains
              print *,'PUT_RADIAL_GRAV: INDEX TOO BIG ', index, ' > ', n1d-1
              print *,'AT i ', i
              print *,'R / DR IS ', r, dr
-             call amrex_error("Error:: Gravity_1d.f90 :: ca_put_radial_grav")
+             call castro_error("Error:: Gravity_1d.f90 :: ca_put_radial_grav")
           else
              ! NOTE: we don't do anything to this point if it's outside the
              !       radial grid and level > 0
@@ -293,7 +293,7 @@ contains
           print *,'PUT_RADIAL_PHI: INDEX TOO BIG ', index, ' > ', numpts_1d-1
           print *,'AT (i) ',i
           print *,'R / DR IS ', r, dr
-          call amrex_error("Error:: Gravity_1d.f90 :: ca_put_radial_phi")
+          call castro_error("Error:: Gravity_1d.f90 :: ca_put_radial_phi")
        end if
 
        if ( (fill_interior .eq. 1) .or. (i .lt. domlo(1) .or. i.gt.domhi(1)) ) then

--- a/Source/gravity/Gravity_2d.f90
+++ b/Source/gravity/Gravity_2d.f90
@@ -1,6 +1,6 @@
 module gravity_2D_module
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
@@ -66,7 +66,7 @@ contains
     else
 
        print *,'Bogus coord_type in test_residual ' ,coord_type
-       call amrex_error("Error:: Gravity_2d.f90 :: ca_test_residual")
+       call castro_error("Error:: Gravity_2d.f90 :: ca_test_residual")
 
     end if
 
@@ -132,7 +132,7 @@ contains
                 print *,'>>> ... index too big: ', index,' > ',n1d-1
                 print *,'>>> ... at (i,j)     : ',i,j
                 print *,'    ' 
-                call amrex_error("Error:: Gravity_2d.f90 :: ca_compute_radial_mass")
+                call castro_error("Error:: Gravity_2d.f90 :: ca_compute_radial_mass")
              end if
 
           else
@@ -213,7 +213,7 @@ contains
                 print *,'PUT_RADIAL_GRAV: INDEX TOO BIG ',index,' > ',n1d-1
                 print *,'AT (i,j) ',i,j
                 print *,'R / DR IS ',r,dr
-                call amrex_error("Error:: Gravity_2d.f90 :: ca_put_radial_grav")
+                call castro_error("Error:: Gravity_2d.f90 :: ca_put_radial_grav")
              else 
                 ! NOTE: we don't do anything to this point if it's outside the
                 !       radial grid and level > 0
@@ -296,7 +296,7 @@ contains
              print *,'PUT_RADIAL_PHI: INDEX TOO BIG ',index,' > ',numpts_1d-1
              print *,'AT (i,j) ',i,j
              print *,'R / DR IS ',r,dr
-             call amrex_error("Error:: Gravity_2d.f90 :: ca_put_radial_phi")
+             call castro_error("Error:: Gravity_2d.f90 :: ca_put_radial_phi")
           end if
 
           if (  (fill_interior .eq. 1) .or. &

--- a/Source/gravity/Gravity_3d.f90
+++ b/Source/gravity/Gravity_3d.f90
@@ -1,6 +1,6 @@
 module gravity_3D_module
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
@@ -118,7 +118,7 @@ contains
                    print *,'>>> Error: Gravity_3d::ca_compute_radial_mass ',i,j,k
                    print *,'>>> ... index too big: ', index,' > ',n1d-1
                    print *,'>>> ... at (i,j,k)   : ',i,j,k
-                   call amrex_error("Error:: Gravity_3d.f90 :: ca_compute_radial_mass")
+                   call castro_error("Error:: Gravity_3d.f90 :: ca_compute_radial_mass")
                 end if
 
              else
@@ -212,7 +212,7 @@ contains
                    print *,'AT (i,j,k) ',i,j,k
                    print *,'X Y Z ',x,y,z
                    print *,'R / DR ',r,dr
-                   call amrex_error("Error:: Gravity_3d.f90 :: ca_put_radial_grav")
+                   call castro_error("Error:: Gravity_3d.f90 :: ca_put_radial_grav")
                 else
                    ! NOTE: we don't do anything to this point if it's outside the
                    !       radial grid and level > 0
@@ -313,7 +313,7 @@ contains
                 print *,'PUT_RADIAL_PHI: INDEX TOO BIG ',index,' > ',numpts_1d-1
                 print *,'AT (i,j) ',i,j,k
                 print *,'R / DR IS ',r,dr
-                call amrex_error("Error:: Gravity_3d.f90 :: ca_put_radial_phi")
+                call castro_error("Error:: Gravity_3d.f90 :: ca_put_radial_phi")
              end if
 
              if ( (fill_interior .eq. 1) .or. &

--- a/Source/gravity/Gravity_nd.F90
+++ b/Source/gravity/Gravity_nd.F90
@@ -440,7 +440,7 @@ contains
                                    bind(C, name="ca_put_multipole_phi")
 
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use prob_params_module, only: problo, center, dim, coord_type
     use fundamental_constants_module, only: Gconst
@@ -480,7 +480,7 @@ contains
 
 #ifndef AMREX_USE_CUDA
     if (lnum > lnum_max) then
-       call amrex_error("Error: ca_put_multipole_phi: requested more multipole moments than we allocated data for.")
+       call castro_error("Error: ca_put_multipole_phi: requested more multipole moments than we allocated data for.")
     endif
 #endif
 
@@ -604,7 +604,7 @@ contains
                                           bind(C, name="ca_compute_multipole_moments")
 
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use prob_params_module, only: problo, center, probhi, dim, coord_type
     use amrex_constants_module
@@ -649,7 +649,7 @@ contains
 
 #ifndef AMREX_USE_CUDA
     if (lnum > lnum_max) then
-       call amrex_error("Error: ca_compute_multipole_moments: requested more multipole moments than we allocated data for.")
+       call castro_error("Error: ca_compute_multipole_moments: requested more multipole moments than we allocated data for.")
     endif
 #endif
 

--- a/Source/gravity/gravity_sources_nd.F90
+++ b/Source/gravity/gravity_sources_nd.F90
@@ -19,7 +19,7 @@ contains
     use amrex_fort_module, only: rt => amrex_real
     use amrex_constants_module, only: ZERO, HALF, ONE
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use meth_params_module, only: NVAR, URHO, UMX, UMZ, UEDEN, grav_source_type
     use castro_util_module, only: position ! function
@@ -147,7 +147,7 @@ contains
 #ifndef AMREX_USE_CUDA
              else
 
-                call amrex_error("Error:: gravity_sources_nd.F90 :: invalid grav_source_type")
+                call castro_error("Error:: gravity_sources_nd.F90 :: invalid grav_source_type")
 #endif
 
              end if
@@ -189,7 +189,7 @@ contains
 
     use amrex_fort_module, only: rt => amrex_real
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use amrex_constants_module, only: ZERO, HALF, ONE, TWO
     use amrex_mempool_module, only: bl_allocate, bl_deallocate
@@ -495,7 +495,7 @@ contains
 #ifndef AMREX_USE_CUDA
              else
 
-                call amrex_error("Error:: gravity_sources_nd.F90 :: invalid grav_source_type")
+                call castro_error("Error:: gravity_sources_nd.F90 :: invalid grav_source_type")
 #endif
              end if
 

--- a/Source/hydro/Castro_ctu_nd.F90
+++ b/Source/hydro/Castro_ctu_nd.F90
@@ -3,7 +3,7 @@ module ctu_module
   ! advection routines in support of the CTU unsplit advection scheme
 
   use amrex_constants_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
 
   implicit none
@@ -458,7 +458,7 @@ contains
 
 #ifdef RADIATION
 #ifndef AMREX_USE_CUDA
-    call amrex_error("ppm_type <=0 is not supported in with radiation")
+    call castro_error("ppm_type <=0 is not supported in with radiation")
 #endif
 #endif
 

--- a/Source/hydro/Castro_fourth_order.F90
+++ b/Source/hydro/Castro_fourth_order.F90
@@ -54,7 +54,7 @@ contains
     use advection_util_module, only : limit_hydro_fluxes_on_small_dens, ca_shock, &
                                       normalize_species_fluxes, avisc
 
-    use amrex_error_module
+    use castro_error_module
     use amrex_constants_module, only : ZERO, HALF, ONE, FOURTH
     use flatten_module, only: ca_uflatten
     use riemann_module, only: riemann_state
@@ -177,7 +177,7 @@ contains
     ! averages and cell-centers with the correct volume terms in the integral.
 #ifndef AMREX_USE_CUDA
     if (coord_type > 0) then
-       call amrex_error("Error: fourth order not implemented for axisymmetric")
+       call castro_error("Error: fourth order not implemented for axisymmetric")
     endif
 #endif
 
@@ -885,7 +885,7 @@ contains
 #else
 #ifndef AMREX_USE_CUDA
    ! RADIATION check
-    call amrex_error("ERROR: ca_fourth_single_stage does not support radiation")
+    call castro_error("ERROR: ca_fourth_single_stage does not support radiation")
 #endif
 #endif
   end subroutine ca_fourth_single_stage
@@ -907,7 +907,7 @@ contains
     use eos_type_module, only : eos_t, eos_input_re
     use conductivity_module, only : conducteos
     use network, only : nspec
-    use amrex_error_module, only : amrex_error
+    use castro_error_module, only : castro_error
 
     integer, intent(in) :: idir
     integer, intent(in) :: q_lo(3), q_hi(3)

--- a/Source/hydro/Castro_mol_nd.F90
+++ b/Source/hydro/Castro_mol_nd.F90
@@ -15,7 +15,7 @@ contains
                                     qp, qp_lo, qp_hi, &
                                     dx) bind(C, name="ca_mol_plm_reconstruct")
 
-    use amrex_error_module
+    use castro_error_module
     use meth_params_module, only : NQ, NVAR, NGDNV, GDPRES, &
                                    UTEMP, UMX, &
                                    use_flattening, QPRES, &
@@ -164,7 +164,7 @@ contains
                                     qp, qp_lo, qp_hi, &
                                     dx) bind(C, name="ca_mol_ppm_reconstruct")
 
-    use amrex_error_module
+    use castro_error_module
     use meth_params_module, only : NQ, NVAR, NGDNV, GDPRES, &
                                    UTEMP, UMX, &
                                    use_flattening, QPRES, &
@@ -272,7 +272,7 @@ contains
 #endif
                            vol, vol_lo, vol_hi) bind(C, name="ca_mol_consup")
 
-    use amrex_error_module
+    use castro_error_module
     use meth_params_module, only : NQ, NVAR, NGDNV, GDPRES, &
                                    UTEMP, UMX, &
                                    use_flattening, QPRES, &
@@ -407,7 +407,7 @@ contains
                                    flux, f_lo, f_hi, &
                                    dx) bind(C, name="ca_mol_diffusive_flux")
 
-    use amrex_error_module
+    use castro_error_module
     use meth_params_module, only : NVAR, UTEMP, UEINT, UEDEN
     use amrex_constants_module, only : HALF
     use amrex_fort_module, only : rt => amrex_real

--- a/Source/hydro/advection_util_nd.F90
+++ b/Source/hydro/advection_util_nd.F90
@@ -14,7 +14,7 @@ contains
     use meth_params_module, only : NVAR, URHO, small_dens, density_reset_method
     use amrex_constants_module, only : ZERO
 #ifndef AMREX_USE_GPU
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use amrex_fort_module, only: rt => amrex_real, amrex_min
 
@@ -47,7 +47,7 @@ contains
 #ifndef AMREX_USE_GPU
                 print *,'DENSITY EXACTLY ZERO AT CELL ', i, j, k
                 print *,'  in grid ',lo(1), lo(2), lo(3), hi(1), hi(2), hi(3)
-                call amrex_error("Error :: ca_enforce_minimum_density")
+                call castro_error("Error :: ca_enforce_minimum_density")
 #endif
 
              else if (state(i,j,k,URHO) < small_dens) then
@@ -152,7 +152,7 @@ contains
 #ifndef AMREX_USE_CUDA
                 else
 
-                   call amrex_error("Unknown density_reset_method in subroutine ca_enforce_minimum_density.")
+                   call castro_error("Unknown density_reset_method in subroutine ca_enforce_minimum_density.")
 #endif
                 endif
 
@@ -449,7 +449,7 @@ contains
          small_dens
 
     use amrex_constants_module, only: ZERO, HALF, ONE
-    use amrex_error_module
+    use castro_error_module
 #ifdef ROTATION
     use meth_params_module, only: do_rotation, state_in_rotating_frame
     use rotation_module, only: inertial_to_rotational_velocity
@@ -505,12 +505,12 @@ contains
                 print *,'   '
                 print *,'>>> Error: advection_util_nd.F90::ctoprim ',i, j, k
                 print *,'>>> ... negative density ', uin(i,j,k,URHO)
-                call amrex_error("Error:: advection_util_nd.f90 :: ctoprim")
+                call castro_error("Error:: advection_util_nd.f90 :: ctoprim")
              else if (uin(i,j,k,URHO) .lt. small_dens) then
                 print *,'   '
                 print *,'>>> Error: advection_util_nd.F90::ctoprim ',i, j, k
                 print *,'>>> ... small density ', uin(i,j,k,URHO)
-                call amrex_error("Error:: advection_util_nd.f90 :: ctoprim")
+                call castro_error("Error:: advection_util_nd.f90 :: ctoprim")
              endif
           end do
 #endif
@@ -1137,7 +1137,7 @@ contains
     use meth_params_module, only : QPRES, QU, QV, QW, NQ
     use prob_params_module, only : coord_type
     use amrex_constants_module, only: ZERO, HALF, ONE
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
 
     implicit none
@@ -1170,7 +1170,7 @@ contains
 
 #ifndef AMREX_USE_CUDA
     if (coord_type /= 0) then
-       call amrex_error("ERROR: invalid geometry in shock()")
+       call castro_error("ERROR: invalid geometry in shock()")
     endif
 #endif
 
@@ -1212,7 +1212,7 @@ contains
 
 #ifndef AMREX_USE_CUDA
              else
-                call amrex_error("ERROR: invalid coord_type in shock")
+                call castro_error("ERROR: invalid coord_type in shock")
 #endif
              endif
 

--- a/Source/hydro/hybrid_advection_nd.F90
+++ b/Source/hydro/hybrid_advection_nd.F90
@@ -197,7 +197,7 @@ contains
 
     use meth_params_module, only: NVAR, NGDNV, GDRHO, GDU, GDV, GDW, GDPRES, UMR, UML, UMP
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use prob_params_module, only: center
     use castro_util_module, only: position ! function
@@ -236,7 +236,7 @@ contains
        u_adv = state(GDW)
 #ifndef AMREX_USE_CUDA
     else
-       call amrex_error("Error: unknown direction in compute_hybrid_flux.")
+       call castro_error("Error: unknown direction in compute_hybrid_flux.")
 #endif
     endif
 
@@ -267,7 +267,7 @@ contains
 #ifndef AMREX_USE_CUDA
     else
 
-       call amrex_error("Error: unknown direction in compute_hybrid_flux.")
+       call castro_error("Error: unknown direction in compute_hybrid_flux.")
 #endif
     endif
 

--- a/Source/hydro/ppm_nd.F90
+++ b/Source/hydro/ppm_nd.F90
@@ -36,7 +36,7 @@ contains
 
 
 #ifndef AMREX_USE_GPU
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use prob_params_module, only : dim
 
@@ -73,7 +73,7 @@ contains
          (dim == 3 .and. s_lo(3) > lo(3)-3)) then
        print *,'Low bounds of array: ',s_lo(1), s_lo(2),s_lo(3)
        print *,'Low bounds of  loop: ',lo(1),lo(2),lo(3)
-       call amrex_error("Need more ghost cells on array in ppm_type1")
+       call castro_error("Need more ghost cells on array in ppm_type1")
     end if
 
     if ((s_hi(1) < hi(1)+3) .or. &
@@ -81,11 +81,11 @@ contains
          (dim == 3 .and. s_hi(3) < hi(3)+3)) then
        print *,'Hi  bounds of array: ',s_hi(1), s_hi(2), s_hi(3)
        print *,'Hi  bounds of  loop: ',hi(1),hi(2),hi(3)
-       call amrex_error("Need more ghost cells on array in ppm_type1")
+       call castro_error("Need more ghost cells on array in ppm_type1")
     end if
 
     if (nend - nstart /= nqend - nqstart) then
-       call amrex_error("Number of components do not match in ca_ppm_reconstruct")
+       call castro_error("Number of components do not match in ca_ppm_reconstruct")
     end if
 #endif
 

--- a/Source/hydro/riemann_nd.F90
+++ b/Source/hydro/riemann_nd.F90
@@ -50,7 +50,7 @@ contains
     use eos_module, only: eos
     use eos_type_module, only: eos_t
     use network, only: nspec, naux
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
     use meth_params_module, only : hybrid_riemann, ppm_temp_fix, riemann_solver
 
@@ -134,7 +134,7 @@ contains
     use eos_module, only: eos
     use eos_type_module, only: eos_t
     use network, only: nspec, naux
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
     use meth_params_module, only : hybrid_riemann, ppm_temp_fix, riemann_solver
 
@@ -221,7 +221,7 @@ contains
                  domlo, domhi)
 #ifndef AMREX_USE_CUDA
     else
-       call amrex_error("ERROR: invalid value of riemann_solver")
+       call castro_error("ERROR: invalid value of riemann_solver")
 #endif
     endif
 
@@ -287,7 +287,7 @@ contains
     use eos_module, only: eos
     use eos_type_module, only: eos_t, eos_input_re
     use network, only: nspec, naux
-    use amrex_error_module
+    use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
     use meth_params_module, only : hybrid_riemann, ppm_temp_fix, riemann_solver, &
                                    T_guess
@@ -341,11 +341,11 @@ contains
 #ifdef RADIATION
 #ifndef AMREX_USE_CUDA
     if (hybrid_riemann == 1) then
-       call amrex_error("ERROR: hybrid Riemann not supported for radiation")
+       call castro_error("ERROR: hybrid Riemann not supported for radiation")
     endif
 
     if (riemann_solver > 0) then
-       call amrex_error("ERROR: only the CGF Riemann solver is supported for radiation")
+       call castro_error("ERROR: only the CGF Riemann solver is supported for radiation")
     endif
 #endif
 #endif
@@ -353,7 +353,7 @@ contains
 #if AMREX_SPACEDIM == 1
 #ifndef AMREX_USE_CUDA
     if (riemann_solver > 1) then
-       call amrex_error("ERROR: HLLC not implemented for 1-d")
+       call castro_error("ERROR: HLLC not implemented for 1-d")
     endif
 #endif
 #endif
@@ -444,13 +444,13 @@ contains
                       domlo, domhi)
 #else
 #ifndef AMREX_USE_CUDA
-       call amrex_error("ERROR: CG solver does not support radiaiton")
+       call castro_error("ERROR: CG solver does not support radiaiton")
 #endif
 #endif
 
 #ifndef AMREX_USE_CUDA
     else
-       call amrex_error("ERROR: invalid value of riemann_solver")
+       call castro_error("ERROR: invalid value of riemann_solver")
 #endif
     endif
 
@@ -472,7 +472,7 @@ contains
     ! this version is dimension agnostic -- for 1- and 2-d, set kc,
     ! kflux, and k3d to 0
 
-    use amrex_error_module
+    use castro_error_module
 #ifndef AMREX_USE_CUDA
     use amrex_mempool_module, only : bl_allocate, bl_deallocate
 #endif
@@ -556,7 +556,7 @@ contains
 #ifndef AMREX_USE_CUDA
     if (cg_blend == 2 .and. cg_maxiter < 5) then
 
-       call amrex_error("Error: need cg_maxiter >= 5 to do a bisection search on secant iteration failure.")
+       call castro_error("Error: need cg_maxiter >= 5 to do a bisection search on secant iteration failure.")
 
     endif
 #endif
@@ -846,7 +846,7 @@ contains
                    print *, 'left state  (r,u,p,re,gc): ', rl, ul, pl, rel, gcl
                    print *, 'right state (r,u,p,re,gc): ', rr, ur, pr, rer, gcr
                    print *, 'cavg, smallc:', cavg, csmall
-                   call amrex_error("ERROR: non-convergence in the Riemann solver")
+                   call castro_error("ERROR: non-convergence in the Riemann solver")
 #endif
                 else if (cg_blend == 1) then
 
@@ -881,14 +881,14 @@ contains
                       print *, 'left state  (r,u,p,re,gc): ', rl, ul, pl, rel, gcl
                       print *, 'right state (r,u,p,re,gc): ', rr, ur, pr, rer, gcr
                       print *, 'cavg, smallc:', cavg, csmall
-                      call amrex_error("ERROR: non-convergence in the Riemann solver")
+                      call castro_error("ERROR: non-convergence in the Riemann solver")
 
                    endif
 #endif
                 else
 
 #ifndef AMREX_USE_CUDA
-                   call amrex_error("ERROR: unrecognized cg_blend option.")
+                   call castro_error("ERROR: unrecognized cg_blend option.")
 #endif
                 endif
 

--- a/Source/hydro/trace_plm.F90
+++ b/Source/hydro/trace_plm.F90
@@ -1,6 +1,6 @@
 module trace_plm_module
 
-  use amrex_error_module, only : amrex_error
+  use castro_error_module, only : castro_error
   use amrex_fort_module, only : rt => amrex_real
   use prob_params_module, only : dg
 
@@ -92,7 +92,7 @@ contains
 #ifndef AMREX_USE_CUDA
     if (ppm_type .ne. 0) then
        print *,'Oops -- shouldnt be in tracexy with ppm_type != 0'
-       call amrex_error("Error:: trace_3d.f90 :: tracexy")
+       call castro_error("Error:: trace_3d.f90 :: tracexy")
     end if
 #endif
 

--- a/Source/hydro/trace_ppm.F90
+++ b/Source/hydro/trace_ppm.F90
@@ -4,7 +4,7 @@ module trace_ppm_module
   ! profiles in each zone to the edge / half-time.
 
   use prob_params_module, only : dg
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   use amrex_constants_module, only : ZERO, HALF, ONE
 
@@ -322,7 +322,7 @@ contains
 #ifndef AMREX_USE_CUDA
     if (ppm_type == 0) then
        print *,'Oops -- shouldnt be in tracexy_ppm with ppm_type = 0'
-       call amrex_error("Error:: trace_ppm_nd.f90 :: tracexy_ppm")
+       call castro_error("Error:: trace_ppm_nd.f90 :: tracexy_ppm")
     end if
 #endif
 
@@ -783,7 +783,7 @@ contains
 #ifndef AMREX_USE_CUDA
     if (ppm_type == 0) then
        print *,'Oops -- shouldnt be in tracexy_ppm with ppm_type = 0'
-       call amrex_error("Error:: trace_ppm_nd.f90 :: tracexy_ppm")
+       call castro_error("Error:: trace_ppm_nd.f90 :: tracexy_ppm")
     end if
 #endif
 
@@ -1273,7 +1273,7 @@ contains
 #ifndef AMREX_USE_CUDA
     if (ppm_type == 0) then
        print *,'Oops -- shouldnt be in tracexy_ppm with ppm_type = 0'
-       call amrex_error("Error:: trace_ppm_nd.f90 :: tracexy_ppm")
+       call castro_error("Error:: trace_ppm_nd.f90 :: tracexy_ppm")
     end if
 #endif
 

--- a/Source/hydro/trans.F90
+++ b/Source/hydro/trans.F90
@@ -1,6 +1,6 @@
 module transverse_module
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   use prob_params_module, only : dg
 

--- a/Source/problems/Prob_nd.F90
+++ b/Source/problems/Prob_nd.F90
@@ -35,7 +35,7 @@ subroutine ca_initdata(level,time,lo,hi,nvar, &
     !              right hand corner of grid.  (does not include
     !		   ghost region).
 
-  use amrex_error_module
+  use castro_error_module
 
   use amrex_fort_module, only : rt => amrex_real
   implicit none
@@ -51,6 +51,6 @@ subroutine ca_initdata(level,time,lo,hi,nvar, &
   ! Remove this call if you're defining your own problem; it is here to
   ! ensure that you cannot run CASTRO if you haven't got your own copy of this function.
 
-  call amrex_error("Prob_nd.f90 has not been defined for this problem!")
+  call castro_error("Prob_nd.f90 has not been defined for this problem!")
 
 end subroutine ca_initdata

--- a/Source/problems/bc_ext_fill_nd.F90
+++ b/Source/problems/bc_ext_fill_nd.F90
@@ -8,7 +8,7 @@ module bc_ext_fill_module
 
   use amrex_constants_module, only: ZERO, HALF
 #ifndef AMREX_USE_CUDA
-  use amrex_error_module, only: amrex_error
+  use castro_error_module, only: castro_error
 #endif
   use amrex_fort_module, only: rt => amrex_real
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, &
@@ -177,7 +177,7 @@ contains
                       print *, "column info: "
                       print *, "   dens: ", adv(i:domlo(1),j,k,URHO)
                       print *, "   temp: ", adv(i:domlo(1),j,k,UTEMP)
-                      call amrex_error("ERROR in bc_ext_fill_nd: failure to converge in -X BC")
+                      call castro_error("ERROR in bc_ext_fill_nd: failure to converge in -X BC")
                    endif
 #endif
 
@@ -290,7 +290,7 @@ contains
 
        if (xr_ext == EXT_HSE) then
 #ifndef AMREX_USE_CUDA
-          call amrex_error("ERROR: HSE boundaries not implemented for +X")
+          call castro_error("ERROR: HSE boundaries not implemented for +X")
 #endif
 
        elseif (xr_ext == EXT_INTERP) then
@@ -466,7 +466,7 @@ contains
                       print *, "column info: "
                       print *, "   dens: ", adv(i,j:domlo(2),k,URHO)
                       print *, "   temp: ", adv(i,j:domlo(2),k,UTEMP)
-                      call amrex_error("ERROR in bc_ext_fill_nd: failure to converge in -Y BC")
+                      call castro_error("ERROR in bc_ext_fill_nd: failure to converge in -Y BC")
                    endif
 #endif
 
@@ -579,7 +579,7 @@ contains
 
        if (yr_ext == EXT_HSE) then
 #ifndef AMREX_USE_CUDA
-          call amrex_error("ERROR: HSE boundaries not implemented for +Y")
+          call castro_error("ERROR: HSE boundaries not implemented for +Y")
 #endif
 
        elseif (yr_ext == EXT_INTERP) then
@@ -754,7 +754,7 @@ contains
                       print *, "column info: "
                       print *, "   dens: ", adv(i,j,k:domlo(3),URHO)
                       print *, "   temp: ", adv(i,j,k:domlo(3),UTEMP)
-                      call amrex_error("ERROR in bc_ext_fill_1d: failure to converge in -Z BC")
+                      call castro_error("ERROR in bc_ext_fill_1d: failure to converge in -Z BC")
                    endif
 #endif
 
@@ -867,7 +867,7 @@ contains
 
        if (zr_ext == EXT_HSE) then
 #ifndef AMREX_USE_CUDA
-          call amrex_error("ERROR: HSE boundaries not implemented for +Z")
+          call castro_error("ERROR: HSE boundaries not implemented for +Z")
 #endif
 
        elseif (zr_ext == EXT_INTERP) then
@@ -935,7 +935,7 @@ contains
     use prob_params_module, only: problo
     use model_parser_module, only: npts_model, model_r, model_state, idens_model, interpolate_sub
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only: amrex_error
+    use castro_error_module, only: castro_error
 #endif
     use amrex_filcc_module, only: amrex_filccn
 
@@ -964,12 +964,12 @@ contains
 #ifndef AMREX_USE_CUDA
     ! XLO
     if ( bc(1,1) == EXT_DIR .and. lo(1) < domlo(1)) then
-       call amrex_error("We should not be here (xlo denfill)")
+       call castro_error("We should not be here (xlo denfill)")
     end if
 
     ! XHI
     if ( bc(1,2) == EXT_DIR .and. hi(1) > domhi(1)) then
-       call amrex_error("We should not be here (xhi denfill)")
+       call castro_error("We should not be here (xhi denfill)")
     endif
 #endif
 

--- a/Source/radiation/RadEOS_1d.f90
+++ b/Source/radiation/RadEOS_1d.f90
@@ -174,7 +174,7 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
   use meth_params_module, only : NVAR, URHO, UFS, UFX, &
        small_temp
 
-  use amrex_error_module, only : amrex_error
+  use castro_error_module, only : castro_error
   use amrex_fort_module, only : rt => amrex_real
   implicit none
   integer         , intent(in) :: lo(1), hi(1)
@@ -213,7 +213,7 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
 
         if(temp(i).lt.0.e0_rt) then
            print*,'negative temp in compute_temp_given_reye ', temp(i)
-           call amrex_error("Error:: ca_compute_temp_given_reye")
+           call castro_error("Error:: ca_compute_temp_given_reye")
         endif
 
      end if

--- a/Source/radiation/RadEOS_2d.f90
+++ b/Source/radiation/RadEOS_2d.f90
@@ -190,7 +190,7 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UFS, UFX, &
        small_temp
 
-  use amrex_error_module, only : amrex_error
+  use castro_error_module, only : castro_error
   use amrex_fort_module, only : rt => amrex_real
   implicit none
   integer         , intent(in) :: lo(2), hi(2)
@@ -230,7 +230,7 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
 
            if(temp(i,j).lt.0.e0_rt) then
               print*,'negative temp in compute_temp_given_reye ', temp(i,j)
-              call amrex_error("Error :: ca_compute_temp_given_reye")
+              call castro_error("Error :: ca_compute_temp_given_reye")
            endif
 
         end if

--- a/Source/radiation/RadEOS_3d.f90
+++ b/Source/radiation/RadEOS_3d.f90
@@ -200,7 +200,7 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UFS, UFX, &
        small_temp
   
-  use amrex_error_module, only : amrex_error
+  use castro_error_module, only : castro_error
   use amrex_fort_module, only : rt => amrex_real
   implicit none
   integer         , intent(in) :: lo(3), hi(3)
@@ -241,7 +241,7 @@ subroutine ca_compute_temp_given_reye(lo, hi, &
 
               if(temp(i,j,k).lt.0.e0_rt) then
                  print*,'negative temp in compute_temp_given_reye ', temp(i,j,k)
-                 call amrex_error("Error:: ca_compute_temp_given_reye")
+                 call castro_error("Error:: ca_compute_temp_given_reye")
               endif
    
            end if

--- a/Source/radiation/rad_util.f90
+++ b/Source/radiation/rad_util.f90
@@ -1,6 +1,6 @@
 module rad_util_module
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_constants_module
   use amrex_fort_module, only : rt => amrex_real
 
@@ -84,7 +84,7 @@ contains
        end if
 
     else
-       call amrex_error("Unknown limiter ", limiter)
+       call castro_error("Unknown limiter ", limiter)
     endif
   end function FLDlambda
 

--- a/Source/radiation/rad_util.f90
+++ b/Source/radiation/rad_util.f90
@@ -84,7 +84,8 @@ contains
        end if
 
     else
-       call castro_error("Unknown limiter ", limiter)
+       print *, "limiter = ", limiter
+       call castro_error("Unknown limiter type")
     endif
   end function FLDlambda
 

--- a/Source/radiation/trace_ppm_rad_nd.F90
+++ b/Source/radiation/trace_ppm_rad_nd.F90
@@ -4,7 +4,7 @@
 module trace_ppm_rad_module
 
   use prob_params_module, only : dg
-  use amrex_error_module, only : amrex_error
+  use castro_error_module, only : castro_error
   use amrex_fort_module, only : rt => amrex_real
 
   implicit none
@@ -133,7 +133,7 @@ contains
 
     if (ppm_type == 0) then
        print *,'Oops -- shouldnt be in tracexy_ppm with ppm_type = 0'
-       call amrex_error("Error:: trace_ppm_rad_nd.f90 :: tracexy_ppm_rad")
+       call castro_error("Error:: trace_ppm_rad_nd.f90 :: tracexy_ppm_rad")
     end if
 
     hdt = HALF * dt

--- a/Source/reactions/react_util.F90
+++ b/Source/reactions/react_util.F90
@@ -101,7 +101,7 @@ contains
     real(rt) :: eps = 1.e-8_rt
 
 #ifdef SDC
-    call amrex_error("we shouldn't be here with the simplified SDC method (USE_SDC=TRUE)")
+    call castro_error("we shouldn't be here with the simplified SDC method (USE_SDC=TRUE)")
 #else
     if (sdc_use_analytic_jac == 0) then
        ! note the numerical Jacobian will be returned in terms of X

--- a/Source/rotation/Rotation_frequency.F90
+++ b/Source/rotation/Rotation_frequency.F90
@@ -1,6 +1,6 @@
 module rotation_frequency_module
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
@@ -44,7 +44,7 @@ contains
 
     else
 #ifndef AMREX_USE_GPU
-       call amrex_error("Error:: rotation_nd.f90 :: invalid coord_type")
+       call castro_error("Error:: rotation_nd.f90 :: invalid coord_type")
 #endif
     endif
 
@@ -86,7 +86,7 @@ contains
 
     else
 #ifndef AMREX_USE_GPU
-       call amrex_error("Error:: rotation_nd.f90 :: unknown coord_type")
+       call castro_error("Error:: rotation_nd.f90 :: unknown coord_type")
 #endif
     endif
 

--- a/Source/rotation/Rotation_nd.F90
+++ b/Source/rotation/Rotation_nd.F90
@@ -3,7 +3,7 @@ module rotation_module
   use meth_params_module, only: rotation_include_centrifugal, rotation_include_coriolis, &
        rotation_include_domegadt
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
 
   implicit none
@@ -41,7 +41,7 @@ contains
           loc = position(idx(1),idx(2),idx(3),ccz=.false.) - center
        else
 #ifndef AMREX_USE_GPU
-          call amrex_error("Error: unknown direction in inertial_to_rotational_velocity.")
+          call castro_error("Error: unknown direction in inertial_to_rotational_velocity.")
 #endif
        endif
     else

--- a/Source/rotation/rotation_sources_nd.F90
+++ b/Source/rotation/rotation_sources_nd.F90
@@ -1,6 +1,6 @@
 module rotation_sources_module
 
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
@@ -116,7 +116,7 @@ contains
 
              else
 #ifndef AMREX_USE_GPU
-                call amrex_error("Error:: rotation_sources_nd.F90 :: invalid rot_source_type")
+                call castro_error("Error:: rotation_sources_nd.F90 :: invalid rot_source_type")
 #endif
              end if
 
@@ -470,7 +470,7 @@ contains
 
              else
 #ifndef AMREX_USE_GPU
-                call amrex_error("Error:: rotation_sources_nd.F90 :: invalid rot_source_type")
+                call castro_error("Error:: rotation_sources_nd.F90 :: invalid rot_source_type")
 #endif
              end if
 

--- a/Util/conservative_interpolate/conservative_map.F90
+++ b/Util/conservative_interpolate/conservative_map.F90
@@ -43,7 +43,7 @@ contains
     use meth_params_module, only : NVAR, URHO, UMX, UTEMP, UEDEN, UEINT, UFS
     use amrex_constants_module
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module
+    use castro_error_module
 #endif
 
     character(len=*), intent(in   ) :: model_file
@@ -70,7 +70,7 @@ contains
     if (ierr .ne. 0) then
        print *,'Couldnt open model_file: ',model_file
 #ifndef AMREX_USE_CUDA
-       call amrex_error('Aborting now -- please supply model_file')
+       call castro_error('Aborting now -- please supply model_file')
 #endif
     end if
 
@@ -183,28 +183,28 @@ contains
        if (i == 1) then
 #ifndef AMREX_USE_CUDA
           if (.not. found_dens) then
-             call amrex_error("ERROR: density not provided in inputs file")
+             call castro_error("ERROR: density not provided in inputs file")
           end if
 
           if (.not. found_xmom) then
-             call amrex_error("ERROR: x-momentum not provided in inputs file")
+             call castro_error("ERROR: x-momentum not provided in inputs file")
           end if
 
           if (.not. found_rho_E) then
-             call amrex_error("ERROR: rho_E not provided in inputs file")
+             call castro_error("ERROR: rho_E not provided in inputs file")
           end if
 
           if (.not. found_rho_eint) then
-             call amrex_error("ERROR: rho_e not provided in inputs file")
+             call castro_error("ERROR: rho_e not provided in inputs file")
           end if
 
           if (.not. found_temp) then
-             call amrex_error("ERROR: Temp not provided in inputs file")
+             call castro_error("ERROR: Temp not provided in inputs file")
           end if
 
           do comp = 1, nspec
              if (.not. found_spec(comp)) then
-                call amrex_error("ERROR: " // trim(spec_names(comp)), &
+                call castro_error("ERROR: " // trim(spec_names(comp)), &
                      ' not provided in inputs file')
              end if
           end do
@@ -258,7 +258,7 @@ contains
 
     use amrex_constants_module, only : ZERO, HALF
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only : amrex_error
+    use castro_error_module, only : castro_error
 #endif
     use amrex_fort_module, only : rt => amrex_real
 
@@ -294,7 +294,7 @@ contains
        if (abs(x_model_l - xl) < tol*xscale) then
           if (ileft > 0) then
 #ifndef AMREX_USE_CUDA
-             call amrex_error("Error: ileft already set")
+             call castro_error("Error: ileft already set")
 #endif
           else
              ileft = n
@@ -304,7 +304,7 @@ contains
        if (abs(x_model_r - xr) < tol*abs(xr)) then
           if (iright > 0) then
 #ifndef AMREX_USE_CUDA
-             call amrex_error("Error: iright already set")
+             call castro_error("Error: iright already set")
 #endif
           else
              iright = n
@@ -318,11 +318,11 @@ contains
 
 #ifndef AMREX_USE_CUDA
     if (ileft == -1 .or. iright == -1) then
-       call amrex_error("Error: ileft or iright not set")
+       call castro_error("Error: ileft or iright not set")
     end if
 
     if (iright < ileft) then
-       call amrex_error("Error: iright < ileft")
+       call castro_error("Error: iright < ileft")
     end if
 #endif
 
@@ -347,7 +347,7 @@ contains
 
     use amrex_constants_module, only : ZERO, HALF, ONE, TWO
 #ifndef AMREX_USE_CUDA
-    use amrex_error_module, only : amrex_error
+    use castro_error_module, only : castro_error
 #endif
     use amrex_fort_module, only : rt => amrex_real
 
@@ -384,7 +384,7 @@ contains
        if (abs(x_model_l - xl) < tol*xscale) then
           if (ileft > 0) then
 #ifndef AMREX_USE_CUDA
-             call amrex_error("Error: ileft already set")
+             call castro_error("Error: ileft already set")
 #endif
           else
              ileft = n
@@ -394,7 +394,7 @@ contains
        if (abs(x_model_r - xr) < tol*abs(xr)) then
           if (iright > 0) then
 #ifndef AMREX_USE_CUDA
-             call amrex_error("Error: iright already set")
+             call castro_error("Error: iright already set")
 #endif
           else
              iright = n
@@ -408,11 +408,11 @@ contains
 
 #ifndef AMREX_USE_CUDA
     if (ileft == -1 .or. iright == -1) then
-       call amrex_error("Error: ileft or iright not set")
+       call castro_error("Error: ileft or iright not set")
     end if
 
     if (iright < ileft) then
-       call amrex_error("Error: iright < ileft")
+       call castro_error("Error: iright < ileft")
     end if
 #endif
 

--- a/Util/conservative_interpolate/conservative_map.F90
+++ b/Util/conservative_interpolate/conservative_map.F90
@@ -204,7 +204,7 @@ contains
 
           do comp = 1, nspec
              if (.not. found_spec(comp)) then
-                call castro_error("ERROR: " // trim(spec_names(comp)), &
+                call castro_error("ERROR: " // trim(spec_names(comp)) // &
                      ' not provided in inputs file')
              end if
           end do

--- a/Util/exact_riemann/riemann_sample.f90
+++ b/Util/exact_riemann/riemann_sample.f90
@@ -105,7 +105,7 @@ subroutine riemann_sample(rho_l, u_l, p_l, &
 
   else
      ! we should average in this case
-     call amrex_error("Not implemented")
+     call castro_error("Not implemented")
 
   endif
 

--- a/Util/exact_riemann/riemann_support.f90
+++ b/Util/exact_riemann/riemann_support.f90
@@ -1,7 +1,7 @@
 module riemann_support
 
   use amrex_constants_module
-  use amrex_error_module
+  use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
 
   use eos_type_module
@@ -139,7 +139,7 @@ contains
        enddo
        
        !print *, 'did we try to bisect? ', found
-       call amrex_error("ERROR: shock did not converge")
+       call castro_error("ERROR: shock did not converge")
     endif
     
 
@@ -335,7 +335,7 @@ contains
        enddo
        
     else
-       call amrex_error('unable to bracket the root')
+       call castro_error('unable to bracket the root')
     endif
 
     if (converged) W_s = 0.5_rt*(W1 + W2)

--- a/Util/model_parser/model_parser.F90
+++ b/Util/model_parser/model_parser.F90
@@ -59,7 +59,7 @@ contains
   subroutine read_model_file(model_file)
 
     use amrex_constants_module
-    use amrex_error_module
+    use castro_error_module
 
     character(len=*), intent(in   ) :: model_file
 
@@ -83,7 +83,7 @@ contains
 
     if (ierr .ne. 0) then
        print *,'Couldnt open model_file: ',model_file
-       call amrex_error('Aborting now -- please supply model_file')
+       call castro_error('Aborting now -- please supply model_file')
     end if
 
     ! the first line has the number of points in the model


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This adds a `castro_error()` routine that simply calls `amrex_error()`.  This will allow us to hook into the error routine for GPUs.

closes #244 

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
