### PR TITLE
Call EOS on host explicitly in probinit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # changes since the last release
 
+   * A subroutine eos_on_host has been added to the EOS module.
+     This is a wrapper for the EOS that must be used for CUDA
+     builds if the EOS is being called in probinit or other
+     places that don't run on the GPU. (#693)
+
    * We now use VODE90 instead of VODE by default. (#677)
 
 # 19.11

--- a/Exec/gravity_tests/DustCollapse/Prob_nd.F90
+++ b/Exec/gravity_tests/DustCollapse/Prob_nd.F90
@@ -7,7 +7,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
                              r_old, r_old_s, r_0, smooth_delta, r_offset, offset_smooth_delta, &
                              center_x, center_y, center_z, nsub
   use eos_type_module, only: eos_t, eos_input_rp
-  use eos_module, only: eos
+  use eos_module, only: eos_on_host
   use network, only: nspec
   use meth_params_module, only: small_temp
   use prob_params_module, only: center
@@ -59,13 +59,13 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   eos_state % xn  = x_0
   eos_state % T   = small_temp ! Initial guess for the EOS
 
-  call eos(eos_input_rp, eos_state)
+  call eos_on_host(eos_input_rp, eos_state)
 
   T_0 = eos_state % T
 
   eos_state % rho = rho_ambient
 
-  call eos(eos_input_rp, eos_state)
+  call eos_on_host(eos_input_rp, eos_state)
 
   T_ambient = eos_state % T
 

--- a/Exec/gravity_tests/code_comp/model_util.F90
+++ b/Exec/gravity_tests/code_comp/model_util.F90
@@ -74,7 +74,7 @@ contains
     use amrex_constants_module, only: HALF, ZERO, M_PI, ONE
     use amrex_fort_module, only : rt => amrex_real
     use eos_type_module, only: eos_input_rp, eos_t
-    use eos_module, only: eos
+    use eos_module, only: eos_on_host
     use prescribe_grav_module, only : grav_zone ! function
     use probdata_module, only: gamma1
     use meth_params_module, only : T_guess
@@ -89,14 +89,12 @@ contains
     ! U(1) = rho
     ! U(2) = p
 
-    !$gpu
-
     eos_state % rho = U(1)
     eos_state % p = U(2)
     eos_state % xn = set_species(y)
     eos_state % T = T_guess
 
-    call eos(eos_input_rp, eos_state)
+    call eos_on_host(eos_input_rp, eos_state)
 
     gamma0 = eos_state % gam1
     gamma = gamma0 + fv(y) * (gamma1 - gamma0)
@@ -117,7 +115,7 @@ contains
     use model_parser_module, only: model_r, model_state, npts_model, nvars_model, idens_model, ipres_model, ispec_model, itemp_model
     use network, only : nspec
     use eos_type_module, only : eos_t, eos_input_rp
-    use eos_module, only : eos
+    use eos_module, only : eos_on_host
 
     implicit none
 
@@ -199,7 +197,7 @@ contains
        eos_state % xn(1:nspec) = model_state(j, ispec_model:ispec_model-1+nspec)
        eos_state % p = model_state(j, ipres_model)
 
-       call eos(eos_input_rp, eos_state)
+       call eos_on_host(eos_input_rp, eos_state)
 
        model_state(j, itemp_model) = eos_state % T
 

--- a/Exec/gravity_tests/evrard_collapse/Prob_nd.F90
+++ b/Exec/gravity_tests/evrard_collapse/Prob_nd.F90
@@ -4,7 +4,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   use amrex_fort_module, only : rt => amrex_real
   use probdata_module
   use eos_type_module, only : eos_t, eos_input_rt
-  use eos_module, only : eos
+  use eos_module, only : eos_on_host
   use network, only : nspec
 
   implicit none
@@ -24,7 +24,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state % T   = small_temp
      eos_state % xn  = 1.0e0_rt / nspec
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
 
      small_pres = eos_state % p
      small_ener = eos_state % e

--- a/Exec/gravity_tests/hydrostatic_adjust/Prob_nd.F90
+++ b/Exec/gravity_tests/hydrostatic_adjust/Prob_nd.F90
@@ -91,7 +91,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   eos_state%T     = hse_T_top
   eos_state%xn(:) = hse_X_top
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   hse_eint_top = eos_state%e
   hse_p_top = eos_state%p

--- a/Exec/hydro_tests/HCBubble/Prob_nd.F90
+++ b/Exec/hydro_tests/HCBubble/Prob_nd.F90
@@ -1,6 +1,6 @@
 subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
-  use eos_module, only: eos
+  use eos_module, only: eos_on_host
   use eos_type_module, only: eos_input_rt, eos_input_rp, eos_t
   use castro_error_module, only: castro_error
   use network, only: nspec
@@ -36,7 +36,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = T_l
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
  
      rhoe_l = rho_l*eos_state%e
      p_l = eos_state%p
@@ -45,7 +45,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = T_r
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
  
      rhoe_r = rho_r*eos_state%e
      p_r = eos_state%p
@@ -57,7 +57,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rp, eos_state)
+     call eos_on_host(eos_input_rp, eos_state)
  
      rhoe_l = rho_l*eos_state%e
      T_l = eos_state%T
