### PR TITLE
Reorder sources so external is last

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -46,11 +46,7 @@ enum StateType { State_Type = 0,
 
 // Create storage for all source terms.
 
-enum sources { ext_src = 0,
-               thermo_src,
-#ifdef SPONGE
-               sponge_src,
-#endif
+enum sources { thermo_src = 0,
 #ifdef DIFFUSION
                diff_src,
 #endif
@@ -63,6 +59,10 @@ enum sources { ext_src = 0,
 #ifdef ROTATION
                rot_src,
 #endif
+#ifdef SPONGE
+               sponge_src,
+#endif
+               ext_src,
 	       num_src };
 
 


### PR DESCRIPTION
## PR summary

This PR reorders the listing of the source terms so that the external source terms are last. This currently enables nothing new, but is in anticipation of later changes. Answers will change to roundoff since we're adding the sources in a different order now.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
