### PR TITLE
Add option to apply sources consecutively

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # 20.01
 
+   * A new option castro.apply_sources_consecutively has been added. By default
+     we add all source terms together at once. This option, if enabled, adds the
+     sources one at a time, so that each source sees the effect of the previously
+     added sources. This can matter, as an example, for the sponge source term,
+     which may be more effective if it is added after source terms such as gravity
+     that update the velocity. (#710)
+
    * A new option castro.ext_src_implicit has been added. The external source
      terms were previously only implemented as an explicit predictor-corrector
      scheme. The new option, if turned on, changes the handling of the external

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -527,13 +527,16 @@ public:
 /// @param time     the current simulation time
 /// @param dt       the timestep to advance (e.g., go from time to
 ///                    time + dt)
+/// @param apply_to_state   whether to apply the source to state_new
 /// @param amr_iteration    where we are in the current AMR subcycle.  Each
 ///                    level will take a number of steps to reach the
 ///                    final time of the coarser level below it.  This
 ///                    counter starts at 1
 /// @param amr_ncycle   the number of subcycles at this level
 ///
-    void do_old_sources(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
+    void do_old_sources(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new,
+                        amrex::Real time, amrex::Real dt, bool apply_to_state,
+                        int amr_iteration = -1, int amr_ncycle = -1);
 
 ///
 /// Construct the old-time source
@@ -562,13 +565,16 @@ public:
 /// @param time     the current simulation time
 /// @param dt       the timestep to advance (e.g., go from time to
 ///                    time + dt)
+/// @param apply_to_state   whether to apply the source to state_new
 /// @param amr_iteration    where we are in the current AMR subcycle.  Each
 ///                    level will take a number of steps to reach the
 ///                    final time of the coarser level below it.  This
 ///                    counter starts at 1
 /// @param amr_ncycle   the number of subcycles at this level
 ///
-    void do_new_sources(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
+    void do_new_sources(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new,
+                        amrex::Real time, amrex::Real dt, bool apply_to_state,
+                        int amr_iteration = -1, int amr_ncycle = -1);
 
 ///
 /// Construct the new-time sources.

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -522,7 +522,8 @@ public:
 /// Construct source terms at old time
 ///
 /// @param source   MultiFab to save sources to
-/// @param state    Current state
+/// @param state_old   Old state
+/// @param state_new   New state
 /// @param time     the current simulation time
 /// @param dt       the timestep to advance (e.g., go from time to
 ///                    time + dt)
@@ -532,7 +533,7 @@ public:
 ///                    counter starts at 1
 /// @param amr_ncycle   the number of subcycles at this level
 ///
-    void do_old_sources(amrex::MultiFab& source, amrex::MultiFab& state, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
+    void do_old_sources(amrex::MultiFab& source, amrex::MultiFab& state_old, amrex::MultiFab& state_new, amrex::Real time, amrex::Real dt, int amr_iteration = -1, int amr_ncycle = -1);
 
 ///
 /// Construct the old-time source

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -2784,12 +2784,7 @@ Castro::reflux(int crse_level, int fine_level)
             }
 
             if (getLevel(lev).apply_sources()) {
-
                 getLevel(lev).do_new_sources(source, S_old, S_new, time, dt_advance);
-
-                getLevel(lev).apply_source_to_state(S_new, source, dt_advance, 0);
-                getLevel(lev).clean_state(S_new, time, 0);
-
             }
 
             if (use_retry && dt_advance < dt_amr && getLevel(lev).keep_prev_state) {

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -2784,7 +2784,8 @@ Castro::reflux(int crse_level, int fine_level)
             }
 
             if (getLevel(lev).apply_sources()) {
-                getLevel(lev).do_new_sources(source, S_old, S_new, time, dt_advance);
+                bool apply_sources_to_state = true;
+                getLevel(lev).do_new_sources(source, S_old, S_new, time, dt_advance, apply_sources_to_state);
             }
 
             if (use_retry && dt_advance < dt_amr && getLevel(lev).keep_prev_state) {

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -89,11 +89,13 @@ Castro::do_advance_ctu(Real time,
     construct_old_gravity(amr_iteration, amr_ncycle, prev_time);
 #endif
 
+    bool apply_sources_to_state = true;
+
     MultiFab& old_source = get_old_data(Source_Type);
 
     if (apply_sources()) {
 
-      do_old_sources(old_source, Sborder, S_new, prev_time, dt, amr_iteration, amr_ncycle);
+      do_old_sources(old_source, Sborder, S_new, prev_time, dt, apply_sources_to_state, amr_iteration, amr_ncycle);
 
       // Apply the old sources to the sources for the hydro.
       // Note that we are doing an add here, not a copy,
@@ -172,7 +174,7 @@ Castro::do_advance_ctu(Real time,
 
     if (apply_sources()) {
 
-      do_new_sources(new_source, Sborder, S_new, cur_time, dt, amr_iteration, amr_ncycle);
+      do_new_sources(new_source, Sborder, S_new, cur_time, dt, apply_sources_to_state, amr_iteration, amr_ncycle);
 
     } else {
 

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -93,9 +93,7 @@ Castro::do_advance_ctu(Real time,
 
     if (apply_sources()) {
 
-      do_old_sources(old_source, Sborder, prev_time, dt, amr_iteration, amr_ncycle);
-      apply_source_to_state(S_new, old_source, dt, 0);
-      clean_state(S_new, cur_time, 0);
+      do_old_sources(old_source, Sborder, S_new, prev_time, dt, amr_iteration, amr_ncycle);
 
       // Apply the old sources to the sources for the hydro.
       // Note that we are doing an add here, not a copy,
@@ -175,8 +173,6 @@ Castro::do_advance_ctu(Real time,
     if (apply_sources()) {
 
       do_new_sources(new_source, Sborder, S_new, cur_time, dt, amr_iteration, amr_ncycle);
-      apply_source_to_state(S_new, new_source, dt, 0);
-      clean_state(S_new, cur_time, 0);
 
     } else {
 

--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -54,6 +54,8 @@ Castro::do_advance_sdc (Real time,
   MultiFab& old_source = get_old_data(Source_Type);
   MultiFab& new_source = get_new_data(Source_Type);
 
+  bool apply_sources_to_state = false;
+
   // we loop over all nodes, even the last, since we need to compute
   // the advective update source at each node
 
@@ -109,7 +111,7 @@ Castro::do_advance_sdc (Real time,
           }
 
           // we pass in the stage time here
-          do_old_sources(old_source, Sburn, node_time, dt, amr_iteration, amr_ncycle);
+          do_old_sources(old_source, Sburn, Sburn, node_time, dt, apply_sources_to_state, amr_iteration, amr_ncycle);
 
           // fill the ghost cells for the sources -- note since we have
           // not defined the new_source yet, we either need to copy this
@@ -130,7 +132,7 @@ Castro::do_advance_sdc (Real time,
         } else {
           // there is a ghost cell fill hidden in diffusion, so we need
           // to pass in the time associate with Sborder
-          do_old_sources(old_source, Sborder, cur_time, dt, amr_iteration, amr_ncycle);
+          do_old_sources(old_source, Sborder, Sborder, cur_time, dt, apply_sources_to_state, amr_iteration, amr_ncycle);
         }
 
         // note: we don't need a FillPatch on the sources, since they
@@ -264,12 +266,12 @@ Castro::do_advance_sdc (Real time,
     // TODO: we also need to make these 4th order!
     clean_state(S_old, prev_time, 0);
     expand_state(Sborder, prev_time, Sborder.nGrow());
-    do_old_sources(old_source, Sborder, prev_time, dt, amr_iteration, amr_ncycle);
+    do_old_sources(old_source, Sborder, Sborder, prev_time, dt, apply_sources_to_state, amr_iteration, amr_ncycle);
     AmrLevel::FillPatch(*this, old_source, old_source.nGrow(), prev_time, Source_Type, 0, NSRC);
 
     clean_state(S_new, cur_time, 0);
     expand_state(Sborder, cur_time, Sborder.nGrow());
-    do_old_sources(new_source, Sborder, cur_time, dt, amr_iteration, amr_ncycle);
+    do_old_sources(new_source, Sborder, Sborder, cur_time, dt, apply_sources_to_state, amr_iteration, amr_ncycle);
     AmrLevel::FillPatch(*this, new_source, new_source.nGrow(), cur_time, Source_Type, 0, NSRC);
   }
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -31,6 +31,9 @@ do_reflux                    int           1
 # drivers
 update_sources_after_reflux  int           1
 
+# should we apply the sources one by one or all at once?
+apply_sources_consecutively  int           0
+
 # should we have state data for custom load-balancing weighting?
 use_custom_knapsack_weights  int           0
 

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -519,14 +519,6 @@ contains
     allocate(diffuse_cond_scale_fac)
     diffuse_cond_scale_fac = 1.0_rt;
 #endif
-#ifdef GRAVITY
-    allocate(use_point_mass)
-    use_point_mass = 0;
-    allocate(point_mass)
-    point_mass = 0.0_rt;
-    allocate(point_mass_fix_solution)
-    point_mass_fix_solution = 0;
-#endif
 #ifdef ROTATION
     allocate(rot_period)
     rot_period = -1.e200_rt;
@@ -546,6 +538,14 @@ contains
     implicit_rotation_update = 1;
     allocate(rot_axis)
     rot_axis = 3;
+#endif
+#ifdef GRAVITY
+    allocate(use_point_mass)
+    use_point_mass = 0;
+    allocate(point_mass)
+    point_mass = 0.0_rt;
+    allocate(point_mass_fix_solution)
+    point_mass_fix_solution = 0;
 #endif
     allocate(difmag)
     difmag = 0.1_rt;
@@ -701,11 +701,6 @@ contains
     call pp%query("diffuse_cutoff_density_hi", diffuse_cutoff_density_hi)
     call pp%query("diffuse_cond_scale_fac", diffuse_cond_scale_fac)
 #endif
-#ifdef GRAVITY
-    call pp%query("use_point_mass", use_point_mass)
-    call pp%query("point_mass", point_mass)
-    call pp%query("point_mass_fix_solution", point_mass_fix_solution)
-#endif
 #ifdef ROTATION
     call pp%query("rotational_period", rot_period)
     call pp%query("rotational_dPdt", rot_period_dot)
@@ -716,6 +711,11 @@ contains
     call pp%query("rot_source_type", rot_source_type)
     call pp%query("implicit_rotation_update", implicit_rotation_update)
     call pp%query("rot_axis", rot_axis)
+#endif
+#ifdef GRAVITY
+    call pp%query("use_point_mass", use_point_mass)
+    call pp%query("point_mass", point_mass)
+    call pp%query("point_mass_fix_solution", point_mass_fix_solution)
 #endif
     call pp%query("difmag", difmag)
     call pp%query("small_dens", small_dens)

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -3,14 +3,12 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
-#ifdef AMREX_PARTICLES
-int         Castro::do_tracer_particles = 0;
-#endif
 int         Castro::state_interp_order = 1;
 int         Castro::lin_limit_state_interp = 0;
 int         Castro::state_nghost = 0;
 int         Castro::do_reflux = 1;
 int         Castro::update_sources_after_reflux = 1;
+int         Castro::apply_sources_consecutively = 0;
 int         Castro::use_custom_knapsack_weights = 0;
 amrex::Real Castro::difmag = 0.1;
 amrex::Real Castro::small_dens = -1.e200;
@@ -134,16 +132,19 @@ std::string Castro::job_name = "";
 int         Castro::output_at_completion = 1;
 amrex::Real Castro::reset_checkpoint_time = -1.e200;
 int         Castro::reset_checkpoint_step = -1;
+#ifdef GRAVITY
+int         Castro::use_point_mass = 0;
+amrex::Real Castro::point_mass = 0.0;
+int         Castro::point_mass_fix_solution = 0;
+#endif
 #ifdef DIFFUSION
 int         Castro::diffuse_temp = 0;
 amrex::Real Castro::diffuse_cutoff_density = -1.e200;
 amrex::Real Castro::diffuse_cutoff_density_hi = -1.e200;
 amrex::Real Castro::diffuse_cond_scale_fac = 1.0;
 #endif
-#ifdef GRAVITY
-int         Castro::use_point_mass = 0;
-amrex::Real Castro::point_mass = 0.0;
-int         Castro::point_mass_fix_solution = 0;
+#ifdef AMREX_PARTICLES
+int         Castro::do_tracer_particles = 0;
 #endif
 #ifdef ROTATION
 amrex::Real Castro::rotational_period = -1.e200;

--- a/Source/driver/param_includes/castro_job_info_tests.H
+++ b/Source/driver/param_includes/castro_job_info_tests.H
@@ -1,11 +1,9 @@
-#ifdef AMREX_PARTICLES
-jobInfoFile << (Castro::do_tracer_particles == 0 ? "    " : "[*] ") << "castro.do_tracer_particles = " << Castro::do_tracer_particles << std::endl;
-#endif
 jobInfoFile << (Castro::state_interp_order == 1 ? "    " : "[*] ") << "castro.state_interp_order = " << Castro::state_interp_order << std::endl;
 jobInfoFile << (Castro::lin_limit_state_interp == 0 ? "    " : "[*] ") << "castro.lin_limit_state_interp = " << Castro::lin_limit_state_interp << std::endl;
 jobInfoFile << (Castro::state_nghost == 0 ? "    " : "[*] ") << "castro.state_nghost = " << Castro::state_nghost << std::endl;
 jobInfoFile << (Castro::do_reflux == 1 ? "    " : "[*] ") << "castro.do_reflux = " << Castro::do_reflux << std::endl;
 jobInfoFile << (Castro::update_sources_after_reflux == 1 ? "    " : "[*] ") << "castro.update_sources_after_reflux = " << Castro::update_sources_after_reflux << std::endl;
+jobInfoFile << (Castro::apply_sources_consecutively == 0 ? "    " : "[*] ") << "castro.apply_sources_consecutively = " << Castro::apply_sources_consecutively << std::endl;
 jobInfoFile << (Castro::use_custom_knapsack_weights == 0 ? "    " : "[*] ") << "castro.use_custom_knapsack_weights = " << Castro::use_custom_knapsack_weights << std::endl;
 jobInfoFile << (Castro::difmag == 0.1 ? "    " : "[*] ") << "castro.difmag = " << Castro::difmag << std::endl;
 jobInfoFile << (Castro::small_dens == -1.e200 ? "    " : "[*] ") << "castro.small_dens = " << Castro::small_dens << std::endl;
@@ -121,16 +119,19 @@ jobInfoFile << (Castro::job_name == "" ? "    " : "[*] ") << "castro.job_name = 
 jobInfoFile << (Castro::output_at_completion == 1 ? "    " : "[*] ") << "castro.output_at_completion = " << Castro::output_at_completion << std::endl;
 jobInfoFile << (Castro::reset_checkpoint_time == -1.e200 ? "    " : "[*] ") << "castro.reset_checkpoint_time = " << Castro::reset_checkpoint_time << std::endl;
 jobInfoFile << (Castro::reset_checkpoint_step == -1 ? "    " : "[*] ") << "castro.reset_checkpoint_step = " << Castro::reset_checkpoint_step << std::endl;
+#ifdef GRAVITY
+jobInfoFile << (Castro::use_point_mass == 0 ? "    " : "[*] ") << "castro.use_point_mass = " << Castro::use_point_mass << std::endl;
+jobInfoFile << (Castro::point_mass == 0.0 ? "    " : "[*] ") << "castro.point_mass = " << Castro::point_mass << std::endl;
+jobInfoFile << (Castro::point_mass_fix_solution == 0 ? "    " : "[*] ") << "castro.point_mass_fix_solution = " << Castro::point_mass_fix_solution << std::endl;
+#endif
 #ifdef DIFFUSION
 jobInfoFile << (Castro::diffuse_temp == 0 ? "    " : "[*] ") << "castro.diffuse_temp = " << Castro::diffuse_temp << std::endl;
 jobInfoFile << (Castro::diffuse_cutoff_density == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density = " << Castro::diffuse_cutoff_density << std::endl;
 jobInfoFile << (Castro::diffuse_cutoff_density_hi == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density_hi = " << Castro::diffuse_cutoff_density_hi << std::endl;
 jobInfoFile << (Castro::diffuse_cond_scale_fac == 1.0 ? "    " : "[*] ") << "castro.diffuse_cond_scale_fac = " << Castro::diffuse_cond_scale_fac << std::endl;
 #endif
-#ifdef GRAVITY
-jobInfoFile << (Castro::use_point_mass == 0 ? "    " : "[*] ") << "castro.use_point_mass = " << Castro::use_point_mass << std::endl;
-jobInfoFile << (Castro::point_mass == 0.0 ? "    " : "[*] ") << "castro.point_mass = " << Castro::point_mass << std::endl;
-jobInfoFile << (Castro::point_mass_fix_solution == 0 ? "    " : "[*] ") << "castro.point_mass_fix_solution = " << Castro::point_mass_fix_solution << std::endl;
+#ifdef AMREX_PARTICLES
+jobInfoFile << (Castro::do_tracer_particles == 0 ? "    " : "[*] ") << "castro.do_tracer_particles = " << Castro::do_tracer_particles << std::endl;
 #endif
 #ifdef ROTATION
 jobInfoFile << (Castro::rotational_period == -1.e200 ? "    " : "[*] ") << "castro.rotational_period = " << Castro::rotational_period << std::endl;

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -3,14 +3,12 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
-#ifdef AMREX_PARTICLES
-static int do_tracer_particles;
-#endif
 static int state_interp_order;
 static int lin_limit_state_interp;
 static int state_nghost;
 static int do_reflux;
 static int update_sources_after_reflux;
+static int apply_sources_consecutively;
 static int use_custom_knapsack_weights;
 static amrex::Real difmag;
 static amrex::Real small_dens;
@@ -126,16 +124,19 @@ static std::string job_name;
 static int output_at_completion;
 static amrex::Real reset_checkpoint_time;
 static int reset_checkpoint_step;
+#ifdef GRAVITY
+static int use_point_mass;
+static amrex::Real point_mass;
+static int point_mass_fix_solution;
+#endif
 #ifdef DIFFUSION
 static int diffuse_temp;
 static amrex::Real diffuse_cutoff_density;
 static amrex::Real diffuse_cutoff_density_hi;
 static amrex::Real diffuse_cond_scale_fac;
 #endif
-#ifdef GRAVITY
-static int use_point_mass;
-static amrex::Real point_mass;
-static int point_mass_fix_solution;
+#ifdef AMREX_PARTICLES
+static int do_tracer_particles;
 #endif
 #ifdef ROTATION
 static amrex::Real rotational_period;

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -3,14 +3,12 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
-#ifdef AMREX_PARTICLES
-pp.query("do_tracer_particles", do_tracer_particles);
-#endif
 pp.query("state_interp_order", state_interp_order);
 pp.query("lin_limit_state_interp", lin_limit_state_interp);
 pp.query("state_nghost", state_nghost);
 pp.query("do_reflux", do_reflux);
 pp.query("update_sources_after_reflux", update_sources_after_reflux);
+pp.query("apply_sources_consecutively", apply_sources_consecutively);
 pp.query("use_custom_knapsack_weights", use_custom_knapsack_weights);
 pp.query("difmag", difmag);
 pp.query("small_dens", small_dens);
@@ -126,16 +124,19 @@ pp.query("job_name", job_name);
 pp.query("output_at_completion", output_at_completion);
 pp.query("reset_checkpoint_time", reset_checkpoint_time);
 pp.query("reset_checkpoint_step", reset_checkpoint_step);
+#ifdef GRAVITY
+pp.query("use_point_mass", use_point_mass);
+pp.query("point_mass", point_mass);
+pp.query("point_mass_fix_solution", point_mass_fix_solution);
+#endif
 #ifdef DIFFUSION
 pp.query("diffuse_temp", diffuse_temp);
 pp.query("diffuse_cutoff_density", diffuse_cutoff_density);
 pp.query("diffuse_cutoff_density_hi", diffuse_cutoff_density_hi);
 pp.query("diffuse_cond_scale_fac", diffuse_cond_scale_fac);
 #endif
-#ifdef GRAVITY
-pp.query("use_point_mass", use_point_mass);
-pp.query("point_mass", point_mass);
-pp.query("point_mass_fix_solution", point_mass_fix_solution);
+#ifdef AMREX_PARTICLES
+pp.query("do_tracer_particles", do_tracer_particles);
 #endif
 #ifdef ROTATION
 pp.query("rotational_period", rotational_period);

--- a/Source/sources/Castro_sources.cpp
+++ b/Source/sources/Castro_sources.cpp
@@ -93,7 +93,7 @@ Castro::source_flag(int src)
 }
 
 void
-Castro::do_old_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt, int amr_iteration, int amr_ncycle)
+Castro::do_old_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt, bool apply_to_state, int amr_iteration, int amr_ncycle)
 {
 
     BL_PROFILE("Castro::do_old_sources()");
@@ -106,7 +106,7 @@ Castro::do_old_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_ne
 
     MultiFab temp_source;
 
-    if (apply_sources_consecutively) {
+    if (apply_sources_consecutively && apply_to_state) {
         temp_source.define(grids, dmap, NSRC, NUM_GROW);
         temp_source.setVal(0.0, NUM_GROW);
     }
@@ -117,7 +117,7 @@ Castro::do_old_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_ne
         // We can either apply the sources to the state one by one, or we can
         // group them all together at the end.
 
-        if (apply_sources_consecutively) {
+        if (apply_sources_consecutively && apply_to_state) {
 
             apply_source_to_state(state_new, source, dt, 0);
             clean_state(state_new, time + dt, 0);
@@ -136,11 +136,15 @@ Castro::do_old_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_ne
 
     }
 
-    if (apply_sources_consecutively) {
-        MultiFab::Copy(source, temp_source, 0, 0, NSRC, NUM_GROW);
-    } else {
-        apply_source_to_state(state_new, source, dt, 0);
-        clean_state(state_new, time, 0);
+    if (apply_to_state) {
+
+        if (apply_sources_consecutively) {
+            MultiFab::Copy(source, temp_source, 0, 0, NSRC, NUM_GROW);
+        } else {
+            apply_source_to_state(state_new, source, dt, 0);
+            clean_state(state_new, time, 0);
+        }
+
     }
 
     // Optionally print out diagnostic information about how much
@@ -171,7 +175,7 @@ Castro::do_old_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_ne
 }
 
 void
-Castro::do_new_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt, int amr_iteration, int amr_ncycle)
+Castro::do_new_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt, bool apply_to_state, int amr_iteration, int amr_ncycle)
 {
 
     BL_PROFILE("Castro::do_new_sources()");
@@ -182,7 +186,7 @@ Castro::do_new_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_ne
 
     MultiFab temp_source;
 
-    if (apply_sources_consecutively) {
+    if (apply_sources_consecutively && apply_to_state) {
         temp_source.define(grids, dmap, NSRC, NUM_GROW);
         temp_source.setVal(0.0, NUM_GROW);
     }
@@ -195,7 +199,7 @@ Castro::do_new_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_ne
         // We can either apply the sources to the state one by one, or we can
         // group them all together at the end.
 
-        if (apply_sources_consecutively) {
+        if (apply_sources_consecutively && apply_to_state) {
 
             // The individual source terms only calculate the source on the valid domain.
             // FillPatch to get valid data in the ghost zones.
@@ -219,11 +223,15 @@ Castro::do_new_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_ne
 
     }
 
-    if (apply_sources_consecutively) {
-        MultiFab::Copy(source, temp_source, 0, 0, NSRC, NUM_GROW);
-    } else {
-        apply_source_to_state(state_new, source, dt, 0);
-        clean_state(state_new, time, 0);
+    if (apply_to_state) {
+
+        if (apply_sources_consecutively) {
+            MultiFab::Copy(source, temp_source, 0, 0, NSRC, NUM_GROW);
+        } else {
+            apply_source_to_state(state_new, source, dt, 0);
+            clean_state(state_new, time, 0);
+        }
+
     }
 
     // Optionally print out diagnostic information about how much

--- a/Source/sources/Castro_sources.cpp
+++ b/Source/sources/Castro_sources.cpp
@@ -93,7 +93,7 @@ Castro::source_flag(int src)
 }
 
 void
-Castro::do_old_sources(MultiFab& source, MultiFab& state_in, Real time, Real dt, int amr_iteration, int amr_ncycle)
+Castro::do_old_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_new, Real time, Real dt, int amr_iteration, int amr_ncycle)
 {
 
     BL_PROFILE("Castro::do_old_sources()");
@@ -104,8 +104,44 @@ Castro::do_old_sources(MultiFab& source, MultiFab& state_in, Real time, Real dt,
 
     source.setVal(0.0, source.nGrow());
 
-    for (int n = 0; n < num_src; ++n)
-        construct_old_source(n, source, state_in, time, dt, amr_iteration, amr_ncycle);
+    MultiFab temp_source;
+
+    if (apply_sources_consecutively) {
+        temp_source.define(grids, dmap, NSRC, NUM_GROW);
+        temp_source.setVal(0.0, NUM_GROW);
+    }
+
+    for (int n = 0; n < num_src; ++n) {
+        construct_old_source(n, source, state_old, time, dt, amr_iteration, amr_ncycle);
+
+        // We can either apply the sources to the state one by one, or we can
+        // group them all together at the end.
+
+        if (apply_sources_consecutively) {
+
+            apply_source_to_state(state_new, source, dt, 0);
+            clean_state(state_new, time + dt, 0);
+
+            // Zero out the source MultiFab for the next source term.
+            // Also, log the sum of all source terms since we need
+            // to save that after we're done.
+
+            MultiFab::Add(temp_source, source, 0, 0, NSRC, NUM_GROW);
+
+            if (n < num_src - 1) {
+                source.setVal(0.0, NUM_GROW);
+            }
+
+        }
+
+    }
+
+    if (apply_sources_consecutively) {
+        MultiFab::Copy(source, temp_source, 0, 0, NSRC, NUM_GROW);
+    } else {
+        apply_source_to_state(state_new, source, dt, 0);
+        clean_state(state_new, time, 0);
+    }
 
     // Optionally print out diagnostic information about how much
     // these source terms changed the state.
@@ -144,15 +180,51 @@ Castro::do_new_sources(MultiFab& source, MultiFab& state_old, MultiFab& state_ne
 
     source.setVal(0.0, NUM_GROW);
 
+    MultiFab temp_source;
+
+    if (apply_sources_consecutively) {
+        temp_source.define(grids, dmap, NSRC, NUM_GROW);
+        temp_source.setVal(0.0, NUM_GROW);
+    }
+
     // Construct the new-time source terms.
 
-    for (int n = 0; n < num_src; ++n)
+    for (int n = 0; n < num_src; ++n) {
         construct_new_source(n, source, state_old, state_new, time, dt, amr_iteration, amr_ncycle);
 
-    // The individual source terms only calculate the source on the valid domain.
-    // FillPatch to get valid data in the ghost zones.
+        // We can either apply the sources to the state one by one, or we can
+        // group them all together at the end.
 
-    AmrLevel::FillPatch(*this, source, NUM_GROW, time, Source_Type, 0, source.nComp());
+        if (apply_sources_consecutively) {
+
+            // The individual source terms only calculate the source on the valid domain.
+            // FillPatch to get valid data in the ghost zones.
+
+            AmrLevel::FillPatch(*this, source, NUM_GROW, time, Source_Type, 0, source.nComp());
+
+            apply_source_to_state(state_new, source, dt, 0);
+            clean_state(state_new, time, 0);
+
+            // Zero out the source MultiFab for the next source term.
+            // Also, log the sum of all source terms since we need
+            // to save that after we're done.
+
+            MultiFab::Add(temp_source, source, 0, 0, NSRC, NUM_GROW);
+
+            if (n < num_src - 1) {
+                source.setVal(0.0, NUM_GROW);
+            }
+
+        }
+
+    }
+
+    if (apply_sources_consecutively) {
+        MultiFab::Copy(source, temp_source, 0, 0, NSRC, NUM_GROW);
+    } else {
+        apply_source_to_state(state_new, source, dt, 0);
+        clean_state(state_new, time, 0);
+    }
 
     // Optionally print out diagnostic information about how much
     // these source terms changed the state.


### PR DESCRIPTION

## PR summary

This new option allows you to add sources to the state as they are calculated, rather than grouping them together at the end. Its purpose is to allow sources that come at the end, in particular the sponge and the external source term, to act on the state after the actual physics source terms have already been applied.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
