### PR TITLE
Fix the double Mach reflection problem so it compiles for GPUs

### DIFF
--- a/Exec/hydro_tests/double_mach_reflection/Prob_nd.F90
+++ b/Exec/hydro_tests/double_mach_reflection/Prob_nd.F90
@@ -21,8 +21,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   namelist /fortin/ p_l, u_l, v_l, rho_l, rhoe_l, &
                     p_r, u_r, v_r, rho_r, rhoe_r, &
-                    T_l, T_r, frac, idir, &
-                    use_Tinit
+                    T_l, T_r, use_Tinit
 
   ! Build "probin" filename -- the name of file containing fortin namelist.
   integer, parameter :: maxlen=256
@@ -36,7 +35,17 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
      probin(i:i) = char(name(i))
   end do
 
+#if AMREX_SPACEDIM == 1 || AMREX_SPACEDIM == 3
+  call castro_error("ERROR: this problem only works for 2-d")
+#endif
+
   ! set namelist defaults
+
+  allocate(p_l)
+  allocate(u_l)
+  allocate(v_l)
+  allocate(rho_l)
+  allocate(T_l)
 
   p_l = 116.5             ! left pressure (erg/cc)
   u_l = 7.1447096          ! left u (cm/s)
@@ -44,11 +53,19 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   rho_l = 8.0             ! left density (g/cc)
   T_l = 1.0
 
+  allocate(p_r)
+  allocate(u_r)
+  allocate(v_r)
+  allocate(rho_r)
+  allocate(T_r)
+
   p_r = 1.0               ! right pressure (erg/cc)
   u_r = 0.0               ! right u (cm/s)
   v_r = 0.0               ! right v (cm/s)
   rho_r = 1.4             ! right density (g/cc)
   T_r = 1.0
+
+  allocate(use_Tinit)
 
   use_Tinit = .false.     ! optionally use T_l/r instead of p_l/r for initialization
 
@@ -63,6 +80,9 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   xn(:) = 0.0e0_rt
   xn(1) = 1.0e0_rt
 
+  allocate(rhoe_l)
+  allocate(rhoe_r)
+  
   if (use_Tinit) then
 
      eos_state%rho = rho_l
@@ -139,9 +159,9 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   use probdata_module
   use prob_params_module, only : problo
   use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEDEN, UEINT, UTEMP, UFS
-
-  use amrex_constants_module, only : M_PI, sixth
+  use amrex_constants_module, only : M_PI, SIXTH, HALF, THREE
   use amrex_fort_module, only : rt => amrex_real
+
   implicit none
 
   integer,  intent(in   ) :: level, nscal
@@ -150,36 +170,33 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   real(rt), intent(in   ) :: xlo(3), xhi(3), time, delta(3)
   real(rt), intent(inout) :: state(s_lo(1):s_hi(1), s_lo(2):s_hi(2), s_lo(3):s_hi(3), NVAR)
 
-  real(rt), parameter :: gp(2) = (/ -1.d0/sqrt(3.d0), 1.d0/sqrt(3.d0) /)
-  real(rt), parameter :: pi_over_3 = M_pi / 3.d0
+  real(rt), parameter :: pi_over_3 = M_pi / THREE
   real(rt), parameter :: ff = 0.25d0
 
   real(rt) :: x,y,xcen,ycen,shockfront
   integer  :: i, j, k, ii,jj
 
-#if AMREX_SPACEDIM == 1 || AMREX_SPACEDIM == 3
-  call castro_error("ERROR: this problem only works for 2-d")
-#endif
-
   do k = lo(3), hi(3)
      do j = lo(2), hi(2)
-        ycen = problo(2) + delta(2)*(dble(j)+ 0.5e0_rt)
+        ycen = problo(2) + delta(2) * (dble(j) + HALF)
 
         do i = lo(1), hi(1)
-           xcen = problo(1) + delta(1)*(dble(i)+ 0.5e0_rt)
+           xcen = problo(1) + delta(1) * (dble(i) + HALF)
 
            state(i,j,k,URHO   ) = 0.d0
            state(i,j,k,UMX:UMZ) = 0.d0
            state(i,j,k,UEDEN  ) = 0.d0
            state(i,j,k,UEINT  ) = 0.d0
 
-           do jj = 1, 2
-              y = ycen + 0.5d0*delta(2)*gp(jj)
+           do jj = -1, 1
+              if (jj == 0) cycle
+              y = ycen + HALF * delta(2) * (dble(jj) / sqrt(THREE))
 
