### PR TITLE
don't enforce EXT_DIR for source_fill and generic_fill in setup

### DIFF
--- a/Exec/reacting_tests/reacting_convergence/convergence_sdc4.sh
+++ b/Exec/reacting_tests/reacting_convergence/convergence_sdc4.sh
@@ -3,7 +3,7 @@
 # echo the commands
 set -x
 
-DIM=1
+DIM=2
 EXEC=./Castro${DIM}d.gnu.MPI.ex
 
 RUNPARAMS="castro.sdc_order=4 castro.time_integration_method=2 castro.limit_fourth_order=1 castro.use_reconstructed_gamma1=1 castro.sdc_solve_for_rhoe=1 castro.sdc_solver_tol_dens=1.e-10 castro.sdc_solver_tol_spec=1.e-10 castro.sdc_solver_tol_ener=1.e-10 castro.sdc_solver=1"

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -563,15 +563,6 @@ Castro::variableSetUp ()
     state_type_source_names[i] = name[i] + "_source";
     source_bcs[i] = bcs[i];
 
-    // Replace inflow BCs with FOEXTRAP.
-
-    for (int j = 0; j < AMREX_SPACEDIM; ++j) {
-        if (source_bcs[i].lo(j) == EXT_DIR)
-            source_bcs[i].setLo(j, FOEXTRAP);
-
-        if (source_bcs[i].hi(j) == EXT_DIR)
-            source_bcs[i].setHi(j, FOEXTRAP);
-    }
   }
 
   desc_lst.setComponent(Source_Type,Density,state_type_source_names,source_bcs,
@@ -595,16 +586,6 @@ Castro::variableSetUp ()
           char buf[64];
           sprintf(buf, "sdc_react_source_%d", i);
           set_scalar_bc(bc,phys_bc);
-
-          // Replace inflow BCs with FOEXTRAP.
-
-          for (int j = 0; j < AMREX_SPACEDIM; ++j) {
-              if (bc.lo(j) == EXT_DIR)
-                  bc.setLo(j, FOEXTRAP);
-
-              if (bc.hi(j) == EXT_DIR)
-                  bc.setHi(j, FOEXTRAP);
-          }
 
           desc_lst.setComponent(Simplified_SDC_React_Type,i,std::string(buf),bc,BndryFunc(ca_generic_single_fill));
       }

--- a/Source/problems/Castro_bc_fill_nd.H
+++ b/Source/problems/Castro_bc_fill_nd.H
@@ -20,20 +20,6 @@ extern "C"
      const amrex::Real* dx, const amrex::Real* glo,
      const amrex::Real* time, const int* bc);
 
-    void ca_ext_fill
-    (const int* lo, const int* hi,
-     BL_FORT_FAB_ARG_3D(state),
-     const int* dlo, const int* dhi,
-     const amrex::Real* dx, const amrex::Real* glo,
-     const amrex::Real* time, const int* bc);
-
-    void ca_ext_denfill
-    (const int* lo, const int* hi,
-     BL_FORT_FAB_ARG_3D(state),
-     const int* dlo, const int* dhi,
-     const amrex::Real* dx, const amrex::Real* glo,
-     const amrex::Real* time, const int* bc);
-
 #ifdef GRAVITY
     void ca_phigravfill
     (BL_FORT_FAB_ARG_3D(state),
@@ -47,35 +33,14 @@ extern "C"
      const amrex::Real* dx, const amrex::Real* glo,
      const amrex::Real* time, const int* bc);
 
-    void ca_ext_gravxfill
-    (const int* lo, const int* hi,
-     BL_FORT_FAB_ARG_3D(state),
-     const int* dlo, const int* dhi,
-     const amrex::Real* dx, const amrex::Real* glo,
-     const amrex::Real* time, const int* bc);
-
     void ca_gravyfill
     (BL_FORT_FAB_ARG_3D(state),
      const int* dlo, const int* dhi,
      const amrex::Real* dx, const amrex::Real* glo,
      const amrex::Real* time, const int* bc);
 
-    void ca_ext_gravyfill
-    (const int* lo, const int* hi,
-     BL_FORT_FAB_ARG_3D(state),
-     const int* dlo, const int* dhi,
-     const amrex::Real* dx, const amrex::Real* glo,
-     const amrex::Real* time, const int* bc);
-
     void ca_gravzfill
     (BL_FORT_FAB_ARG_3D(state),
-     const int* dlo, const int* dhi,
-     const amrex::Real* dx, const amrex::Real* glo,
-     const amrex::Real* time, const int* bc);
-
-    void ca_ext_gravzfill
-    (const int* lo, const int* hi,
-     BL_FORT_FAB_ARG_3D(state),
      const int* dlo, const int* dhi,
      const amrex::Real* dx, const amrex::Real* glo,
      const amrex::Real* time, const int* bc);


### PR DESCRIPTION

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

don't enforce EXT_DIR for source_fill and generic_fill in setup
instead we leave it for the implementation to enforce, so it can be overridden.
remove redundant function prototypes

closes #409 

<!-- please summarize your PR here.  If it addresses any issues, reference
 them by issue # here as well -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
