### PR TITLE
Inline pdivu

### DIFF
--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -114,7 +114,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
     FArrayBox qmxz, qpxz;
     FArrayBox qmyz, qpyz;
 #endif
-    FArrayBox pdivu;
 
     size_t starting_size = MultiFab::queryMemUsage("AmrLevel_Level_" + std::to_string(level));
     size_t current_size = starting_size;
@@ -1111,10 +1110,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
 
 
-      pdivu.resize(bx, 1);
-      Elixir elix_pdivu = pdivu.elixir();
-      fab_size += pdivu.nBytes();
-
       // conservative update
 
 #pragma gpu box(bx)
@@ -1158,7 +1153,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
                  BL_TO_FORTRAN_ANYD(area[2][mfi]),
 #endif
                  BL_TO_FORTRAN_ANYD(volume[mfi]),
-                 BL_TO_FORTRAN_ANYD(pdivu),
                  AMREX_REAL_ANYD(dx), dt);
 
 #ifdef RADIATION

--- a/Source/hydro/Castro_ctu_nd.F90
+++ b/Source/hydro/Castro_ctu_nd.F90
@@ -428,7 +428,6 @@ contains
        area3, area3_lo, area3_hi, &
 #endif
        vol, vol_lo, vol_hi, &
-       pdivu, pdivu_lo, pdivu_hi, &
        dx, dt) bind(C, name="ctu_consup")
 
     use meth_params_module, only : difmag, NVAR, URHO, UMX, UMY, UMZ, &
@@ -438,7 +437,7 @@ contains
          GDU, GDV, GDW, GDLAMS, GDERADS, &
 #endif
          GDPRES
-    use advection_util_module, only : calc_pdivu
+    use advection_util_module, only: pdivu ! function
     use prob_params_module, only : mom_flux_has_p, center, dg
 #ifdef RADIATION
     use rad_params_module, only : ngroups, nugroup, dlognu
@@ -472,7 +471,6 @@ contains
 #endif
     integer, intent(in) ::    qx_lo(3),    qx_hi(3)
     integer, intent(in) ::   vol_lo(3),   vol_hi(3)
-    integer, intent(in) ::   pdivu_lo(3),   pdivu_hi(3)
 #ifdef RADIATION
     integer, intent(in) ::  uout_lo(3),  uout_hi(3)
     integer, intent(in) :: Erout_lo(3), Erout_hi(3)
@@ -509,7 +507,6 @@ contains
 #endif
 
     real(rt), intent(in) :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
-    real(rt), intent(inout) :: pdivu(pdivu_lo(1):pdivu_hi(1),pdivu_lo(2):pdivu_hi(2),pdivu_lo(3):pdivu_hi(3))
     real(rt), intent(in) :: dx(3)
     real(rt), intent(in), value :: dt
 
@@ -557,21 +554,6 @@ contains
     end if
 #endif
 
-    call calc_pdivu(lo, hi, &
-         qx, qx_lo, qx_hi, &
-         area1, area1_lo, area1_hi, &
-#if AMREX_SPACEDIM >= 2
-         qy, qy_lo, qy_hi, &
-         area2, area2_lo, area2_hi, &
-#endif
-#if AMREX_SPACEDIM == 3
-         qz, qz_lo, qz_hi, &
-         area3, area3_lo, area3_hi, &
-#endif
-         vol, vol_lo, vol_hi, &
-         dx, pdivu, pdivu_lo, pdivu_hi)
-
-
     ! For hydro, we will create an update source term that is
     ! essentially the flux divergence.  This can be added with dt to
     ! get the update
@@ -595,7 +577,18 @@ contains
 
                 ! Add the p div(u) source term to (rho e).
                 if (n .eq. UEINT) then
-                   update(i,j,k,n) = update(i,j,k,n) - pdivu(i,j,k)
+                   update(i,j,k,n) = update(i,j,k,n) - pdivu(i, j, k, &
+                                                             qx, qx_lo, qx_hi, &
+                                                             area1, area1_lo, area1_hi, &
+#if AMREX_SPACEDIM >= 2
+                                                             qy, qy_lo, qy_hi, &
+                                                             area2, area2_lo, area2_hi, &
+#endif
+#if AMREX_SPACEDIM == 3
+                                                             qz, qz_lo, qz_hi, &
+                                                             area3, area3_lo, area3_hi, &
+#endif
+                                                             vol, vol_lo, vol_hi)
                 endif
 
              enddo

--- a/Source/hydro/Castro_hydro_F.H
+++ b/Source/hydro/Castro_hydro_F.H
@@ -87,7 +87,6 @@ extern "C"
      const BL_FORT_FAB_ARG_3D(area2),
 #endif
      const BL_FORT_FAB_ARG_3D(volume),
-     const BL_FORT_FAB_ARG_3D(pdivu),
      const amrex::Real* dx, const amrex::Real dt);
 
   void scale_flux

--- a/Source/hydro/advection_util_nd.F90
+++ b/Source/hydro/advection_util_nd.F90
@@ -1380,36 +1380,28 @@ contains
   ! ::: ------------------------------------------------------------------
   ! :::
 
