### PR TITLE
Avoid an unnecessary EOS call in diffusion

### DIFF
--- a/Source/diffusion/Diffusion_nd.F90
+++ b/Source/diffusion/Diffusion_nd.F90
@@ -47,18 +47,17 @@ contains
        do j = lo(2), hi(2)
           do i = lo(1), hi(1)
 
-             eos_state%rho    = state(i,j,k,URHO)
-             eos_state%T      = state(i,j,k,UTEMP)   ! needed as an initial guess
-             eos_state%e      = state(i,j,k,UEINT)/state(i,j,k,URHO)
-             eos_state%xn(:)  = state(i,j,k,UFS:UFS-1+nspec)/ state(i,j,k,URHO)
-             eos_state%aux(:) = state(i,j,k,UFX:UFX-1+naux)/ state(i,j,k,URHO)
+             ! Fill in the EOS state for the conductivity call.
+             ! We do not need to actually call the EOS here to
+             ! get T consistent with E, since that should already
+             ! be true due to the clean_state call prior to
+             ! computing the source terms.
 
-             if (eos_state%e < ZERO) then
-                eos_state%T = small_temp
-                call eos(eos_input_rt,eos_state)
-             else
-                call eos(eos_input_re,eos_state)
-             endif
+             eos_state%rho    = state(i,j,k,URHO)
+             eos_state%T      = state(i,j,k,UTEMP)
+             eos_state%e      = state(i,j,k,UEINT) / state(i,j,k,URHO)
+             eos_state%xn(:)  = state(i,j,k,UFS:UFS-1+nspec) / state(i,j,k,URHO)
+             eos_state%aux(:) = state(i,j,k,UFX:UFX-1+naux) / state(i,j,k,URHO)
 
              if (eos_state%rho > diffuse_cutoff_density) then
                 call conductivity(eos_state)


### PR DESCRIPTION
## PR summary

`ca_fill_temp_cond` has an unnecessary EOS call -- we already call the EOS to get a consistent temperature when we call `clean_state`.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
