### PR TITLE
explicitly fill shk instead of setVal

### DIFF
--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -174,7 +174,9 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
       shk.resize(obx, 1);
       Elixir elix_shk = shk.elixir();
       fab_size += shk.nBytes();
-        
+
+      Array4<Real> const shk_arr = shk.array();
+
       // Multidimensional shock detection
       // Used for the hybrid Riemann solver
 
@@ -192,7 +194,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
                    AMREX_REAL_ANYD(dx));
       }
       else {
-          shk.setVal(0.0);
+        AMREX_PARALLEL_FOR_3D(obx, i, j, k, { shk_arr(i,j,k) = 0.0; });
       }
 
       qxm.resize(obx, NQ);


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This gets rid of the `.setVal()` on `shk` and instead fills it via a loop.  Closes #680 

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
