### PR TITLE
split the X derivatives from eos_t

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -322,8 +322,8 @@ ifndef GENERAL_NET_INPUTS
    endif
 endif
 
-EXTERN_CORE += $(EOS_HOME)
 EXTERN_CORE += $(EOS_PATH)
+EXTERN_CORE += $(EOS_HOME)
 
 # the helmholtz EOS has an include file -- also add a target to link
 # the table into the problem directory.

--- a/Microphysics/EOS/eos.F90
+++ b/Microphysics/EOS/eos.F90
@@ -120,9 +120,6 @@ contains
   subroutine eos(input, state)
 
     use eos_type_module, only: eos_t, composition
-#ifdef EXTRA_THERMO
-    use eos_type_module, only : composition_derivatives
-#endif
     use actual_eos_module, only: actual_eos
     use eos_override_module, only: eos_override
 #if (!(defined(AMREX_USE_CUDA) || defined(AMREX_USE_ACC)))
@@ -166,12 +163,6 @@ contains
     if (.not. has_been_reset) then
        call actual_eos(input, state)
     endif
-
-#if EXTRA_THERMO
-    ! Get dpdX, dedX, dhdX.
-
-    call composition_derivatives(state)
-#endif
 
   end subroutine eos
 

--- a/Microphysics/EOS/eos.F90
+++ b/Microphysics/EOS/eos.F90
@@ -119,7 +119,8 @@ contains
 
   subroutine eos(input, state)
 
-    use eos_type_module, only: eos_t, composition
+    use eos_type_module, only: eos_t
+    use eos_composition_module, only : composition
     use actual_eos_module, only: actual_eos
     use eos_override_module, only: eos_override
 #if (!(defined(AMREX_USE_CUDA) || defined(AMREX_USE_ACC)))

--- a/Microphysics/EOS/eos_type.F90
+++ b/Microphysics/EOS/eos_type.F90
@@ -220,6 +220,7 @@ contains
     to_eos % abar = from_eos % abar
     to_eos % zbar = from_eos % zbar
 
+#ifdef EXTRA_THERMO
     to_eos % dpdA = from_eos % dpdA
     to_eos % dpdZ = from_eos % dpdZ
     to_eos % dedA = from_eos % dedA

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -114,7 +114,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
     FArrayBox qmxz, qpxz;
     FArrayBox qmyz, qpyz;
 #endif
-    FArrayBox pdivu;
 
     size_t starting_size = MultiFab::queryMemUsage("AmrLevel_Level_" + std::to_string(level));
     size_t current_size = starting_size;
@@ -1111,10 +1110,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
 
 
-      pdivu.resize(bx, 1);
-      Elixir elix_pdivu = pdivu.elixir();
-      fab_size += pdivu.nBytes();
-
       // conservative update
 
 #pragma gpu box(bx)
@@ -1158,7 +1153,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
                  BL_TO_FORTRAN_ANYD(area[2][mfi]),
 #endif
                  BL_TO_FORTRAN_ANYD(volume[mfi]),
-                 BL_TO_FORTRAN_ANYD(pdivu),
                  AMREX_REAL_ANYD(dx), dt);
 
 #ifdef RADIATION

--- a/Source/hydro/Castro_ctu_nd.F90
+++ b/Source/hydro/Castro_ctu_nd.F90
@@ -428,7 +428,6 @@ contains
        area3, area3_lo, area3_hi, &
 #endif
        vol, vol_lo, vol_hi, &
-       pdivu, pdivu_lo, pdivu_hi, &
        dx, dt) bind(C, name="ctu_consup")
 
     use meth_params_module, only : difmag, NVAR, URHO, UMX, UMY, UMZ, &
@@ -438,7 +437,7 @@ contains
          GDU, GDV, GDW, GDLAMS, GDERADS, &
 #endif
          GDPRES
