### PR TITLE
remove the transverse velocities from the passive map

### DIFF
--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -633,28 +633,12 @@ subroutine ca_set_method_params(dm, Density_in, Xmom_in, &
   ! easy indexing for the passively advected quantities.  This lets us
   ! loop over all groups (advected, species, aux) in a single loop.
   ! Note: these sizes are the maximum size we expect for passives.
-  allocate(qpass_map(NQ))
-  allocate(upass_map(NVAR))
+  allocate(qpass_map(nadv + nspec + naux))
+  allocate(upass_map(nadv + nspec + naux))
 
   ! Transverse velocities
 
-  if (dm == 1) then
-     upass_map(1) = UMY
-     qpass_map(1) = QV
-
-     upass_map(2) = UMZ
-     qpass_map(2) = QW
-
-     npassive = 2
-
-  else if (dm == 2) then
-     upass_map(1) = UMZ
-     qpass_map(1) = QW
-
-     npassive = 1
-  else
-     npassive = 0
-  endif
+  npassive = 0
 
   do iadv = 1, nadv
      upass_map(npassive + iadv) = UFA + iadv - 1

--- a/Source/hydro/advection_util_nd.F90
+++ b/Source/hydro/advection_util_nd.F90
@@ -555,28 +555,14 @@ contains
              q(i,j,k,qrad:qradhi) = Erin(i,j,k,:)
 #endif
 
-          enddo
-       enddo
-    enddo
-
-    ! Load passively advected quatities into q
-    do ipassive = 1, npassive
-       n  = upass_map(ipassive)
-       iq = qpass_map(ipassive)
-       do k = lo(3),hi(3)
-          do j = lo(2),hi(2)
-             do i = lo(1),hi(1)
-                q(i,j,k,iq) = uin(i,j,k,n)/q(i,j,k,QRHO)
+             ! Load passively advected quatities into q
+             do ipassive = 1, npassive
+                n  = upass_map(ipassive)
+                iq = qpass_map(ipassive)
+                q(i,j,k,iq) = uin(i,j,k,n) * rhoinv
              enddo
-          enddo
-       enddo
-    enddo
 
-    ! get gamc, p, T, c, csml using q state
-    do k = lo(3), hi(3)
-       do j = lo(2), hi(2)
-          do i = lo(1), hi(1)
-
+             ! get gamc, p, T, c, csml using q state
              eos_state % T   = q(i,j,k,QTEMP )
              eos_state % rho = q(i,j,k,QRHO  )
              eos_state % e   = q(i,j,k,QREINT)
@@ -682,9 +668,6 @@ contains
     do ipassive = 1, npassive
        n = upass_map(ipassive)
        iq = qpass_map(ipassive)
-
-       ! we already accounted for velocities above
-       if (iq == QU .or. iq == QV .or. iq == QW) cycle
 
        ! we may not be including the ability to have species sources,
        ! so check to make sure that we are < NQSRC

--- a/Source/hydro/advection_util_nd.F90
+++ b/Source/hydro/advection_util_nd.F90
@@ -559,8 +559,7 @@ contains
              do ipassive = 1, npassive
                 n  = upass_map(ipassive)
                 iq = qpass_map(ipassive)
-                !q(i,j,k,iq) = uin(i,j,k,n) * rhoinv
-                q(i,j,k,iq) = uin(i,j,k,n) / q(i,j,k,QRHO)
+                q(i,j,k,iq) = uin(i,j,k,n) * rhoinv
              enddo
 
              ! get gamc, p, T, c, csml using q state

--- a/Source/hydro/advection_util_nd.F90
+++ b/Source/hydro/advection_util_nd.F90
@@ -559,7 +559,8 @@ contains
              do ipassive = 1, npassive
                 n  = upass_map(ipassive)
                 iq = qpass_map(ipassive)
-                q(i,j,k,iq) = uin(i,j,k,n) * rhoinv
+                !q(i,j,k,iq) = uin(i,j,k,n) * rhoinv
+                q(i,j,k,iq) = uin(i,j,k,n) / q(i,j,k,QRHO)
              enddo
 
              ! get gamc, p, T, c, csml using q state

--- a/Source/hydro/riemann_nd.F90
+++ b/Source/hydro/riemann_nd.F90
@@ -1583,17 +1583,9 @@ contains
 
              endif
 
-
-             ! ------------------------------------------------------------------
-             ! compute the fluxes
-             ! ------------------------------------------------------------------
-
-             ! we just found the state on the interface, now we use this to
-             ! evaluate the fluxes
-
+             ! Enforce that fluxes through a symmetry plane or wall are hard zero.
              u_adv = qint(i,j,k,iu)
 
-             ! Enforce that fluxes through a symmetry plane or wall are hard zero.
              if ( special_bnd_lo_x .and. i == domlo(1) .or. &
                   special_bnd_hi_x .and. i == domhi(1)+1 ) then
                 bnd_fac_x = ZERO

--- a/Source/hydro/trace_plm.F90
+++ b/Source/hydro/trace_plm.F90
@@ -293,11 +293,6 @@ contains
     do ipassive = 1, npassive
        n = qpass_map(ipassive)
 
-       ! For DIM < 3, the velocities are included in the passive
-       ! quantities.  But we already dealt with all 3 velocity
-       ! components above, so don't process them here.
-       if (n == QU .or. n == QV .or. n == QW) cycle
-
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)