@@ -67,7 +67,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rp, eos_state)
+     call eos_on_host(eos_input_rp, eos_state)
  
      rhoe_r = rho_r*eos_state%e
      T_r = eos_state%T

--- a/Exec/hydro_tests/Sedov/Prob_nd.F90
+++ b/Exec/hydro_tests/Sedov/Prob_nd.F90
@@ -7,7 +7,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use prob_params_module, only: center, coord_type
   use castro_error_module, only: castro_error
   use eos_type_module, only: eos_t, eos_input_rt, eos_input_rp
-  use eos_module, only: eos
+  use eos_module, only: eos_on_host
   use network, only: nspec
 
   implicit none
@@ -40,7 +40,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
      eos_state % xn(:) = xn_zone(:)
      eos_state % T = temp_ambient
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
 
      p_ambient = eos_state % p
 
@@ -53,7 +53,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   eos_state % T   = 1.d9 ! Initial guess for iterations
   eos_state % xn  = xn_zone
 
-  call eos(eos_input_rp, eos_state)
+  call eos_on_host(eos_input_rp, eos_state)
 
   e_ambient = eos_state % e
 

--- a/Exec/hydro_tests/Sod/Prob_nd.F90
+++ b/Exec/hydro_tests/Sod/Prob_nd.F90
@@ -32,7 +32,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = T_l
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
 
      rhoe_l = rho_l*eos_state%e
      p_l = eos_state%p
@@ -41,7 +41,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = T_r
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
 
      rhoe_r = rho_r*eos_state%e
      p_r = eos_state%p
@@ -53,7 +53,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rp, eos_state)
+     call eos_on_host(eos_input_rp, eos_state)
 
      rhoe_l = rho_l*eos_state%e
      T_l = eos_state%T
@@ -63,7 +63,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rp, eos_state)
+     call eos_on_host(eos_input_rp, eos_state)
 
      rhoe_r = rho_r*eos_state%e
      T_r = eos_state%T

--- a/Exec/hydro_tests/Sod_stellar/Prob_nd.F90
+++ b/Exec/hydro_tests/Sod_stellar/Prob_nd.F90
@@ -33,7 +33,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = T_l
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
 
      rhoe_l = rho_l*eos_state%e
      p_l = eos_state%p
@@ -42,7 +42,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = T_r
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
 
      rhoe_r = rho_r*eos_state%e
      p_r = eos_state%p
@@ -54,7 +54,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rp, eos_state)
+     call eos_on_host(eos_input_rp, eos_state)
 
      rhoe_l = rho_l*eos_state%e
      T_l = eos_state%T
@@ -64,7 +64,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = 100000.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rp, eos_state)
+     call eos_on_host(eos_input_rp, eos_state)
 
      rhoe_r = rho_r*eos_state%e
      T_r = eos_state%T