-    use advection_util_module, only : calc_pdivu
+    use advection_util_module, only: pdivu ! function
     use prob_params_module, only : mom_flux_has_p, center, dg
 #ifdef RADIATION
     use rad_params_module, only : ngroups, nugroup, dlognu
@@ -472,7 +471,6 @@ contains
 #endif
     integer, intent(in) ::    qx_lo(3),    qx_hi(3)
     integer, intent(in) ::   vol_lo(3),   vol_hi(3)
-    integer, intent(in) ::   pdivu_lo(3),   pdivu_hi(3)
 #ifdef RADIATION
     integer, intent(in) ::  uout_lo(3),  uout_hi(3)
     integer, intent(in) :: Erout_lo(3), Erout_hi(3)
@@ -509,7 +507,6 @@ contains
 #endif
 
     real(rt), intent(in) :: vol(vol_lo(1):vol_hi(1),vol_lo(2):vol_hi(2),vol_lo(3):vol_hi(3))
-    real(rt), intent(inout) :: pdivu(pdivu_lo(1):pdivu_hi(1),pdivu_lo(2):pdivu_hi(2),pdivu_lo(3):pdivu_hi(3))
     real(rt), intent(in) :: dx(3)
     real(rt), intent(in), value :: dt
 
@@ -557,21 +554,6 @@ contains
     end if
 #endif
 
-    call calc_pdivu(lo, hi, &
-         qx, qx_lo, qx_hi, &
-         area1, area1_lo, area1_hi, &
-#if AMREX_SPACEDIM >= 2
-         qy, qy_lo, qy_hi, &
-         area2, area2_lo, area2_hi, &
-#endif
-#if AMREX_SPACEDIM == 3
-         qz, qz_lo, qz_hi, &
-         area3, area3_lo, area3_hi, &
-#endif
-         vol, vol_lo, vol_hi, &
-         dx, pdivu, pdivu_lo, pdivu_hi)
-
-
     ! For hydro, we will create an update source term that is
     ! essentially the flux divergence.  This can be added with dt to
     ! get the update
@@ -595,7 +577,18 @@ contains
 
                 ! Add the p div(u) source term to (rho e).
                 if (n .eq. UEINT) then
-                   update(i,j,k,n) = update(i,j,k,n) - pdivu(i,j,k)
+                   update(i,j,k,n) = update(i,j,k,n) - pdivu(i, j, k, &
+                                                             qx, qx_lo, qx_hi, &
+                                                             area1, area1_lo, area1_hi, &
+#if AMREX_SPACEDIM >= 2
+                                                             qy, qy_lo, qy_hi, &
+                                                             area2, area2_lo, area2_hi, &
+#endif
+#if AMREX_SPACEDIM == 3
+                                                             qz, qz_lo, qz_hi, &
+                                                             area3, area3_lo, area3_hi, &
+#endif
+                                                             vol, vol_lo, vol_hi)
                 endif
 
              enddo

--- a/Source/hydro/Castro_hydro_F.H
+++ b/Source/hydro/Castro_hydro_F.H
@@ -87,7 +87,6 @@ extern "C"
      const BL_FORT_FAB_ARG_3D(area2),
 #endif
      const BL_FORT_FAB_ARG_3D(volume),
-     const BL_FORT_FAB_ARG_3D(pdivu),
      const amrex::Real* dx, const amrex::Real dt);
 
   void scale_flux

--- a/Source/hydro/advection_util_nd.F90
+++ b/Source/hydro/advection_util_nd.F90
@@ -1380,36 +1380,28 @@ contains
   ! ::: ------------------------------------------------------------------
   ! :::
 
