### PR TITLE
use abs() for velerror tagging

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+recent changes
+
+  -- The velerr tagging now takes the abs() of the velocity component
+     to ensure we tag large positive and negative velocities.
+
 # 19.08.1
 
   -- Fix CUDA compilation

--- a/Source/driver/Tagging_nd.F90
+++ b/Source/driver/Tagging_nd.F90
@@ -289,7 +289,7 @@ contains
        do k = lo(3), hi(3)
           do j = lo(2), hi(2)
              do i = lo(1), hi(1)
-                if (vel(i,j,k,1) .ge. velerr) then
+                if (abs(vel(i,j,k,1)) .ge. velerr) then
                    tag(i,j,k) = set
                 endif
              enddo


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

We now take abs() of the velocity component when comparing to velerr to consider for tagging.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