--- a/Source/hydro/trace_ppm.F90
+++ b/Source/hydro/trace_ppm.F90
@@ -198,11 +198,6 @@ contains
     do ipassive = 1, npassive
        n = qpass_map(ipassive)
 
-       ! For DIM < 3, the velocities are included in the passive
-       ! quantities.  We will deal with all 3 velocity
-       ! components below, so don't process them here.
-       if (n == QU .or. n == QV .or. n == QW) cycle
-
        ! Plus state on face i
        if ((idir == 1 .and. i >= vlo(1)) .or. &
            (idir == 2 .and. j >= vlo(2)) .or. &

--- a/Source/hydro/trans.F90
+++ b/Source/hydro/trans.F90
@@ -145,9 +145,6 @@ contains
        n  = upass_map(ipassive)
        nqp = qpass_map(ipassive)
 
-       ! since we merge 2- and 3-d, be sure not to update any velocities
-       if (nqp == QU .or. nqp == QV .or. nqp == QW) cycle
-
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
@@ -719,9 +716,6 @@ contains
        n  = upass_map(ipassive)
        nqp = qpass_map(ipassive)
 
-       ! since we merge 2- and 3-d, be sure not to update any velocities
-       if (nqp == QU .or. nqp == QV .or. nqp == QW) cycle
-
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
@@ -1161,9 +1155,6 @@ contains
        n  = upass_map(ipassive)
        nqp = qpass_map(ipassive)
 
-       ! since we merge 2- and 3-d, be sure not to update any velocities
-       if (nqp == QU .or. nqp == QV .or. nqp == QW) cycle
-
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
@@ -1596,9 +1587,6 @@ contains
     do ipassive = 1,npassive
        n  = upass_map(ipassive)
        nqp = qpass_map(ipassive)
-
-       ! since we merge 2- and 3-d, be sure not to update any velocities
-       if (nqp == QU .or. nqp == QV .or. nqp == QW) cycle
 
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)

--- a/Source/radiation/trace_ppm_rad_nd.F90
+++ b/Source/radiation/trace_ppm_rad_nd.F90
@@ -36,8 +36,8 @@ contains
                                    qrad, qradhi, qptot, qreitot, &
                                    small_dens, small_pres, &
                                    ppm_type, ppm_temp_fix, &
-                                   ppm_reference_eigenvectors, ppm_predict_gammae, &
-                                   npassive, qpass_map
+                                   ppm_reference_eigenvectors, ppm_predict_gammae
+
     use rad_params_module, only : ngroups
     use amrex_constants_module
     use prob_params_module, only : physbc_lo, physbc_hi, Outflow


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This removes QV and QW from the pass_map stuff for looping over passives.  This makes the code overall more consistent.  Note: in some places were we doing the same thing twice (overwriting the previous), with different floating point ops (multiplying by 1/rho instead of dividing by rho).

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