-
-
-  subroutine calc_pdivu(lo, hi, &
-                        q1, q1_lo, q1_hi, &
-                        area1, a1_lo, a1_hi, &
+  function pdivu(i, j, k, &
+                 q1, q1_lo, q1_hi, &
+                 area1, a1_lo, a1_hi, &
 #if AMREX_SPACEDIM >= 2
-                        q2, q2_lo, q2_hi, &
-                        area2, a2_lo, a2_hi, &
+                 q2, q2_lo, q2_hi, &
+                 area2, a2_lo, a2_hi, &
 #endif
 #if AMREX_SPACEDIM == 3
-                        q3, q3_lo, q3_hi, &
-                        area3, a3_lo, a3_hi, &
+                 q3, q3_lo, q3_hi, &
+                 area3, a3_lo, a3_hi, &
 #endif
-                        vol, v_lo, v_hi, &
-                        dx, pdivu, div_lo, div_hi)
+                 vol, v_lo, v_hi) result(pdu)
     ! this computes the cell-centered p div(U) term from the
     ! edge-centered Godunov state.  This is used in the internal energy
     ! update
-    !
 
-    use meth_params_module, only : NGDNV, GDPRES, GDU, GDV, GDW
-    use amrex_constants_module, only : HALF
-    use amrex_fort_module, only : rt => amrex_real
+    use meth_params_module, only: NGDNV, GDPRES, GDU, GDV, GDW
+    use amrex_constants_module, only: HALF, ONE
+
     implicit none
 
-    integer, intent(in) :: lo(3), hi(3)
-
-    integer, intent(in) :: div_lo(3), div_hi(3)
-    real(rt), intent(in) :: dx(3)
-    real(rt), intent(inout) :: pdivu(div_lo(1):div_hi(1),div_lo(2):div_hi(2),div_lo(3):div_hi(3))
+    integer, intent(in) :: i, j, k
 
     integer, intent(in) :: q1_lo(3), q1_hi(3)
     integer, intent(in) :: a1_lo(3), a1_hi(3)
@@ -1430,43 +1422,30 @@ contains
     integer, intent(in) :: v_lo(3), v_hi(3)
     real(rt), intent(in) :: vol(v_lo(1):v_hi(1),v_lo(2):v_hi(2),v_lo(3):v_hi(3))
 
-    integer  :: i, j, k
+    real(rt) :: volinv
+    real(rt) :: pdu
 
     !$gpu
 
-    do k = lo(3), hi(3)
-       do j = lo(2), hi(2)
-          do i = lo(1), hi(1)
+    pdu = (q1(i+1,j,k,GDPRES) + q1(i,j,k,GDPRES)) * &
+            (q1(i+1,j,k,GDU) * area1(i+1,j,k) - q1(i,j,k,GDU) * area1(i,j,k))
 
-#if AMREX_SPACEDIM == 1
-             pdivu(i,j,k) = HALF * &
-                  (q1(i+1,j,k,GDPRES) + q1(i,j,k,GDPRES))* &
-                  (q1(i+1,j,k,GDU)*area1(i+1,j,k) - q1(i,j,k,GDU)*area1(i,j,k)) / vol(i,j,k)
-#endif
-
-#if AMREX_SPACEDIM == 2
-             pdivu(i,j,k) = HALF*( &
-                  (q1(i+1,j,k,GDPRES) + q1(i,j,k,GDPRES)) * &
-                  (q1(i+1,j,k,GDU)*area1(i+1,j,k) - q1(i,j,k,GDU)*area1(i,j,k)) + &
-                  (q2(i,j+1,k,GDPRES) + q2(i,j,k,GDPRES)) * &
-                  (q2(i,j+1,k,GDV)*area2(i,j+1,k) - q2(i,j,k,GDV)*area2(i,j,k)) ) / vol(i,j,k)
+#if AMREX_SPACEDIM >= 2
+    pdu = pdu + &
+            (q2(i,j+1,k,GDPRES) + q2(i,j,k,GDPRES)) * &
+            (q2(i,j+1,k,GDV) * area2(i,j+1,k) - q2(i,j,k,GDV) * area2(i,j,k))
 #endif
 
 #if AMREX_SPACEDIM == 3