-
-
-  subroutine calc_pdivu(lo, hi, &
-                        q1, q1_lo, q1_hi, &
-                        area1, a1_lo, a1_hi, &
+  function pdivu(i, j, k, &
+                 q1, q1_lo, q1_hi, &
+                 area1, a1_lo, a1_hi, &
 #if AMREX_SPACEDIM >= 2
-                        q2, q2_lo, q2_hi, &
-                        area2, a2_lo, a2_hi, &
+                 q2, q2_lo, q2_hi, &
+                 area2, a2_lo, a2_hi, &
 #endif
 #if AMREX_SPACEDIM == 3
-                        q3, q3_lo, q3_hi, &
-                        area3, a3_lo, a3_hi, &
+                 q3, q3_lo, q3_hi, &
+                 area3, a3_lo, a3_hi, &
 #endif
-                        vol, v_lo, v_hi, &
-                        dx, pdivu, div_lo, div_hi)
+                 vol, v_lo, v_hi) result(pdu)
     ! this computes the cell-centered p div(U) term from the
     ! edge-centered Godunov state.  This is used in the internal energy
     ! update
-    !
 
-    use meth_params_module, only : NGDNV, GDPRES, GDU, GDV, GDW
-    use amrex_constants_module, only : HALF
-    use amrex_fort_module, only : rt => amrex_real
+    use meth_params_module, only: NGDNV, GDPRES, GDU, GDV, GDW
+    use amrex_constants_module, only: HALF, ONE
+
     implicit none
 
-    integer, intent(in) :: lo(3), hi(3)
-
-    integer, intent(in) :: div_lo(3), div_hi(3)
-    real(rt), intent(in) :: dx(3)
-    real(rt), intent(inout) :: pdivu(div_lo(1):div_hi(1),div_lo(2):div_hi(2),div_lo(3):div_hi(3))
+    integer, intent(in) :: i, j, k
 
     integer, intent(in) :: q1_lo(3), q1_hi(3)
     integer, intent(in) :: a1_lo(3), a1_hi(3)
@@ -1430,43 +1422,30 @@ contains
     integer, intent(in) :: v_lo(3), v_hi(3)
     real(rt), intent(in) :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
-    integer  :: i, j, k
+    real(rt) :: volinv
+    real(rt) :: pdu
 
     !$gpu
 
-    do k = lo(3), hi(3)
-       do j = lo(2), hi(2)
-          do i = lo(1), hi(1)
+    pdu = (q1(i+1,j,k,GDPRES) + q1(i,j,k,GDPRES)) * &
+            (q1(i+1,j,k,GDU) * area1(i+1,j,k) - q1(i,j,k,GDU) * area1(i,j,k))
 
-#if AMREX_SPACEDIM == 1
-             pdivu(i,j,k) = HALF * &
-                  (q1(i+1,j,k,GDPRES) + q1(i,j,k,GDPRES))* &
-                  (q1(i+1,j,k,GDU)*area1(i+1,j,k) - q1(i,j,k,GDU)*area1(i,j,k)) / vol(i,j,k)
-#endif
-
-#if AMREX_SPACEDIM == 2
-             pdivu(i,j,k) = HALF*( &
-                  (q1(i+1,j,k,GDPRES) + q1(i,j,k,GDPRES)) * &
-                  (q1(i+1,j,k,GDU)*area1(i+1,j,k) - q1(i,j,k,GDU)*area1(i,j,k)) + &
-                  (q2(i,j+1,k,GDPRES) + q2(i,j,k,GDPRES)) * &
-                  (q2(i,j+1,k,GDV)*area2(i,j+1,k) - q2(i,j,k,GDV)*area2(i,j,k)) ) / vol(i,j,k)
+#if AMREX_SPACEDIM >= 2
+    pdu = pdu + &
+            (q2(i,j+1,k,GDPRES) + q2(i,j,k,GDPRES)) * &
+            (q2(i,j+1,k,GDV) * area2(i,j+1,k) - q2(i,j,k,GDV) * area2(i,j,k))
 #endif
 
 #if AMREX_SPACEDIM == 3
-             pdivu(i,j,k) = &
-                  HALF*(q1(i+1,j,k,GDPRES) + q1(i,j,k,GDPRES)) * &
-                  (q1(i+1,j,k,GDU) - q1(i,j,k,GDU))/dx(1) + &
-                  HALF*(q2(i,j+1,k,GDPRES) + q2(i,j,k,GDPRES)) * &
-                  (q2(i,j+1,k,GDV) - q2(i,j,k,GDV))/dx(2) + &
-                  HALF*(q3(i,j,k+1,GDPRES) + q3(i,j,k,GDPRES)) * &
-                  (q3(i,j,k+1,GDW) - q3(i,j,k,GDW))/dx(3)
+    pdu = pdu + &
+            (q3(i,j,k+1,GDPRES) + q3(i,j,k,GDPRES)) * &
+            (q3(i,j,k+1,GDW) * area3(i,j,k+1) - q3(i,j,k,GDW) * area3(i,j,k))
 #endif
 
-          enddo
-       enddo
-    enddo
+    volinv = ONE / vol(i,j,k)
+    pdu = HALF * pdu * volinv
 
-  end subroutine calc_pdivu
+  end function pdivu
 
 
 


### PR DESCRIPTION
## PR summary

There is no need to store a fab for pdivu, it can just be calculated on demand on a per-zone basis in the update.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