-              do ii = 1, 2
-                 x = xcen + 0.5d0*delta(1)*gp(ii)
+              do ii = -1, 1
+                 if (ii == 0) cycle
+                 x = xcen + HALF * delta(1) * (dble(ii) / sqrt(THREE))
 
-                 shockfront = tan(pi_over_3)*(x - sixth) ! initial shock front
+                 shockfront = tan(pi_over_3) * (x - SIXTH) ! initial shock front
 
                  if (y .ge. shockfront ) then
                     state(i,j,k,URHO) = state(i,j,k,URHO) + ff*rho_l

--- a/Exec/hydro_tests/double_mach_reflection/bc_ext_fill_nd.F90
+++ b/Exec/hydro_tests/double_mach_reflection/bc_ext_fill_nd.F90
@@ -48,7 +48,6 @@ contains
     integer :: imin, imax, jmin, jmax, kmin, kmax
     real(rt) :: x, y, z, xcen, ycen, shockfront
 
-    real(rt), parameter :: gp(2) = (/ -1.d0/sqrt(THREE), 1.d0/sqrt(THREE) /)
     real(rt), parameter :: pi_over_3 = M_PI / THREE
     real(rt), parameter :: ff = FOURTH
 
@@ -88,9 +87,11 @@ contains
        end do
     endif
 
+#ifndef AMREX_USE_CUDA
     if (bc(1,2,1) == EXT_DIR .and. hi(1) > domhi(1)) then
        call castro_error("ERROR: special boundary not defined at +x")
     end if
+#endif
 
 #if AMREX_SPACEDIM >= 2
     !-------------------------------------------------------------------------
@@ -147,7 +148,7 @@ contains
 
        do k = lo(3), hi(3)
           do i = lo(1), hi(1)
-             xcen = problo(1) + delta(1)*(dble(i) + 0.5_rt)
+             xcen = problo(1) + delta(1) * (dble(i) + HALF)
 
              jmin = domhi(2)+1
              jmax = adv_hi(2)
@@ -157,7 +158,7 @@ contains
              end if
 #endif
              do j = jmin, jmax
-                ycen = problo(2) + delta(2)*(dble(j) + 0.5_rt)
+                ycen = problo(2) + delta(2) * (dble(j) + HALF)
 
                 adv(i,j,k,URHO ) = 0.d0
                 adv(i,j,k,UMX  ) = 0.d0
@@ -166,13 +167,15 @@ contains
                 adv(i,j,k,UEINT) = 0.d0
                 adv(i,j,k,UTEMP) = 0.d0
 
-                do jj = 1,2
-                   y = ycen + 0.5_rt*delta(2)*gp(jj)
+                do jj = -1, 1
+                   if (jj == 0) cycle
+                   y = ycen + HALF * delta(2) * (jj / sqrt(THREE))
 
                    shockfront = sixth + y/tan(pi_over_3) + (10.d0/sin(pi_over_3))*time
 
-                   do ii = 1,2
-                      x = xcen + 0.5_rt*delta(1)*gp(ii)
+                   do ii = -1, 1
+                      if (ii == 0) cycle
+                      x = xcen + HALF * delta(1) * (ii / sqrt(THREE))
 
                       if (x < shockfront) then
                          ! Post shock ICs
@@ -206,6 +209,7 @@ contains
 
 #endif
 
+#ifndef AMREX_USE_CUDA
 #if AMREX_SPACEDIM == 3
 
     !-------------------------------------------------------------------------
@@ -222,7 +226,7 @@ contains
        call castro_error("ERROR: +z special BCs not implemented")
     end if
 #endif
-
+#endif
 
   end subroutine ext_fill
 
@@ -253,7 +257,6 @@ contains
     integer :: imin, imax, jmin, jmax, kmin, kmax
     real(rt) :: x, y, z, xcen, ycen, shockfront
 
-    real(rt), parameter :: gp(2) = (/ -1.d0/sqrt(THREE), 1.d0/sqrt(THREE) /)
     real(rt), parameter :: pi_over_3 = M_PI / THREE
     real(rt), parameter :: ff = FOURTH
 
@@ -291,9 +294,11 @@ contains
        end do
     endif
 
+#ifndef AMREX_USE_CUDA
     if (bc(1,2) == EXT_DIR .and. hi(1) > domhi(1)) then
        call castro_error("ERROR: special boundary not defined at +x")
     end if
+#endif
 
 #if AMREX_SPACEDIM >= 2
     !-------------------------------------------------------------------------
@@ -336,7 +341,7 @@ contains
 
        do k = lo(3), hi(3)
           do i = lo(1), hi(1)