-             pdivu(i,j,k) = &
-                  HALF*(q1(i+1,j,k,GDPRES) + q1(i,j,k,GDPRES)) * &
-                  (q1(i+1,j,k,GDU) - q1(i,j,k,GDU))/dx(1) + &
-                  HALF*(q2(i,j+1,k,GDPRES) + q2(i,j,k,GDPRES)) * &
-                  (q2(i,j+1,k,GDV) - q2(i,j,k,GDV))/dx(2) + &
-                  HALF*(q3(i,j,k+1,GDPRES) + q3(i,j,k,GDPRES)) * &
-                  (q3(i,j,k+1,GDW) - q3(i,j,k,GDW))/dx(3)
+    pdu = pdu + &
+            (q3(i,j,k+1,GDPRES) + q3(i,j,k,GDPRES)) * &
+            (q3(i,j,k+1,GDW) * area3(i,j,k+1) - q3(i,j,k,GDW) * area3(i,j,k))
 #endif
 
-          enddo
-       enddo
-    enddo
+    volinv = ONE / vol(i,j,k)
+    pdu = HALF * pdu * volinv
 
-  end subroutine calc_pdivu
+  end function pdivu
 
 
 

--- a/Source/sdc/sdc_util.F90
+++ b/Source/sdc/sdc_util.F90
@@ -526,7 +526,7 @@ contains
     use react_util_module
     use eos_type_module, only : eos_t, eos_input_re
     use eos_module, only : eos
-    use eos_composition_module, only : eos_comp_t, composition_derivatives
+    use eos_composition_module, only : eos_xderivs_t, composition_derivatives
     use amrex_constants_module, only : ZERO, HALF, ONE
     use vode_rpar_indices
     use extern_probin_module, only : small_x
@@ -545,7 +545,7 @@ contains
     real(rt) :: R_react(0:neq-1), f_source(0:neq-1)
     type(burn_t) :: burn_state
     type(eos_t) :: eos_state
-    type(eos_comp_t) :: eos_comp
+    type(eos_xderivs_t) :: eos_xderivs
     real(rt) :: dt_m
 
     real(rt) :: denom
@@ -622,21 +622,21 @@ contains
        dwdU(m,m) = ONE/U(0)
     enddo
 
-    call composition_derivatives(eos_state, eos_comp)
+    call composition_derivatives(eos_state, eos_xderivs)
 
     ! now the T row -- this depends on whether we are evolving (rho E) or (rho e)
     denom = ONE/(eos_state % rho * eos_state % dedT)
     if (sdc_solve_for_rhoe == 1) then
