### PR TITLE
Lengthen the last subcycle timestep to avoid very small dt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # changes since the last release
 
+   * A case where use_retry could result in a very small last
+     subcycle has been avoided. (#701)
+
    * A subroutine eos_on_host has been added to the EOS module.
      This is a wrapper for the EOS that must be used for CUDA
      builds if the EOS is being called in probinit or other

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -402,6 +402,8 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
 
     bool do_swap = false;
 
+    Real last_dt_subcycle = 1.e200;
+
     while (subcycle_time < (1.0 - eps) * (time + dt)) {
 
         sub_iteration += 1;
@@ -428,6 +430,10 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
         // safe dt in the subcycling.       
 
         const Real eps2 = 1.0e-10;
+
+        // Save the dt_subcycle before modifying it, we will use it later.
+
+        last_dt_subcycle = dt_subcycle;
 
         if (subcycle_time + dt_subcycle > (1.0 - eps2) * (time + dt))
             dt_subcycle = (time + dt) - subcycle_time;
@@ -561,6 +567,11 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
     }
 
     // We want to return the subcycled timestep as a suggestion.
+    // Let's be sure to return the subcycled timestep that was
+    // unmodified by anything we had to do in the last subcycle
+    // to reach the target time.
+
+    dt_subcycle = last_dt_subcycle;
 
     dt_new = std::min(dt_new, dt_subcycle);
 

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -422,6 +422,21 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
         if (subcycle_time + dt_subcycle > (time + dt))
             dt_subcycle = (time + dt) - subcycle_time;
 
+        // Relatedly, lengthen the last timestep so that we don't
+        // have to take a very short final timestep to get to
+        // the desired time. We'll use a slightly larger tolerance
+        // factor than we do in the outer while loop, to avoid
+        // roundoff issues, under the logic that as long as the
+        // tolerance is still small, there is no meaningful harm
+        // from the timestep being slightly larger than our recommended
+        // safe dt in the subcycling.
+
+        Real eps2 = 1.0e-10;
+
+        if (subcycle_time + dt_subcycle > (1.0 - eps2) * (time + dt)) {
+            dt_subcycle = (time + dt) - subcycle_time;
+        }
+
         // Check on whether we are going to take too many subcycles.
 
         int num_subcycles_remaining = int(round(((time + dt) - subcycle_time) / dt_subcycle));

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -417,25 +417,20 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
         }
 
         // Shorten the last timestep so that we don't overshoot
-        // the ending time.
-
-        if (subcycle_time + dt_subcycle > (time + dt))
-            dt_subcycle = (time + dt) - subcycle_time;
-
-        // Relatedly, lengthen the last timestep so that we don't
+        // the ending time. Relatedly, we also don't want to
+        // undershoot the ending time, which would cause us to
         // have to take a very short final timestep to get to
         // the desired time. We'll use a slightly larger tolerance
         // factor than we do in the outer while loop, to avoid
         // roundoff issues, under the logic that as long as the
         // tolerance is still small, there is no meaningful harm
         // from the timestep being slightly larger than our recommended
-        // safe dt in the subcycling.
+        // safe dt in the subcycling.       
 
-        Real eps2 = 1.0e-10;
+        const Real eps2 = 1.0e-10;
 
-        if (subcycle_time + dt_subcycle > (1.0 - eps2) * (time + dt)) {
+        if (subcycle_time + dt_subcycle > (1.0 - eps2) * (time + dt))
             dt_subcycle = (time + dt) - subcycle_time;
-        }
 
         // Check on whether we are going to take too many subcycles.
 


### PR DESCRIPTION
## PR summary

Due to roundoff issues, it is possible for the current algorithm to divide the main timestep into N smaller dt's that, when summed up, so not exactly equal the desired target time. We already have protection against the case where the final time is slightly larger than the target time (in which case
we shortened that timestep) but we had no protection against the case where we would end up slightly short of the target time, in which case we'd have to take a very short last timestep. This PR resolves that issue by making that last timestep slightly longer.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
