### PR TITLE
Add an option for implicit external source terms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+# 20.01
+
+   * A new option castro.ext_src_implicit has been added. The external source
+     terms were previously only implemented as an explicit predictor-corrector
+     scheme. The new option, if turned on, changes the handling of the external
+     source terms to allow an implicit solve. This is done by subtracting the
+     full old-time source and adding the full new-time source in the corrector,
+     rather than -0.5 and +0.5 of each, respectively. It is still up to the
+     individual problem to make sure it is consistent with this scheme if the
+     option is turned on. (#709)
+
 # 19.12
 
    * The use_retry mechanism has been enabled for the simplified

--- a/Exec/science/wdmerger/inputs_2d
+++ b/Exec/science/wdmerger/inputs_2d
@@ -131,6 +131,7 @@ castro.do_sponge = 1
 
 # Whether or not to apply external source terms
 castro.add_ext_src = 1
+castro.ext_src_implicit = 1
 
 # Whether or not to include the rotation source term
 castro.do_rotation = 1

--- a/Exec/science/wdmerger/inputs_3d
+++ b/Exec/science/wdmerger/inputs_3d
@@ -131,6 +131,7 @@ castro.do_sponge = 1
 
 # Whether or not to apply external source terms
 castro.add_ext_src = 1
+castro.ext_src_implicit = 1
 
 # Whether or not to include the rotation source term
 castro.do_rotation = 1

--- a/Exec/science/wdmerger/tests/wdmerger_2D/inputs_test_wdmerger_2D
+++ b/Exec/science/wdmerger/tests/wdmerger_2D/inputs_test_wdmerger_2D
@@ -54,6 +54,7 @@ castro.do_grav = 1                                 # Whether or not to do gravit
 castro.do_react = 0                                # Whether or not to do reactions
 castro.do_sponge = 0                               # Whether or not to apply the sponge
 castro.add_ext_src = 1                             # Whether or not to apply external source terms
+castro.ext_src_implicit = 1
 castro.do_rotation = 1                             # Whether or not to include the rotation source term
 castro.rotational_period = 100.0                   # Rotational period of the rotating reference frame
 castro.rotational_dPdt = -0.0                      # Time rate of change of the rotational period

--- a/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
+++ b/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
@@ -56,6 +56,7 @@ castro.do_grav = 1                                 # Whether or not to do gravit
 castro.do_react = 0                                # Whether or not to do reactions
 castro.do_sponge = 1                               # Whether or not to apply the sponge
 castro.add_ext_src = 1                             # Whether or not to apply external source terms
+castro.ext_src_implicit = 1
 castro.do_rotation = 0                             # Whether or not to include the rotation source term
 castro.rotational_period = 100.0                   # Rotational period of the rotating reference frame
 castro.rotational_dPdt = -0.0                      # Time rate of change of the rotational period

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
@@ -131,6 +131,7 @@ castro.do_sponge = 1
 
 # Whether or not to apply external source terms
 castro.add_ext_src = 0
+castro.ext_src_implicit = 1
 
 # Whether or not to include the rotation source term
 castro.do_rotation = 0

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
@@ -56,6 +56,7 @@ castro.do_grav = 1                                 # Whether or not to do gravit
 castro.do_react = 1                                # Whether or not to do reactions
 castro.do_sponge = 0                               # Whether or not to apply the sponge
 castro.add_ext_src = 1                             # Whether or not to apply external source terms
+castro.ext_src_implicit = 1
 castro.do_rotation = 0                             # Whether or not to include the rotation source term
 castro.rotational_period = 100.0                   # Rotational period of the rotating reference frame
 castro.rotational_dPdt = -0.0                      # Time rate of change of the rotational period

--- a/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
+++ b/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
@@ -131,6 +131,7 @@ castro.do_sponge = 1
 
 # Whether or not to apply external source terms
 castro.add_ext_src = 1
+castro.ext_src_implicit = 1
 
 # Whether or not to include the rotation source term
 castro.do_rotation = 0

--- a/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
@@ -125,6 +125,7 @@ castro.do_sponge = 0
 
 # Whether or not to apply external source terms
 castro.add_ext_src = 0
+castro.ext_src_implicit = 1
 
 # Whether or not to include the rotation source term
 castro.do_rotation = 0

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -195,6 +195,9 @@ do_sponge                    int           0                  y
 # if we are using the sponge, whether to use the implicit solve for it
 sponge_implicit              int           1                  y
 
+# if we are using user-defined source terms, are these solved implicitly?
+ext_src_implicit             int           0                  y
+
 # extrapolate the source terms (gravity and rotation) to :math:`n+1/2`
 # timelevel for use in the interface state prediction
 source_term_predictor        int           0

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -49,6 +49,7 @@ int         Castro::density_reset_method = 1;
 int         Castro::allow_small_energy = 1;
 int         Castro::do_sponge = 0;
 int         Castro::sponge_implicit = 1;
+int         Castro::ext_src_implicit = 0;
 int         Castro::source_term_predictor = 0;
 int         Castro::first_order_hydro = 0;
 std::string Castro::xl_ext_bc_type = "";
@@ -134,17 +135,6 @@ std::string Castro::job_name = "";
 int         Castro::output_at_completion = 1;
 amrex::Real Castro::reset_checkpoint_time = -1.e200;
 int         Castro::reset_checkpoint_step = -1;
-#ifdef DIFFUSION
-int         Castro::diffuse_temp = 0;
-amrex::Real Castro::diffuse_cutoff_density = -1.e200;
-amrex::Real Castro::diffuse_cutoff_density_hi = -1.e200;
-amrex::Real Castro::diffuse_cond_scale_fac = 1.0;
-#endif
-#ifdef GRAVITY
-int         Castro::use_point_mass = 0;
-amrex::Real Castro::point_mass = 0.0;
-int         Castro::point_mass_fix_solution = 0;
-#endif
 #ifdef ROTATION
 amrex::Real Castro::rotational_period = -1.e200;
 amrex::Real Castro::rotational_dPdt = 0.0;
@@ -155,4 +145,15 @@ int         Castro::state_in_rotating_frame = 1;
 int         Castro::rot_source_type = 4;
 int         Castro::implicit_rotation_update = 1;
 int         Castro::rot_axis = 3;
+#endif
+#ifdef DIFFUSION
+int         Castro::diffuse_temp = 0;
+amrex::Real Castro::diffuse_cutoff_density = -1.e200;
+amrex::Real Castro::diffuse_cutoff_density_hi = -1.e200;
+amrex::Real Castro::diffuse_cond_scale_fac = 1.0;
+#endif
+#ifdef GRAVITY
+int         Castro::use_point_mass = 0;
+amrex::Real Castro::point_mass = 0.0;
+int         Castro::point_mass_fix_solution = 0;
 #endif

--- a/Source/driver/param_includes/castro_job_info_tests.H
+++ b/Source/driver/param_includes/castro_job_info_tests.H
@@ -44,6 +44,7 @@ jobInfoFile << (Castro::density_reset_method == 1 ? "    " : "[*] ") << "castro.
 jobInfoFile << (Castro::allow_small_energy == 1 ? "    " : "[*] ") << "castro.allow_small_energy = " << Castro::allow_small_energy << std::endl;
 jobInfoFile << (Castro::do_sponge == 0 ? "    " : "[*] ") << "castro.do_sponge = " << Castro::do_sponge << std::endl;
 jobInfoFile << (Castro::sponge_implicit == 1 ? "    " : "[*] ") << "castro.sponge_implicit = " << Castro::sponge_implicit << std::endl;
+jobInfoFile << (Castro::ext_src_implicit == 0 ? "    " : "[*] ") << "castro.ext_src_implicit = " << Castro::ext_src_implicit << std::endl;
 jobInfoFile << (Castro::source_term_predictor == 0 ? "    " : "[*] ") << "castro.source_term_predictor = " << Castro::source_term_predictor << std::endl;
 jobInfoFile << (Castro::first_order_hydro == 0 ? "    " : "[*] ") << "castro.first_order_hydro = " << Castro::first_order_hydro << std::endl;
 jobInfoFile << (Castro::xl_ext_bc_type == "" ? "    " : "[*] ") << "castro.xl_ext_bc_type = " << Castro::xl_ext_bc_type << std::endl;
@@ -121,17 +122,6 @@ jobInfoFile << (Castro::job_name == "" ? "    " : "[*] ") << "castro.job_name = 
 jobInfoFile << (Castro::output_at_completion == 1 ? "    " : "[*] ") << "castro.output_at_completion = " << Castro::output_at_completion << std::endl;
 jobInfoFile << (Castro::reset_checkpoint_time == -1.e200 ? "    " : "[*] ") << "castro.reset_checkpoint_time = " << Castro::reset_checkpoint_time << std::endl;
 jobInfoFile << (Castro::reset_checkpoint_step == -1 ? "    " : "[*] ") << "castro.reset_checkpoint_step = " << Castro::reset_checkpoint_step << std::endl;
-#ifdef DIFFUSION
-jobInfoFile << (Castro::diffuse_temp == 0 ? "    " : "[*] ") << "castro.diffuse_temp = " << Castro::diffuse_temp << std::endl;
-jobInfoFile << (Castro::diffuse_cutoff_density == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density = " << Castro::diffuse_cutoff_density << std::endl;
-jobInfoFile << (Castro::diffuse_cutoff_density_hi == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density_hi = " << Castro::diffuse_cutoff_density_hi << std::endl;
-jobInfoFile << (Castro::diffuse_cond_scale_fac == 1.0 ? "    " : "[*] ") << "castro.diffuse_cond_scale_fac = " << Castro::diffuse_cond_scale_fac << std::endl;
-#endif
-#ifdef GRAVITY
-jobInfoFile << (Castro::use_point_mass == 0 ? "    " : "[*] ") << "castro.use_point_mass = " << Castro::use_point_mass << std::endl;
-jobInfoFile << (Castro::point_mass == 0.0 ? "    " : "[*] ") << "castro.point_mass = " << Castro::point_mass << std::endl;
-jobInfoFile << (Castro::point_mass_fix_solution == 0 ? "    " : "[*] ") << "castro.point_mass_fix_solution = " << Castro::point_mass_fix_solution << std::endl;
-#endif
 #ifdef ROTATION
 jobInfoFile << (Castro::rotational_period == -1.e200 ? "    " : "[*] ") << "castro.rotational_period = " << Castro::rotational_period << std::endl;
 jobInfoFile << (Castro::rotational_dPdt == 0.0 ? "    " : "[*] ") << "castro.rotational_dPdt = " << Castro::rotational_dPdt << std::endl;
@@ -142,4 +132,15 @@ jobInfoFile << (Castro::state_in_rotating_frame == 1 ? "    " : "[*] ") << "cast
 jobInfoFile << (Castro::rot_source_type == 4 ? "    " : "[*] ") << "castro.rot_source_type = " << Castro::rot_source_type << std::endl;
 jobInfoFile << (Castro::implicit_rotation_update == 1 ? "    " : "[*] ") << "castro.implicit_rotation_update = " << Castro::implicit_rotation_update << std::endl;
 jobInfoFile << (Castro::rot_axis == 3 ? "    " : "[*] ") << "castro.rot_axis = " << Castro::rot_axis << std::endl;
+#endif
+#ifdef DIFFUSION
+jobInfoFile << (Castro::diffuse_temp == 0 ? "    " : "[*] ") << "castro.diffuse_temp = " << Castro::diffuse_temp << std::endl;
+jobInfoFile << (Castro::diffuse_cutoff_density == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density = " << Castro::diffuse_cutoff_density << std::endl;
+jobInfoFile << (Castro::diffuse_cutoff_density_hi == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density_hi = " << Castro::diffuse_cutoff_density_hi << std::endl;
+jobInfoFile << (Castro::diffuse_cond_scale_fac == 1.0 ? "    " : "[*] ") << "castro.diffuse_cond_scale_fac = " << Castro::diffuse_cond_scale_fac << std::endl;
+#endif
+#ifdef GRAVITY
+jobInfoFile << (Castro::use_point_mass == 0 ? "    " : "[*] ") << "castro.use_point_mass = " << Castro::use_point_mass << std::endl;
+jobInfoFile << (Castro::point_mass == 0.0 ? "    " : "[*] ") << "castro.point_mass = " << Castro::point_mass << std::endl;
+jobInfoFile << (Castro::point_mass_fix_solution == 0 ? "    " : "[*] ") << "castro.point_mass_fix_solution = " << Castro::point_mass_fix_solution << std::endl;
 #endif

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -49,6 +49,7 @@ static int density_reset_method;
 static int allow_small_energy;
 static int do_sponge;
 static int sponge_implicit;
+static int ext_src_implicit;
 static int source_term_predictor;
 static int first_order_hydro;
 static std::string xl_ext_bc_type;
@@ -126,17 +127,6 @@ static std::string job_name;
 static int output_at_completion;
 static amrex::Real reset_checkpoint_time;
 static int reset_checkpoint_step;
-#ifdef DIFFUSION
-static int diffuse_temp;
-static amrex::Real diffuse_cutoff_density;
-static amrex::Real diffuse_cutoff_density_hi;
-static amrex::Real diffuse_cond_scale_fac;
-#endif
-#ifdef GRAVITY
-static int use_point_mass;
-static amrex::Real point_mass;
-static int point_mass_fix_solution;
-#endif
 #ifdef ROTATION
 static amrex::Real rotational_period;
 static amrex::Real rotational_dPdt;
@@ -147,4 +137,15 @@ static int state_in_rotating_frame;
 static int rot_source_type;
 static int implicit_rotation_update;
 static int rot_axis;
+#endif
+#ifdef DIFFUSION
+static int diffuse_temp;
+static amrex::Real diffuse_cutoff_density;
+static amrex::Real diffuse_cutoff_density_hi;
+static amrex::Real diffuse_cond_scale_fac;
+#endif
+#ifdef GRAVITY
+static int use_point_mass;
+static amrex::Real point_mass;
+static int point_mass_fix_solution;
 #endif

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -49,6 +49,7 @@ pp.query("density_reset_method", density_reset_method);
 pp.query("allow_small_energy", allow_small_energy);
 pp.query("do_sponge", do_sponge);
 pp.query("sponge_implicit", sponge_implicit);
+pp.query("ext_src_implicit", ext_src_implicit);
 pp.query("source_term_predictor", source_term_predictor);
 pp.query("first_order_hydro", first_order_hydro);
 pp.query("xl_ext_bc_type", xl_ext_bc_type);
@@ -126,17 +127,6 @@ pp.query("job_name", job_name);
 pp.query("output_at_completion", output_at_completion);
 pp.query("reset_checkpoint_time", reset_checkpoint_time);
 pp.query("reset_checkpoint_step", reset_checkpoint_step);
-#ifdef DIFFUSION
-pp.query("diffuse_temp", diffuse_temp);
-pp.query("diffuse_cutoff_density", diffuse_cutoff_density);
-pp.query("diffuse_cutoff_density_hi", diffuse_cutoff_density_hi);
-pp.query("diffuse_cond_scale_fac", diffuse_cond_scale_fac);
-#endif
-#ifdef GRAVITY
-pp.query("use_point_mass", use_point_mass);
-pp.query("point_mass", point_mass);
-pp.query("point_mass_fix_solution", point_mass_fix_solution);
-#endif
 #ifdef ROTATION
 pp.query("rotational_period", rotational_period);
 pp.query("rotational_dPdt", rotational_dPdt);
@@ -147,4 +137,15 @@ pp.query("state_in_rotating_frame", state_in_rotating_frame);
 pp.query("rot_source_type", rot_source_type);
 pp.query("implicit_rotation_update", implicit_rotation_update);
 pp.query("rot_axis", rot_axis);
+#endif
+#ifdef DIFFUSION
+pp.query("diffuse_temp", diffuse_temp);
+pp.query("diffuse_cutoff_density", diffuse_cutoff_density);
+pp.query("diffuse_cutoff_density_hi", diffuse_cutoff_density_hi);
+pp.query("diffuse_cond_scale_fac", diffuse_cond_scale_fac);
+#endif
+#ifdef GRAVITY
+pp.query("use_point_mass", use_point_mass);
+pp.query("point_mass", point_mass);
+pp.query("point_mass_fix_solution", point_mass_fix_solution);
 #endif


### PR DESCRIPTION
## PR summary

The external source terms are currently only implemented as an explicit predictor-corrector scheme. This is incompatible with how wdmerger implements its relaxation source term, so wdmerger is currently not working as intended. This PR introduces a new option, castro.ext_src_implicit (defaulting to 0) which, if turned on, changes the handling of the external source terms to allow an implicit solve. This is done by subtracting the full old-time source and adding the full new-time source in the corrector, rather than -0.5 and +0.5 of each, respectively. It would still be up to the individual problem to make sure they are consistent with this scheme if they turn the option on. Even if they don't, the source term ends up being a simple time-advanced source term at n+1 which is not a serious problem.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