-       dwdU(nspec_evolve+1,0) = denom*(sum(eos_state % xn(1:nspec_evolve) * eos_comp % dedX(1:nspec_evolve)) - &
+       dwdU(nspec_evolve+1,0) = denom*(sum(eos_state % xn(1:nspec_evolve) * eos_xderivs % dedX(1:nspec_evolve)) - &
                                        eos_state % rho * eos_state % dedr - eos_state % e)
     else
-       dwdU(nspec_evolve+1,0) = denom*(sum(eos_state % xn(1:nspec_evolve) * eos_comp % dedX(1:nspec_evolve)) - &
+       dwdU(nspec_evolve+1,0) = denom*(sum(eos_state % xn(1:nspec_evolve) * eos_xderivs % dedX(1:nspec_evolve)) - &
                                        eos_state % rho * eos_state % dedr - eos_state % e + &
                                        HALF*sum(U_full(UMX:UMZ)**2)/eos_state % rho**2)
     endif
 
     do m = 1, nspec_evolve
-       dwdU(nspec_evolve+1,m) = -denom * eos_comp % dedX(m)
+       dwdU(nspec_evolve+1,m) = -denom * eos_xderivs % dedX(m)
     enddo
 
     dwdU(nspec_evolve+1, nspec_evolve+1) = denom

--- a/Source/sdc/sdc_vode.F90
+++ b/Source/sdc/sdc_vode.F90
@@ -68,6 +68,7 @@ contains
     use meth_params_module, only : nvar, URHO, UFS, UEDEN, UTEMP, UMX, UMZ, UEINT
     use burn_type_module
     use eos_type_module, only : eos_t, eos_input_re
+    use eos_composition_module, only : eos_comp_t, composition_derivatives
     use eos_module, only : eos
     use vode_rpar_indices
     use react_util_module
@@ -81,6 +82,7 @@ contains
 
     type(burn_t) :: burn_state
     type(eos_t) :: eos_state
+    type(eos_comp_t) :: eos_comp
 
     real(rt) :: U_full(nvar),  R_full(nvar)
 
@@ -128,13 +130,15 @@ contains
        dwdU(m,m) = ONE/U(0)
     enddo
 
+    call composition_derivatives(eos_state, eos_comp)
+
     ! now the T row -- this depends on whether we are evolving (rho E) or (rho e)
     denom = ONE/(eos_state % rho * eos_state % dedT)
-    dwdU(nspec_evolve+1,0) = denom*(sum(eos_state % xn(1:nspec_evolve) * eos_state % dedX(1:nspec_evolve)) - &
+    dwdU(nspec_evolve+1,0) = denom*(sum(eos_state % xn(1:nspec_evolve) * eos_comp % dedX(1:nspec_evolve)) - &
                                     eos_state % rho * eos_state % dedr - eos_state % e)
 
     do m = 1, nspec_evolve
-       dwdU(nspec_evolve+1,m) = -denom * eos_state % dedX(m)
+       dwdU(nspec_evolve+1,m) = -denom * eos_comp % dedX(m)
     enddo
 
     dwdU(nspec_evolve+1, nspec_evolve+1) = denom

--- a/Source/sdc/sdc_vode.F90
+++ b/Source/sdc/sdc_vode.F90
@@ -68,7 +68,7 @@ contains
     use meth_params_module, only : nvar, URHO, UFS, UEDEN, UTEMP, UMX, UMZ, UEINT
     use burn_type_module
     use eos_type_module, only : eos_t, eos_input_re
-    use eos_composition_module, only : eos_comp_t, composition_derivatives
+    use eos_composition_module, only : eos_xderivs_t, composition_derivatives
     use eos_module, only : eos
     use vode_rpar_indices
     use react_util_module
@@ -82,7 +82,7 @@ contains
 
     type(burn_t) :: burn_state
     type(eos_t) :: eos_state
-    type(eos_comp_t) :: eos_comp
+    type(eos_xderivs_t) :: eos_xderivs
 
     real(rt) :: U_full(nvar),  R_full(nvar)
 
@@ -130,15 +130,15 @@ contains
        dwdU(m,m) = ONE/U(0)
     enddo
 
-    call composition_derivatives(eos_state, eos_comp)
+    call composition_derivatives(eos_state, eos_xderivs)
 
     ! now the T row -- this depends on whether we are evolving (rho E) or (rho e)
     denom = ONE/(eos_state % rho * eos_state % dedT)
-    dwdU(nspec_evolve+1,0) = denom*(sum(eos_state % xn(1:nspec_evolve) * eos_comp % dedX(1:nspec_evolve)) - &
+    dwdU(nspec_evolve+1,0) = denom*(sum(eos_state % xn(1:nspec_evolve) * eos_xderivs % dedX(1:nspec_evolve)) - &
                                     eos_state % rho * eos_state % dedr - eos_state % e)
 
     do m = 1, nspec_evolve
-       dwdU(nspec_evolve+1,m) = -denom * eos_comp % dedX(m)
+       dwdU(nspec_evolve+1,m) = -denom * eos_xderivs % dedX(m)
     enddo
 
     dwdU(nspec_evolve+1, nspec_evolve+1) = denom


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This PR coordinates with https://github.com/starkiller-astro/Microphysics/pull/207 to remove the composition derivatives from `eos_t` to boost GPU performance.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