-             xcen = problo(1) + delta(1)*(dble(i) + 0.5_rt)
+             xcen = problo(1) + delta(1) * (dble(i) + HALF)
 
              jmin = domhi(2)+1
              jmax = adv_hi(2)
@@ -346,17 +351,19 @@ contains
              end if
 #endif
              do j = jmin, jmax
-                ycen = problo(2) + delta(2)*(dble(j) + 0.5_rt)
+                ycen = problo(2) + delta(2) * (dble(j) + HALF)
 
                 adv(i,j,k) = 0.d0
 
-                do jj = 1,2
-                   y = ycen + 0.5_rt*delta(2)*gp(jj)
+                do jj = -1, 1
+                   if (jj == 0) cycle
+                   y = ycen + HALF * delta(2) * (jj / sqrt(THREE))
 
                    shockfront = sixth + y/tan(pi_over_3) + (10.d0/sin(pi_over_3))*time
 
-                   do ii = 1,2
-                      x = xcen + 0.5_rt*delta(1)*gp(ii)
+                   do ii = -1, 1
+                      if (ii == 0) cycle
+                      x = xcen + HALF * delta(1) * (ii / sqrt(THREE))
 
                       if (x < shockfront) then
                          ! Post shock ICs
@@ -376,6 +383,7 @@ contains
 
 #endif
 
+#ifndef AMREX_USE_CUDA
 #if AMREX_SPACEDIM == 3
 
     !-------------------------------------------------------------------------
@@ -392,7 +400,7 @@ contains
        call castro_error("ERROR: +z special BCs not implemented")
     end if
 #endif
-
+#endif
 
   end subroutine ext_denfill
 

--- a/Exec/hydro_tests/double_mach_reflection/inputs.2d
+++ b/Exec/hydro_tests/double_mach_reflection/inputs.2d
@@ -43,7 +43,7 @@ amr.v                 = 1        # verbosity in Amr.cpp
 amr.max_level       = 0       # maximum level number allowed
 amr.ref_ratio       = 2 2 2 2 # refinement ratio
 amr.regrid_int      = 2       # how often to regrid
-amr.blocking_factor = 2      # block factor in grid generation
+amr.blocking_factor = 8      # block factor in grid generation
 
 # CHECKPOINT FILES
 amr.check_file      = chk    # root name of checkpoint file

--- a/Exec/hydro_tests/double_mach_reflection/inputs.2d.test
+++ b/Exec/hydro_tests/double_mach_reflection/inputs.2d.test
@@ -43,7 +43,7 @@ amr.v                 = 1        # verbosity in Amr.cpp
 amr.max_level       = 0       # maximum level number allowed
 amr.ref_ratio       = 2 2 2 2 # refinement ratio
 amr.regrid_int      = 2       # how often to regrid
-amr.blocking_factor = 2      # block factor in grid generation
+amr.blocking_factor = 8      # block factor in grid generation
 
 # CHECKPOINT FILES
 amr.check_file      = chk    # root name of checkpoint file

--- a/Exec/hydro_tests/double_mach_reflection/probdata.F90
+++ b/Exec/hydro_tests/double_mach_reflection/probdata.F90
@@ -1,15 +1,15 @@
 module probdata_module
 
-!     Sod variables
-      use amrex_fort_module, only : rt => amrex_real
-      real(rt)        , save ::  p_l, u_l, v_l, rho_l, p_r, u_r, v_r, rho_r, rhoe_l, rhoe_r, frac
-      real(rt)        , save :: T_l, T_r
+  use amrex_fort_module, only : rt => amrex_real
 
-      logical, save :: use_Tinit
+  implicit none
 
-!     These help specify which specific problem
-      integer        , save ::  probtype,idir
+  real(rt), allocatable :: p_l, u_l, v_l, rho_l, p_r, u_r, v_r, rho_r, rhoe_l, rhoe_r, T_l, T_r
+  logical, allocatable :: use_Tinit
 
-      real(rt)        , save :: split(3)
+#ifdef AMREX_USE_CUDA
+  attributes(managed) :: p_l, u_l, v_l, rho_l, p_r, u_r, v_r, rho_r, rhoe_l, rhoe_r, frac, T_l, T_r
+  attributes(managed) :: use_Tinit
+#endif
       
 end module probdata_module


### PR DESCRIPTION
## PR summary

The double Mach reflection problem did not compile with PGI due to the use of real parameter arrays (it complained about implied do loops). I replaced them with expressions calculated in the loop. I also fixed issues in the problem-specific bc_ext_fill_nd.F90 which prevented it from compiling with CUDA.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
