### PR TITLE
Fix ca_apply_metric for GPUs

### DIFF
--- a/Source/driver/MGutils_nd.F90
+++ b/Source/driver/MGutils_nd.F90
@@ -52,37 +52,39 @@ contains
     ! r-z
     if (coord_type == 1) then
 
-       ! At centers
-       do i = lo(1), hi(1)
-          r = (dble(i) + 0.5e0_rt) * dx(1)
-          do k = lo(3), hi(3)
-             do j = lo(2), hi(2)
-                rhs(i,j,k) = rhs(i,j,k) * r
-             end do
-          end do
-       end do
+       do k = lo(3), hi(3)
+          do j = lo(2), hi(2)
+             do i = lo(1), hi(1)
 
-       ! On x-edges
-       do i = xlo(1), xhi(1)
-          r = dble(i) * dx(1)
-          do k = xlo(3), xhi(3)
-             do j = xlo(2), xhi(2)
-                ecx(i,j,k) = ecx(i,j,k) * r
-             end do
-          end do
-       end do
+                ! At centers
+                if (i .ge. rlo(1) .and. i .le. rhi(1) .and. &
+                    j .ge. rlo(2) .and. j .le. rhi(2) .and. &
+                    k .ge. rlo(3) .and. k .le. rhi(3)) then
+                   r = (dble(i) + 0.5e0_rt) * dx(1)
+                   rhs(i,j,k) = rhs(i,j,k) * r
+                end if
+
+                ! On x-edges
+                if (i .ge. xlo(1) .and. i .le. xhi(1) .and. &
+                    j .ge. xlo(2) .and. j .le. xhi(2) .and. &
+                    k .ge. xlo(3) .and. k .le. xhi(3)) then
+                   r = dble(i) * dx(1)
+                   ecx(i,j,k) = ecx(i,j,k) * r
+                end if
 
 #if AMREX_SPACEDIM >= 2
-       ! On y-edges
-       do i = ylo(1), yhi(1)
-          r = (dble(i) + 0.5e0_rt) * dx(1)
-          do k = ylo(3), yhi(3)
-             do j = ylo(2), yhi(2)
-                ecy(i,j,k) = ecy(i,j,k) * r
+                ! On y-edges
+                if (i .ge. ylo(1) .and. i .le. yhi(1) .and. &
+                    j .ge. ylo(2) .and. j .le. yhi(2) .and. &
+                    k .ge. ylo(3) .and. k .le. yhi(3)) then
+                   r = (dble(i) + 0.5e0_rt) * dx(1)
+                   ecy(i,j,k) = ecy(i,j,k) * r
+                end if
+#endif
+
              end do
           end do
        end do
-#endif
 
 #ifndef AMREX_USE_CUDA
     else

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -2005,7 +2005,7 @@ Gravity::applyMetricTerms(int level, MultiFab& Rhs, const Vector<MultiFab*>& coe
 #endif
     for (MFIter mfi(Rhs,true); mfi.isValid(); ++mfi)
     {
-        const Box& bx = mfi.tilebox();
+        const Box& bx = mfi.growntilebox(1);
 	const Box& xbx = mfi.nodaltilebox(0);
 #if AMREX_SPACEDIM >= 2
         const Box& ybx = mfi.nodaltilebox(1);


### PR DESCRIPTION
## PR summary

ca_apply_metric was wrong on the GPU for two reasons. First, it was launching work over a cell-centered box but updating two nodal Fabs, so it was missing zones. Second, the memory access pattern is bad, since it is not strided in memory. Probably this is suboptimal for CPUs too, there's not enough work involved in saving `r` that it makes sense to invert the loop order.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