--- a/Exec/hydro_tests/acoustic_pulse_general/Prob_nd.F90
+++ b/Exec/hydro_tests/acoustic_pulse_general/Prob_nd.F90
@@ -6,7 +6,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   use eos_type_module, only : eos_t, eos_input_rt
-  use eos_module, only : eos
+  use eos_module, only : eos_on_host
 
   implicit none
 
@@ -35,7 +35,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   eos_state % T = T0
   eos_state % xn(:) = xn_zone(:)
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   p0 = eos_state % p
   s0 = eos_state % s

--- a/Exec/hydro_tests/double_mach_reflection/Prob_nd.F90
+++ b/Exec/hydro_tests/double_mach_reflection/Prob_nd.F90
@@ -36,7 +36,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = T_l
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
 
      rhoe_l = rho_l*eos_state%e
      p_l = eos_state%p
@@ -45,7 +45,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = T_r
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
 
      rhoe_r = rho_r*eos_state%e
      p_r = eos_state%p
@@ -57,7 +57,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = 10.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rp, eos_state)
+     call eos_on_host(eos_input_rp, eos_state)
 
      rhoe_l = rho_l*eos_state%e
      T_l = eos_state%T
@@ -67,7 +67,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      eos_state%T = 10.e0_rt  ! initial guess
      eos_state%xn(:) = xn(:)
 
-     call eos(eos_input_rp, eos_state)
+     call eos_on_host(eos_input_rp, eos_state)
 
      rhoe_r = rho_r*eos_state%e
      T_r = eos_state%T

--- a/Exec/hydro_tests/heating_verification/Prob_nd.F90
+++ b/Exec/hydro_tests/heating_verification/Prob_nd.F90
@@ -5,7 +5,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   use amrex_fort_module, only: rt => amrex_real
   use network, only : nspec
   use eos_type_module, only : eos_t, eos_input_re
-  use eos_module, only : eos
+  use eos_module, only : eos_on_host
   use meth_params_module, only : T_guess
 
   implicit none
@@ -28,7 +28,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   eos_state % T = T_guess
   eos_state % xn(:) = xn(:)
 
-  call eos(eos_input_re, eos_state)
+  call eos_on_host(eos_input_re, eos_state)
 
   T_in = eos_state % T
 

--- a/Exec/radiation_tests/Rad2Tshock/Prob_nd.F90
+++ b/Exec/radiation_tests/Rad2Tshock/Prob_nd.F90
@@ -21,7 +21,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   eos_state % T   =   T0
   eos_state % xn  = 1.e0_rt
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   eint0 = rho0 * eos_state % e
   etot0 = eint0 + 0.5*rho0*v0**2
@@ -29,7 +29,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   eos_state % rho = rho1
   eos_state % T   =   T1
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   eint1 = rho1 * eos_state % e
   etot1 = eint1 + 0.5*rho1*v1**2

--- a/Exec/radiation_tests/RadFront/Prob_nd.F90
+++ b/Exec/radiation_tests/RadFront/Prob_nd.F90
@@ -20,7 +20,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   eos_state % xn  = 0.e0_rt
   eos_state % xn(1) = 1.e0_rt
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   rhoe_0 = rho_0 * eos_state % e
 

--- a/Exec/radiation_tests/RadSourceTest/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSourceTest/Prob_nd.F90
@@ -2,7 +2,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   use probdata_module
   use network, only : network_init
-  use eos_module, only: eos
+  use eos_module, only: eos_on_host
   use eos_type_module, only: eos_t, eos_input_re
   use network, only : nspec
   use amrex_fort_module, only : rt => amrex_real
@@ -55,7 +55,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   eos_state % e = e_0
   eos_state % xn = X_in
 
-  call eos(eos_input_re, eos_state)
+  call eos_on_host(eos_input_re, eos_state)
 
   T_0 = eos_state % T
 

