### PR TITLE
swtich tagging from integer(1) to c_int8_t

### DIFF
--- a/Exec/hydro_tests/rotating_torus/problem_tagging_nd.F90
+++ b/Exec/hydro_tests/rotating_torus/problem_tagging_nd.F90
@@ -21,16 +21,17 @@ contains
     use castro_util_module, only: position
     use probdata_module, only: torus_center, torus_width
     use amrex_fort_module, only : rt => amrex_real
+    use iso_c_binding, only : c_int8_t
 
     implicit none
 
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: tag_lo(3),tag_hi(3)
     integer,    intent(in   ) :: state_lo(3), state_hi(3)
-    integer(1), intent(inout) :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
     real(rt),   intent(in   ) :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
     real(rt),   intent(in   ) :: dx(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: level
     real(rt),   intent(in   ), value :: time
 

--- a/Exec/hydro_tests/toy_convect/problem_tagging_nd.F90
+++ b/Exec/hydro_tests/toy_convect/problem_tagging_nd.F90
@@ -15,16 +15,17 @@ contains
 
     use meth_params_module, only: URHO, NVAR, UFS
     use probdata_module, only: H_min, cutoff_density
+    use iso_c_binding, only : c_int8_t
 
     implicit none
 
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: tag_lo(3), tag_hi(3)
     integer,    intent(in   ) :: state_lo(3), state_hi(3)
-    integer(1), intent(inout) :: tag(tag_lo(1):tag_hi(1), tag_lo(2):tag_hi(2), tag_lo(3):tag_hi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(tag_lo(1):tag_hi(1), tag_lo(2):tag_hi(2), tag_lo(3):tag_hi(3))
     real(rt),   intent(in   ) :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3), NVAR)
     real(rt),   intent(in   ) :: problo(3), dx(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: level
     real(rt),   intent(in   ), value :: time
 

--- a/Exec/science/convective_flame/problem_tagging_nd.F90
+++ b/Exec/science/convective_flame/problem_tagging_nd.F90
@@ -19,16 +19,17 @@ contains
     use probdata_module, only: refine_cutoff_height
     use prob_params_module, only : dim
     use amrex_fort_module, only : rt => amrex_real
+    use iso_c_binding, only : c_int8_t
 
     implicit none
 
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: tag_lo(3), tag_hi(3)
     integer,    intent(in   ) :: state_lo(3), state_hi(3)
-    integer(1), intent(inout) :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
     real(rt),   intent(in   ) :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
     real(rt),   intent(in   ) :: dx(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: level
     real(rt),   intent(in   ), value :: time
 

--- a/Exec/science/flame_wave/problem_tagging_nd.F90
+++ b/Exec/science/flame_wave/problem_tagging_nd.F90
@@ -20,16 +20,17 @@ contains
     use probdata_module, only: X_min, cutoff_density, &
                                max_hse_tagging_level, max_base_tagging_level, x_refine_distance
     use prob_params_module, only: center
+    use iso_c_binding, only : c_int8_t
 
     implicit none
 
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: tag_lo(3), tag_hi(3)
     integer,    intent(in   ) :: state_lo(3), state_hi(3)
-    integer(1), intent(inout) :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
     real(rt),   intent(in   ) :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
     real(rt),   intent(in   ) :: problo(3), dx(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: level
     real(rt),   intent(in   ), value :: time
 

--- a/Exec/science/wdmerger/problem_tagging_nd.F90
+++ b/Exec/science/wdmerger/problem_tagging_nd.F90
@@ -14,6 +14,7 @@ contains
                               bind(C,name='set_problem_tags')
 
     use amrex_fort_module, only: rt => amrex_real
+    use iso_c_binding, only : c_int8_t
     use amrex_constants_module, only: ZERO, HALF, TWO
     use meth_params_module, only: NVAR, URHO, UTEMP
     use prob_params_module, only: center, probhi, dim, Symmetry, physbc_lo, physbc_hi, &
@@ -34,10 +35,10 @@ contains
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: tag_lo(3), tag_hi(3)
     integer,    intent(in   ) :: state_lo(3), state_hi(3)
-    integer(1), intent(inout) :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(tag_lo(1):tag_hi(1),tag_lo(2):tag_hi(2),tag_lo(3):tag_hi(3))
     real(rt),   intent(in   ) :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3),NVAR)
     real(rt),   intent(in   ) :: dx(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: level
     real(rt),   intent(in   ), value :: time
 

--- a/Exec/science/xrb_mixed/problem_tagging_nd.F90
+++ b/Exec/science/xrb_mixed/problem_tagging_nd.F90
@@ -18,15 +18,17 @@ contains
     use probdata_module, only: H_min, cutoff_density
 
     use amrex_fort_module, only : rt => amrex_real
+    use iso_c_binding, only : c_int8_t
+
     implicit none
 
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: tag_lo(3), tag_hi(3)
     integer,    intent(in   ) :: state_lo(3), state_hi(3)
-    integer(1), intent(inout) :: tag(tag_lo(1):tag_hi(1), tag_lo(2):tag_hi(2), tag_lo(3):tag_hi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(tag_lo(1):tag_hi(1), tag_lo(2):tag_hi(2), tag_lo(3):tag_hi(3))
     real(rt),   intent(in   ) :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3), NVAR)
     real(rt),   intent(in   ) :: dx(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: level
     real(rt),   intent(in   ), value :: time
 

--- a/Source/driver/Tagging_nd.F90
+++ b/Source/driver/Tagging_nd.F90
@@ -1,6 +1,8 @@
 module tagging_module
 
   use amrex_fort_module, only : rt => amrex_real
+  use iso_c_binding, only : c_int8_t
+
 
   implicit none
 
@@ -75,10 +77,10 @@ contains
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: taglo(3), taghi(3)
     integer,    intent(in   ) :: denlo(3), denhi(3)
-    integer(1), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(rt),   intent(in   ) :: den(denlo(1):denhi(1),denlo(2):denhi(2),denlo(3):denhi(3),nd)
     real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: nd, level
     real(rt),   intent(in   ), value :: time
 
@@ -140,10 +142,10 @@ contains
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: taglo(3), taghi(3)
     integer,    intent(in   ) :: templo(3), temphi(3)
-    integer(1), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(rt),   intent(in   ) :: temp(templo(1):temphi(1),templo(2):temphi(2),templo(3):temphi(3),np)
     real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: np, level
     real(rt),   intent(in   ), value :: time
 
@@ -206,10 +208,10 @@ contains
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: taglo(3), taghi(3)
     integer,    intent(in   ) :: presslo(3), presshi(3)
-    integer(1), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(rt),   intent(in   ) :: press(presslo(1):presshi(1),presslo(2):presshi(2),presslo(3):presshi(3),np)
     real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: np, level
     real(rt),   intent(in   ), value :: time
 
@@ -272,10 +274,10 @@ contains
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: taglo(3), taghi(3)
     integer,    intent(in   ) :: vello(3), velhi(3)
-    integer(1), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(rt),   intent(in   ) :: vel(vello(1):velhi(1),vello(2):velhi(2),vello(3):velhi(3),nv)
     real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: nv, level
     real(rt),   intent(in   ), value :: time
 
@@ -338,10 +340,10 @@ contains
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: taglo(3), taghi(3)
     integer,    intent(in   ) :: radlo(3), radhi(3)
-    integer(1), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(rt),   intent(in   ) :: rad(radlo(1):radhi(1),radlo(2):radhi(2),radlo(3):radhi(3),nr)
     real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: nr, level
     real(rt),   intent(in   ), value :: time
 
@@ -405,10 +407,10 @@ contains
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: taglo(3), taghi(3)
     integer,    intent(in   ) :: tlo(3), thi(3)
-    integer(1), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(rt),   intent(in   ) :: t(tlo(1):thi(1),tlo(2):thi(2),tlo(3):thi(3),nr) ! t_sound / t_e
     real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: nr, level
     real(rt),   intent(in   ), value :: time
 
@@ -460,10 +462,10 @@ contains
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: taglo(3), taghi(3)
     integer,    intent(in   ) :: enuclo(3), enuchi(3)
-    integer(1), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(rt),   intent(in   ) :: enuc(enuclo(1):enuchi(1),enuclo(2):enuchi(2),enuclo(3):enuchi(3),nd)
     real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: nd, level
     real(rt),   intent(in   ), value :: time
 

--- a/Source/problems/problem_tagging_nd.F90
+++ b/Source/problems/problem_tagging_nd.F90
@@ -1,6 +1,7 @@
 module problem_tagging_module
 
   use amrex_fort_module, only: rt => amrex_real
+  use iso_c_binding, only : c_int8_t
 
   implicit none
 
@@ -24,10 +25,10 @@ contains
     integer,    intent(in   ) :: lo(3), hi(3)
     integer,    intent(in   ) :: tag_lo(3), tag_hi(3)
     integer,    intent(in   ) :: state_lo(3), state_hi(3)
-    integer(1), intent(inout) :: tag(tag_lo(1):tag_hi(1), tag_lo(2):tag_hi(2), tag_lo(3):tag_hi(3))
+    integer(kind=c_int8_t), intent(inout) :: tag(tag_lo(1):tag_hi(1), tag_lo(2):tag_hi(2), tag_lo(3):tag_hi(3))
     real(rt),   intent(in   ) :: state(state_lo(1):state_hi(1),state_lo(2):state_hi(2),state_lo(3):state_hi(3), NVAR)
     real(rt),   intent(in   ) :: problo(3), dx(3)
-    integer(1), intent(in   ), value :: set, clear
+    integer(kind=c_int8_t), intent(in   ), value :: set, clear
     integer,    intent(in   ), value :: level
     real(rt),   intent(in   ), value :: time
 

--- a/Util/scripts/write_probdata.py
+++ b/Util/scripts/write_probdata.py
@@ -140,8 +140,6 @@ def parse_param_file(param_file):
         current_param.size = size
         current_param.module = module
 
-        print(current_param)
-
         if not err == 1:
             params_list.append(current_param)
 
@@ -212,7 +210,6 @@ def write_probin(probin_template, param_file, out_file):
                 # declaraction statements
                 for p in params:
 
-                    print(p.dtype)
                     if p.dtype == "real":
                         if p.is_array():
                             decl_string = "{}real (kind=rt), allocatable, public :: {}(:)\n"


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This changes the type of the tagging stuff from `integer(1)` to `kind=c_int8_t`.  Closes #625 

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