--- a/Exec/radiation_tests/RadSphere/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSphere/Prob_nd.F90
@@ -46,7 +46,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(C, name="amrex_pr
   eos_state % xn  = 0.e0_rt
   eos_state % xn(1) = 1.e0_rt
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   rhoe_0 = rho_0 * eos_state % e
 

--- a/Exec/reacting_tests/bubble_convergence/initial_model.F90
+++ b/Exec/reacting_tests/bubble_convergence/initial_model.F90
@@ -26,7 +26,7 @@ contains
     use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
 
-    use eos_module, only: eos
+    use eos_module, only: eos_on_host
     use eos_type_module, only: eos_t, eos_input_rt, eos_input_ps
     use network, only : nspec
     use meth_params_module, only : const_grav, sdc_order
@@ -69,7 +69,7 @@ contains
     eos_state % T = model_params % T_base
     eos_state % xn(:) = model_params % xn(:)
 
-    call eos(eos_input_rt, eos_state)
+    call eos_on_host(eos_input_rt, eos_state)
 
     entropy_fixed = eos_state % s
 
@@ -130,7 +130,7 @@ contains
           eos_state % p = pnew
           eos_state % s = s
 
-          call eos(eos_input_ps, eos_state)
+          call eos_on_host(eos_input_ps, eos_state)
 
           ! update the thermodynamics in this zone
           model_state(i, idens_model) = eos_state % rho
@@ -171,7 +171,7 @@ contains
           eos_state % p = pnew
           eos_state % s = s
 
-          call eos(eos_input_ps, eos_state)
+          call eos_on_host(eos_input_ps, eos_state)
 
           ! update the thermodynamics in this zone
           model_state(i, idens_model) = eos_state % rho
@@ -201,7 +201,7 @@ contains
              eos_state % xn(:) = model_params % xn(:)
              eos_state % s = entropy_fixed
 
-             call eos(eos_input_ps, eos_state)
+             call eos_on_host(eos_input_ps, eos_state)
 
              model_state(i, idens_model) = eos_state % rho
              model_state(i, itemp_model) = eos_state % T
@@ -223,7 +223,7 @@ contains
                 eos_state % s = entropy_fixed
                 eos_state % xn(:) = model_params % xn(:)
 
-                call eos(eos_input_ps, eos_state)
+                call eos_on_host(eos_input_ps, eos_state)
 
                 drho = eos_state % rho - dens_zone
                 dens_zone = eos_state % rho
@@ -267,7 +267,7 @@ contains
              eos_state % s = entropy_fixed
              eos_state % xn(:) = model_params % xn(:)
 
-             call eos(eos_input_ps, eos_state)
+             call eos_on_host(eos_input_ps, eos_state)
 
              drho = eos_state % rho - dens_zone
              dens_zone = eos_state % rho
@@ -298,7 +298,7 @@ contains
   function f(p, s, g, rho, T, xn) result (rhs)
 
     use eos_type_module, only : eos_t, eos_input_ps
-    use eos_module, only : eos
+    use eos_module, only : eos_on_host
 
     real(rt), intent(in) :: p, s, g, rho, T, xn(nspec)
 
@@ -311,7 +311,7 @@ contains
     eos_state % p = p
     eos_state % s = s
 
-    call eos(eos_input_ps, eos_state)
+    call eos_on_host(eos_input_ps, eos_state)
 
     rhs = eos_state % rho * g
 

--- a/Exec/reacting_tests/nse_test/Prob_nd.F90
+++ b/Exec/reacting_tests/nse_test/Prob_nd.F90
@@ -5,8 +5,6 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use network, only: network_species_index, nspec
   use castro_error_module, only: castro_error
   use amrex_fort_module, only: rt => amrex_real
-  use eos_type_module, only: eos_t, eos_input_rt
-  use eos_module, only: eos
   use prob_params_module, only : center
 
   implicit none
@@ -14,8 +12,6 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   integer,  intent(in) :: init, namlen
   integer,  intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
-
-  type(eos_t) :: eos_state
 
   integer :: untin,i
 

--- a/Exec/reacting_tests/reacting_bubble/initdata_others.f90
+++ b/Exec/reacting_tests/reacting_bubble/initdata_others.f90
@@ -55,7 +55,7 @@ subroutine ca_initdata_maestro(lo,hi,MAESTRO_init_type, &
            eos_state % T   = state(i,j,UTEMP)
            eos_state % xn  = state(i,j,UFS:UFS+nspec-1)
 
-           call eos(eos_input_rp, eos_state)
+           call eos_on_host(eos_input_rp, eos_state)
 
            state(i,j,UTEMP) = state(i,j,UTEMP)
            state(i,j,UEINT) = eos_state % e
@@ -93,7 +93,7 @@ subroutine ca_initdata_maestro(lo,hi,MAESTRO_init_type, &
            eos_state % p  = pressure
            eos_state % xn = state(i,j,UFS:UFS+nspec-1)
 
-           call eos(eos_input_pt, eos_state)
+           call eos_on_host(eos_input_pt, eos_state)
 
            state(i,j,URHO)  = eos_state % rho
            state(i,j,UEINT) = eos_state % e
@@ -137,7 +137,7 @@ subroutine ca_initdata_maestro(lo,hi,MAESTRO_init_type, &
            eos_state % s  = entropy
            eos_state % xn = state(i,j,UFS:UFS+nspec-1)
 
-           call eos(eos_input_ps, eos_state)
+           call eos_on_host(eos_input_ps, eos_state)
 
            state(i,j,URHO)  = eos_state % rho
            state(i,j,UEINT) = eos_state % e
@@ -220,7 +220,7 @@ subroutine ca_initdata_makemodel(model,model_size,MAESTRO_npts_model, &
   eos_state % T    = tempbar(r_model_start)
   eos_state % xn   = xn(:)
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   model(1,r_model_start) = rho0(r_model_start)
   model(2,r_model_start) = tempbar(r_model_start)
@@ -291,7 +291,7 @@ subroutine ca_initdata_makemodel(model,model_size,MAESTRO_npts_model, &
               eos_state % rho = dens_zone
               eos_state % xn  = xn(:)
 
-              call eos(eos_input_rt, eos_state)
+              call eos_on_host(eos_input_rt, eos_state)
 
               entropy = eos_state % s
               pres_zone = eos_state % p
@@ -347,7 +347,7 @@ subroutine ca_initdata_makemodel(model,model_size,MAESTRO_npts_model, &
               eos_state % rho = dens_zone
               eos_state % xn  = xn(:)
 
-              call eos(eos_input_rt, eos_state)
+              call eos_on_host(eos_input_rt, eos_state)
 
               entropy = eos_state % s
               pres_zone = eos_state % p
@@ -405,7 +405,7 @@ subroutine ca_initdata_makemodel(model,model_size,MAESTRO_npts_model, &
      eos_state % rho = dens_zone
      eos_state % xn  = xn(:)
 
-     call eos(eos_input_rt, eos_state)
+     call eos_on_host(eos_input_rt, eos_state)
 
      pres_zone = eos_state % p
 
@@ -469,7 +469,7 @@ subroutine ca_initdata_overwrite(lo,hi, &
            eos_state % T   = state(i,j,UTEMP)
            eos_state % xn  = state(i,j,UFS:UFS+nspec-1)
 
-           call eos(eos_input_rt, eos_state)
+           call eos_on_host(eos_input_rt, eos_state)
 
            state(i,j,UEINT) = eos_state % e
 

--- a/Exec/reacting_tests/reacting_convergence/Prob_nd.F90
+++ b/Exec/reacting_tests/reacting_convergence/Prob_nd.F90
@@ -6,7 +6,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use castro_error_module
   use amrex_fort_module, only : rt => amrex_real
   use eos_type_module, only : eos_t, eos_input_rt
-  use eos_module, only : eos
+  use eos_module, only : eos_on_host
   use extern_probin_module, only : small_x
 
   implicit none
@@ -63,7 +63,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   eos_state % T = T0
   eos_state % xn(:) = xn_zone(:)
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   p0 = eos_state % p
   s0 = eos_state % s

--- a/Exec/reacting_tests/toy_flame/Prob_nd.F90
+++ b/Exec/reacting_tests/toy_flame/Prob_nd.F90
@@ -1,6 +1,6 @@
 subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amrex_probinit")
 
-  use eos_module, only: eos
+  use eos_module, only: eos_on_host
   use eos_type_module, only: eos_t, eos_input_rt
   use castro_error_module
   use network, only: nspec
@@ -54,7 +54,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   eos_state%xn(:) = ZERO
   eos_state%xn(1) = ONE
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   lambda_f = sqrt(const_conductivity*T_burn_ref/ &
        (rho_burn_ref*specific_q_burn*nu*rtilde))

--- a/Exec/scf_tests/single_star/Prob_nd.F90
+++ b/Exec/scf_tests/single_star/Prob_nd.F90
@@ -5,9 +5,8 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   use amrex_constants_module
   use castro_error_module
   use fundamental_constants_module
-  use eos_module
-
   use amrex_fort_module, only : rt => amrex_real
+
   implicit none
 
   integer, intent(in) :: init, namlen

--- a/Exec/science/Detonation/Prob_nd.F90
+++ b/Exec/science/Detonation/Prob_nd.F90
@@ -7,7 +7,7 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   use castro_error_module, only: castro_error
   use amrex_fort_module, only: rt => amrex_real
   use eos_type_module, only: eos_t, eos_input_rt
-  use eos_module, only: eos
+  use eos_module, only: eos_on_host
 
   implicit none
 
@@ -102,13 +102,13 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   eos_state % T   = T_l
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   ambient_e_l = eos_state % e
 
   eos_state % T   = T_r
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   ambient_e_r = eos_state % e
 

--- a/Exec/science/bwp-rad/Prob_nd.F90
+++ b/Exec/science/bwp-rad/Prob_nd.F90
@@ -137,7 +137,7 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
            eos_state%T = state(i,j,k,UTEMP)
            eos_state%xn(:) = state(i,j,k,UFS:UFS-1+nspec)
 
-           call eos(eos_input_rt, eos_state)
+           call eos_on_host(eos_input_rt, eos_state)
 
            state(i,j,k,UEINT) = state(i,j,k,URHO) * eos_state%e
            state(i,j,k,UEDEN) = state(i,j,k,URHO) * eos_state%e

--- a/Exec/science/convective_flame/initial_model.f90
+++ b/Exec/science/convective_flame/initial_model.f90
@@ -115,7 +115,7 @@ contains
     use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
 
-    use eos_module, only: eos
+    use eos_module, only: eos_on_host
     use eos_type_module, only: eos_t, eos_input_rt
     use network, only : nspec, network_species_index, spec_names
     use fundamental_constants_module, only: Gconst
@@ -206,7 +206,7 @@ contains
     eos_state%rho   = model_params % dens_base
     eos_state%xn(:) = model_params % xn_star(:)
 
-    call eos(eos_input_rt, eos_state)
+    call eos_on_host(eos_input_rt, eos_state)
 
     ! store the conditions at the base -- we'll use the entropy later
     ! to constrain the isentropic layer
@@ -247,7 +247,7 @@ contains
     eos_state%T = gen_model_state(index_base,itemp_model,model_num)
     eos_state%xn(:) = gen_model_state(index_base,ispec_model:ispec_model-1+nspec,model_num)
 
-    call eos(eos_input_rt, eos_state)
+    call eos_on_host(eos_input_rt, eos_state)
 
     gen_model_state(index_base,ipres_model,model_num) = eos_state%p
 
@@ -277,7 +277,7 @@ contains
           eos_state % T = gen_model_state(i-1,itemp_model,model_num)
           eos_state % xn(:) = gen_model_state(i-1,ispec_model:ispec_model-1+nspec,model_num)
 
-          call eos(eos_input_rt, eos_state)
+          call eos_on_host(eos_input_rt, eos_state)
 
           entropy_base = eos_state % s
 
@@ -340,7 +340,7 @@ contains
                 eos_state%rho   = dens_zone
                 eos_state%xn(:) = xn(:)
 
-                call eos(eos_input_rt, eos_state)
+                call eos_on_host(eos_input_rt, eos_state)
 
                 entropy = eos_state%s
                 pres_zone = eos_state%p
@@ -399,7 +399,7 @@ contains
                 eos_state%rho = dens_zone
                 eos_state%xn(:) = xn(:)
 
-                call eos(eos_input_rt, eos_state)
+                call eos_on_host(eos_input_rt, eos_state)
 
                 entropy = eos_state%s
                 pres_zone = eos_state%p
@@ -459,7 +459,7 @@ contains
        eos_state%rho   = dens_zone
        eos_state%xn(:) = xn(:)
 
-       call eos(eos_input_rt, eos_state)
+       call eos_on_host(eos_input_rt, eos_state)
 
        pres_zone = eos_state%p
 
@@ -520,7 +520,7 @@ contains
           eos_state%rho   = dens_zone
           eos_state%xn(:) = xn(:)
 
-          call eos(eos_input_rt, eos_state)
+          call eos_on_host(eos_input_rt, eos_state)
 
           pres_zone = eos_state%p
 
@@ -559,7 +559,7 @@ contains
        eos_state%rho   = dens_zone
        eos_state%xn(:) = xn(:)
 
-       call eos(eos_input_rt, eos_state)
+       call eos_on_host(eos_input_rt, eos_state)
 
        pres_zone = eos_state%p
 

--- a/Exec/science/flame/Prob_nd.F90
+++ b/Exec/science/flame/Prob_nd.F90
@@ -148,7 +148,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   eos_state % T = T_fuel
   eos_state % xn(:) = xn_fuel(:)
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
   e_fuel = eos_state % e
   p_fuel = eos_state % p
@@ -159,7 +159,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   eos_state % T = T_ash
   eos_state % xn(:) = xn_ash(:)
 
-  call eos(eos_input_tp, eos_state)
+  call eos_on_host(eos_input_tp, eos_state)
 
   rho_ash = eos_state % rho
   e_ash = eos_state % e

--- a/Exec/science/flame_wave/initial_model.F90
+++ b/Exec/science/flame_wave/initial_model.F90
@@ -121,7 +121,7 @@ contains
     use castro_error_module
     use amrex_fort_module, only : rt => amrex_real
 
-    use eos_module, only: eos
+    use eos_module, only: eos_on_host
     use eos_type_module, only: eos_t, eos_input_rt
     use network, only : nspec, network_species_index
     use fundamental_constants_module, only: Gconst
@@ -208,7 +208,7 @@ contains
     eos_state%rho   = model_params % dens_base
     eos_state%xn(:) = model_params % xn_star(:)
 
-    call eos(eos_input_rt, eos_state)
+    call eos_on_host(eos_input_rt, eos_state)
 
     ! store the conditions at the base -- we'll use the entropy later
     ! to constrain the isentropic layer
@@ -247,7 +247,7 @@ contains
     eos_state%T = gen_model_state(index_base,itemp_model,model_num)
     eos_state%xn(:) = gen_model_state(index_base,ispec_model:ispec_model-1+nspec,model_num)
 
-    call eos(eos_input_rt, eos_state)
+    call eos_on_host(eos_input_rt, eos_state)
 
     gen_model_state(index_base,ipres_model,model_num) = eos_state%p
 
@@ -277,7 +277,7 @@ contains
           eos_state % T = gen_model_state(i-1,itemp_model,model_num)
           eos_state % xn(:) = gen_model_state(i-1,ispec_model:ispec_model-1+nspec,model_num)
 
-          call eos(eos_input_rt, eos_state)
+          call eos_on_host(eos_input_rt, eos_state)
 
           entropy_base = eos_state % s
 
@@ -340,7 +340,7 @@ contains
                 eos_state%rho   = dens_zone
                 eos_state%xn(:) = xn(:)
 
-                call eos(eos_input_rt, eos_state)
+                call eos_on_host(eos_input_rt, eos_state)
 
                 entropy = eos_state%s
                 pres_zone = eos_state%p
@@ -399,7 +399,7 @@ contains
                 eos_state%rho = dens_zone
                 eos_state%xn(:) = xn(:)
 
-                call eos(eos_input_rt, eos_state)
+                call eos_on_host(eos_input_rt, eos_state)
 
                 entropy = eos_state%s
                 pres_zone = eos_state%p
@@ -459,7 +459,7 @@ contains
        eos_state%rho   = dens_zone
        eos_state%xn(:) = xn(:)
 
-       call eos(eos_input_rt, eos_state)
+       call eos_on_host(eos_input_rt, eos_state)
 
        pres_zone = eos_state%p
 
@@ -520,7 +520,7 @@ contains
           eos_state%rho   = dens_zone
           eos_state%xn(:) = xn(:)
 
-          call eos(eos_input_rt, eos_state)
+          call eos_on_host(eos_input_rt, eos_state)
 
           pres_zone = eos_state%p
 
@@ -559,7 +559,7 @@ contains
        eos_state%rho   = dens_zone
        eos_state%xn(:) = xn(:)
 
-       call eos(eos_input_rt, eos_state)
+       call eos_on_host(eos_input_rt, eos_state)
 
        pres_zone = eos_state%p
 

--- a/Exec/science/wdmerger/initial_model.F90
+++ b/Exec/science/wdmerger/initial_model.F90
@@ -116,7 +116,7 @@ contains
 
   subroutine establish_hse(model, rho, T, xn, r)
 
-    use eos_module, only: eos
+    use eos_module, only: eos_on_host
 
     implicit none
 
@@ -200,7 +200,7 @@ contains
        model % state(1) % T    = T(1)
        model % state(1) % xn   = xn(1,:)
 
-       call eos(eos_input_rt, model % state(1))
+       call eos_on_host(eos_input_rt, model % state(1))
 
        ! Make the initial guess be completely uniform.
 
@@ -261,7 +261,7 @@ contains
              rho_avg = HALF * (rho(i) + rho(i-1))
              p_want = model % state(i-1) % p + model % dx * rho_avg * model % g(i)
 
-             call eos(eos_input_rt, model % state(i))
+             call eos_on_host(eos_input_rt, model % state(i))
 
              drho = (p_want - model % state(i) % p) / (model % state(i) % dpdr - HALF * model % dx * model % g(i))
 
@@ -292,7 +292,7 @@ contains
 
           ! Call the EOS to establish the final properties of this zone.
 
-          call eos(eos_input_rt, model % state(i))
+          call eos_on_host(eos_input_rt, model % state(i))
 
           ! Discretize the mass enclose as (4 pi / 3) * rho * dr * (rl**2 + rl * rr + rr**2).
 

--- a/Exec/science/wdmerger/wdmerger_util.F90
+++ b/Exec/science/wdmerger/wdmerger_util.F90
@@ -430,7 +430,7 @@ contains
 
     use meth_params_module, only: small_temp, small_pres, small_dens, small_ener
     use eos_type_module, only: eos_t, eos_input_rt
-    use eos_module, only: eos
+    use eos_module, only: eos_on_host
 
     implicit none
 
@@ -442,7 +442,7 @@ contains
     eos_state % T   = small_temp
     eos_state % xn  = ambient_comp
 
-    call eos(eos_input_rt, eos_state)
+    call eos_on_host(eos_input_rt, eos_state)
 
     small_pres = eos_state % p
     small_ener = eos_state % e

--- a/Exec/unit_tests/diffusion_test/Prob_nd.F90
+++ b/Exec/unit_tests/diffusion_test/Prob_nd.F90
@@ -6,7 +6,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   use prob_params_module, only: center, coord_type
   use probdata_module
   use eos_type_module, only: eos_t, eos_input_rt
-  use eos_module, only : eos
+  use eos_module, only : eos_on_host
   use network, only : nspec
 #ifdef DIFFUSION
   use conductivity_module
@@ -80,7 +80,7 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   eos_state%rho = 1.0
   eos_state%xn(:) = X(:)
 
-  call eos(eos_input_rt, eos_state)
+  call eos_on_host(eos_input_rt, eos_state)
 
 #ifdef DIFFUSION
   ! get the conductivity


### PR DESCRIPTION
## PR summary

In preparation for future GPU changes, when we call the EOS in probinit, call it explicitly from the host, which for CUDA builds will call the EOS on a single GPU thread. (Slow, but functional.)

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
