### PR TITLE
Add a flux limiter based on large velocities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # 20.01
 
+   * A new option castro.limit_fluxes_on_large_vel has been added. It is similar
+     to the existing option limit_fluxes_on_small_dens -- fluxes are limited to
+     prevent the velocity in any zone from getting too high. The largest legal
+     speed is set by castro.riemann_speed_limit. (#712)
+
    * A new option castro.apply_sources_consecutively has been added. By default
      we add all source terms together at once. This option, if enabled, adds the
      sources one at a time, so that each source sees the effect of the previously

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -183,6 +183,10 @@ use_pslope                   int           1                  y
 # Should we limit the density fluxes so that we do not create small densities?
 limit_fluxes_on_small_dens   int           0                  y
 
+# Should we limit the momentum fluxes so that we do not create large velocities?
+# If so, riemann_speed_limit will be used as the velocity cap.
+limit_fluxes_on_large_vel    int           0                  y
+
 # Which method to use when resetting a negative/small density
 # 1 = Reset to characteristics of adjacent zone with largest density
 # 2 = Use average of all adjacent zones for all state variables

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -150,6 +150,7 @@ module meth_params_module
   real(rt), allocatable, save :: dual_energy_eta2
   integer,  allocatable, save :: use_pslope
   integer,  allocatable, save :: limit_fluxes_on_small_dens
+  integer,  allocatable, save :: limit_fluxes_on_large_vel
   integer,  allocatable, save :: density_reset_method
   integer,  allocatable, save :: allow_small_energy
   integer,  allocatable, save :: do_sponge
@@ -245,6 +246,7 @@ attributes(managed) :: dual_energy_eta1
 attributes(managed) :: dual_energy_eta2
 attributes(managed) :: use_pslope
 attributes(managed) :: limit_fluxes_on_small_dens
+attributes(managed) :: limit_fluxes_on_large_vel
 attributes(managed) :: density_reset_method
 attributes(managed) :: allow_small_energy
 attributes(managed) :: do_sponge
@@ -373,6 +375,7 @@ attributes(managed) :: get_g_from_phi
   !$acc create(dual_energy_eta2) &
   !$acc create(use_pslope) &
   !$acc create(limit_fluxes_on_small_dens) &
+  !$acc create(limit_fluxes_on_large_vel) &
   !$acc create(density_reset_method) &
   !$acc create(allow_small_energy) &
   !$acc create(do_sponge) &
@@ -498,14 +501,20 @@ contains
 #endif
     allocate(xl_ext, yl_ext, zl_ext, xr_ext, yr_ext, zr_ext)
 
-#ifdef GRAVITY
-    allocate(use_point_mass)
-    use_point_mass = 0;
-    allocate(point_mass)
-    point_mass = 0.0_rt;
-    allocate(point_mass_fix_solution)
-    point_mass_fix_solution = 0;
-#endif
+    allocate(character(len=1)::gravity_type)
+    gravity_type = "fillme";
+    allocate(const_grav)
+    const_grav = 0.0_rt;
+    allocate(get_g_from_phi)
+    get_g_from_phi = 0;
+
+    call amrex_parmparse_build(pp, "gravity")
+    call pp%query("gravity_type", gravity_type)
+    call pp%query("const_grav", const_grav)
+    call pp%query("get_g_from_phi", get_g_from_phi)
+    call amrex_parmparse_destroy(pp)
+
+
 #ifdef ROTATION
     allocate(rot_period)
     rot_period = -1.e200_rt;
@@ -535,6 +544,14 @@ contains
     diffuse_cutoff_density_hi = -1.e200_rt;
     allocate(diffuse_cond_scale_fac)
     diffuse_cond_scale_fac = 1.0_rt;
+#endif
+#ifdef GRAVITY
+    allocate(use_point_mass)
+    use_point_mass = 0;
+    allocate(point_mass)
+    point_mass = 0.0_rt;
+    allocate(point_mass_fix_solution)
+    point_mass_fix_solution = 0;
 #endif
     allocate(difmag)
     difmag = 0.1_rt;
@@ -598,6 +615,8 @@ contains
     use_pslope = 1;
     allocate(limit_fluxes_on_small_dens)
     limit_fluxes_on_small_dens = 0;
+    allocate(limit_fluxes_on_large_vel)
+    limit_fluxes_on_large_vel = 0;
     allocate(density_reset_method)
     density_reset_method = 1;
     allocate(allow_small_energy)
@@ -686,11 +705,6 @@ contains
     track_grid_losses = 0;
 
     call amrex_parmparse_build(pp, "castro")
-#ifdef GRAVITY
-    call pp%query("use_point_mass", use_point_mass)
-    call pp%query("point_mass", point_mass)
-    call pp%query("point_mass_fix_solution", point_mass_fix_solution)
-#endif
 #ifdef ROTATION
     call pp%query("rotational_period", rot_period)
     call pp%query("rotational_dPdt", rot_period_dot)
@@ -707,6 +721,11 @@ contains
     call pp%query("diffuse_cutoff_density", diffuse_cutoff_density)
     call pp%query("diffuse_cutoff_density_hi", diffuse_cutoff_density_hi)
     call pp%query("diffuse_cond_scale_fac", diffuse_cond_scale_fac)
+#endif
+#ifdef GRAVITY
+    call pp%query("use_point_mass", use_point_mass)
+    call pp%query("point_mass", point_mass)
+    call pp%query("point_mass_fix_solution", point_mass_fix_solution)
 #endif
     call pp%query("difmag", difmag)
     call pp%query("small_dens", small_dens)
@@ -739,6 +758,7 @@ contains
     call pp%query("dual_energy_eta2", dual_energy_eta2)
     call pp%query("use_pslope", use_pslope)
     call pp%query("limit_fluxes_on_small_dens", limit_fluxes_on_small_dens)
+    call pp%query("limit_fluxes_on_large_vel", limit_fluxes_on_large_vel)
     call pp%query("density_reset_method", density_reset_method)
     call pp%query("allow_small_energy", allow_small_energy)
     call pp%query("do_sponge", do_sponge)
@@ -785,20 +805,6 @@ contains
     call amrex_parmparse_destroy(pp)
 
 
-    allocate(character(len=1)::gravity_type)
-    gravity_type = "fillme";
-    allocate(const_grav)
-    const_grav = 0.0_rt;
-    allocate(get_g_from_phi)
-    get_g_from_phi = 0;
-
-    call amrex_parmparse_build(pp, "gravity")
-    call pp%query("gravity_type", gravity_type)
-    call pp%query("const_grav", const_grav)
-    call pp%query("get_g_from_phi", get_g_from_phi)
-    call amrex_parmparse_destroy(pp)
-
-
 
     !$acc update &
     !$acc device(difmag, small_dens, small_temp) &
@@ -811,25 +817,26 @@ contains
     !$acc device(use_eos_in_riemann, riemann_speed_limit, use_flattening) &
     !$acc device(transverse_use_eos, transverse_reset_density, transverse_reset_rhoe) &
     !$acc device(dual_energy_eta1, dual_energy_eta2, use_pslope) &
-    !$acc device(limit_fluxes_on_small_dens, density_reset_method, allow_small_energy) &
-    !$acc device(do_sponge, sponge_implicit, ext_src_implicit) &
-    !$acc device(first_order_hydro, hse_zero_vels, hse_interp_temp) &
-    !$acc device(hse_reflect_vels, sdc_order, sdc_quadrature) &
-    !$acc device(sdc_extra, sdc_solver, sdc_solver_tol_dens) &
-    !$acc device(sdc_solver_tol_spec, sdc_solver_tol_ener, sdc_solver_atol) &
-    !$acc device(sdc_solver_relax_factor, sdc_solve_for_rhoe, sdc_use_analytic_jac) &
-    !$acc device(cfl, dtnuc_e, dtnuc_X) &
-    !$acc device(dtnuc_X_threshold, do_react, react_T_min) &
-    !$acc device(react_T_max, react_rho_min, react_rho_max) &
-    !$acc device(disable_shock_burning, T_guess, diffuse_temp) &
-    !$acc device(diffuse_cutoff_density, diffuse_cutoff_density_hi, diffuse_cond_scale_fac) &
-    !$acc device(do_grav, grav_source_type, do_rotation) &
-    !$acc device(rot_period, rot_period_dot, rotation_include_centrifugal) &
-    !$acc device(rotation_include_coriolis, rotation_include_domegadt, state_in_rotating_frame) &
-    !$acc device(rot_source_type, implicit_rotation_update, rot_axis) &
-    !$acc device(use_point_mass, point_mass, point_mass_fix_solution) &
-    !$acc device(do_acc, grown_factor, track_grid_losses) &
-    !$acc device(const_grav, get_g_from_phi)
+    !$acc device(limit_fluxes_on_small_dens, limit_fluxes_on_large_vel, density_reset_method) &
+    !$acc device(allow_small_energy, do_sponge, sponge_implicit) &
+    !$acc device(ext_src_implicit, first_order_hydro, hse_zero_vels) &
+    !$acc device(hse_interp_temp, hse_reflect_vels, sdc_order) &
+    !$acc device(sdc_quadrature, sdc_extra, sdc_solver) &
+    !$acc device(sdc_solver_tol_dens, sdc_solver_tol_spec, sdc_solver_tol_ener) &
+    !$acc device(sdc_solver_atol, sdc_solver_relax_factor, sdc_solve_for_rhoe) &
+    !$acc device(sdc_use_analytic_jac, cfl, dtnuc_e) &
+    !$acc device(dtnuc_X, dtnuc_X_threshold, do_react) &
+    !$acc device(react_T_min, react_T_max, react_rho_min) &
+    !$acc device(react_rho_max, disable_shock_burning, T_guess) &
+    !$acc device(diffuse_temp, diffuse_cutoff_density, diffuse_cutoff_density_hi) &
+    !$acc device(diffuse_cond_scale_fac, do_grav, grav_source_type) &
+    !$acc device(do_rotation, rot_period, rot_period_dot) &
+    !$acc device(rotation_include_centrifugal, rotation_include_coriolis, rotation_include_domegadt) &
+    !$acc device(state_in_rotating_frame, rot_source_type, implicit_rotation_update) &
+    !$acc device(rot_axis, use_point_mass, point_mass) &
+    !$acc device(point_mass_fix_solution, do_acc, grown_factor) &
+    !$acc device(track_grid_losses, const_grav) &
+    !$acc device(get_g_from_phi)
 
 
 #ifdef GRAVITY
@@ -1026,6 +1033,9 @@ contains
     end if
     if (allocated(limit_fluxes_on_small_dens)) then
         deallocate(limit_fluxes_on_small_dens)
+    end if
+    if (allocated(limit_fluxes_on_large_vel)) then
+        deallocate(limit_fluxes_on_large_vel)
     end if
     if (allocated(density_reset_method)) then
         deallocate(density_reset_method)

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -3,16 +3,25 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
-#ifdef GRAVITY
-int         Castro::use_point_mass = 0;
-amrex::Real Castro::point_mass = 0.0;
-int         Castro::point_mass_fix_solution = 0;
+#ifdef AMREX_PARTICLES
+int         Castro::do_tracer_particles = 0;
 #endif
 #ifdef DIFFUSION
 int         Castro::diffuse_temp = 0;
 amrex::Real Castro::diffuse_cutoff_density = -1.e200;
 amrex::Real Castro::diffuse_cutoff_density_hi = -1.e200;
 amrex::Real Castro::diffuse_cond_scale_fac = 1.0;
+#endif
+#ifdef ROTATION
+amrex::Real Castro::rotational_period = -1.e200;
+amrex::Real Castro::rotational_dPdt = 0.0;
+int         Castro::rotation_include_centrifugal = 1;
+int         Castro::rotation_include_coriolis = 1;
+int         Castro::rotation_include_domegadt = 1;
+int         Castro::state_in_rotating_frame = 1;
+int         Castro::rot_source_type = 4;
+int         Castro::implicit_rotation_update = 1;
+int         Castro::rot_axis = 3;
 #endif
 int         Castro::state_interp_order = 1;
 int         Castro::lin_limit_state_interp = 0;
@@ -54,6 +63,7 @@ amrex::Real Castro::dual_energy_eta1 = 1.0e0;
 amrex::Real Castro::dual_energy_eta2 = 1.0e-4;
 int         Castro::use_pslope = 1;
 int         Castro::limit_fluxes_on_small_dens = 0;
+int         Castro::limit_fluxes_on_large_vel = 0;
 int         Castro::density_reset_method = 1;
 int         Castro::allow_small_energy = 1;
 int         Castro::do_sponge = 0;
@@ -144,17 +154,8 @@ std::string Castro::job_name = "";
 int         Castro::output_at_completion = 1;
 amrex::Real Castro::reset_checkpoint_time = -1.e200;
 int         Castro::reset_checkpoint_step = -1;
-#ifdef ROTATION
-amrex::Real Castro::rotational_period = -1.e200;
-amrex::Real Castro::rotational_dPdt = 0.0;
-int         Castro::rotation_include_centrifugal = 1;
-int         Castro::rotation_include_coriolis = 1;
-int         Castro::rotation_include_domegadt = 1;
-int         Castro::state_in_rotating_frame = 1;
-int         Castro::rot_source_type = 4;
-int         Castro::implicit_rotation_update = 1;
-int         Castro::rot_axis = 3;
-#endif
-#ifdef AMREX_PARTICLES
-int         Castro::do_tracer_particles = 0;
+#ifdef GRAVITY
+int         Castro::use_point_mass = 0;
+amrex::Real Castro::point_mass = 0.0;
+int         Castro::point_mass_fix_solution = 0;
 #endif

--- a/Source/driver/param_includes/castro_job_info_tests.H
+++ b/Source/driver/param_includes/castro_job_info_tests.H
@@ -1,13 +1,22 @@
-#ifdef GRAVITY
-jobInfoFile << (Castro::use_point_mass == 0 ? "    " : "[*] ") << "castro.use_point_mass = " << Castro::use_point_mass << std::endl;
-jobInfoFile << (Castro::point_mass == 0.0 ? "    " : "[*] ") << "castro.point_mass = " << Castro::point_mass << std::endl;
-jobInfoFile << (Castro::point_mass_fix_solution == 0 ? "    " : "[*] ") << "castro.point_mass_fix_solution = " << Castro::point_mass_fix_solution << std::endl;
+#ifdef AMREX_PARTICLES
+jobInfoFile << (Castro::do_tracer_particles == 0 ? "    " : "[*] ") << "castro.do_tracer_particles = " << Castro::do_tracer_particles << std::endl;
 #endif
 #ifdef DIFFUSION
 jobInfoFile << (Castro::diffuse_temp == 0 ? "    " : "[*] ") << "castro.diffuse_temp = " << Castro::diffuse_temp << std::endl;
 jobInfoFile << (Castro::diffuse_cutoff_density == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density = " << Castro::diffuse_cutoff_density << std::endl;
 jobInfoFile << (Castro::diffuse_cutoff_density_hi == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density_hi = " << Castro::diffuse_cutoff_density_hi << std::endl;
 jobInfoFile << (Castro::diffuse_cond_scale_fac == 1.0 ? "    " : "[*] ") << "castro.diffuse_cond_scale_fac = " << Castro::diffuse_cond_scale_fac << std::endl;
+#endif
+#ifdef ROTATION
+jobInfoFile << (Castro::rotational_period == -1.e200 ? "    " : "[*] ") << "castro.rotational_period = " << Castro::rotational_period << std::endl;
+jobInfoFile << (Castro::rotational_dPdt == 0.0 ? "    " : "[*] ") << "castro.rotational_dPdt = " << Castro::rotational_dPdt << std::endl;
+jobInfoFile << (Castro::rotation_include_centrifugal == 1 ? "    " : "[*] ") << "castro.rotation_include_centrifugal = " << Castro::rotation_include_centrifugal << std::endl;
+jobInfoFile << (Castro::rotation_include_coriolis == 1 ? "    " : "[*] ") << "castro.rotation_include_coriolis = " << Castro::rotation_include_coriolis << std::endl;
+jobInfoFile << (Castro::rotation_include_domegadt == 1 ? "    " : "[*] ") << "castro.rotation_include_domegadt = " << Castro::rotation_include_domegadt << std::endl;
+jobInfoFile << (Castro::state_in_rotating_frame == 1 ? "    " : "[*] ") << "castro.state_in_rotating_frame = " << Castro::state_in_rotating_frame << std::endl;
+jobInfoFile << (Castro::rot_source_type == 4 ? "    " : "[*] ") << "castro.rot_source_type = " << Castro::rot_source_type << std::endl;
+jobInfoFile << (Castro::implicit_rotation_update == 1 ? "    " : "[*] ") << "castro.implicit_rotation_update = " << Castro::implicit_rotation_update << std::endl;
+jobInfoFile << (Castro::rot_axis == 3 ? "    " : "[*] ") << "castro.rot_axis = " << Castro::rot_axis << std::endl;
 #endif
 jobInfoFile << (Castro::state_interp_order == 1 ? "    " : "[*] ") << "castro.state_interp_order = " << Castro::state_interp_order << std::endl;
 jobInfoFile << (Castro::lin_limit_state_interp == 0 ? "    " : "[*] ") << "castro.lin_limit_state_interp = " << Castro::lin_limit_state_interp << std::endl;
@@ -49,6 +58,7 @@ jobInfoFile << (Castro::dual_energy_eta1 == 1.0e0 ? "    " : "[*] ") << "castro.
 jobInfoFile << (Castro::dual_energy_eta2 == 1.0e-4 ? "    " : "[*] ") << "castro.dual_energy_eta2 = " << Castro::dual_energy_eta2 << std::endl;
 jobInfoFile << (Castro::use_pslope == 1 ? "    " : "[*] ") << "castro.use_pslope = " << Castro::use_pslope << std::endl;
 jobInfoFile << (Castro::limit_fluxes_on_small_dens == 0 ? "    " : "[*] ") << "castro.limit_fluxes_on_small_dens = " << Castro::limit_fluxes_on_small_dens << std::endl;
+jobInfoFile << (Castro::limit_fluxes_on_large_vel == 0 ? "    " : "[*] ") << "castro.limit_fluxes_on_large_vel = " << Castro::limit_fluxes_on_large_vel << std::endl;
 jobInfoFile << (Castro::density_reset_method == 1 ? "    " : "[*] ") << "castro.density_reset_method = " << Castro::density_reset_method << std::endl;
 jobInfoFile << (Castro::allow_small_energy == 1 ? "    " : "[*] ") << "castro.allow_small_energy = " << Castro::allow_small_energy << std::endl;
 jobInfoFile << (Castro::do_sponge == 0 ? "    " : "[*] ") << "castro.do_sponge = " << Castro::do_sponge << std::endl;
@@ -131,17 +141,8 @@ jobInfoFile << (Castro::job_name == "" ? "    " : "[*] ") << "castro.job_name = 
 jobInfoFile << (Castro::output_at_completion == 1 ? "    " : "[*] ") << "castro.output_at_completion = " << Castro::output_at_completion << std::endl;
 jobInfoFile << (Castro::reset_checkpoint_time == -1.e200 ? "    " : "[*] ") << "castro.reset_checkpoint_time = " << Castro::reset_checkpoint_time << std::endl;
 jobInfoFile << (Castro::reset_checkpoint_step == -1 ? "    " : "[*] ") << "castro.reset_checkpoint_step = " << Castro::reset_checkpoint_step << std::endl;
-#ifdef ROTATION
-jobInfoFile << (Castro::rotational_period == -1.e200 ? "    " : "[*] ") << "castro.rotational_period = " << Castro::rotational_period << std::endl;
-jobInfoFile << (Castro::rotational_dPdt == 0.0 ? "    " : "[*] ") << "castro.rotational_dPdt = " << Castro::rotational_dPdt << std::endl;
-jobInfoFile << (Castro::rotation_include_centrifugal == 1 ? "    " : "[*] ") << "castro.rotation_include_centrifugal = " << Castro::rotation_include_centrifugal << std::endl;
-jobInfoFile << (Castro::rotation_include_coriolis == 1 ? "    " : "[*] ") << "castro.rotation_include_coriolis = " << Castro::rotation_include_coriolis << std::endl;
-jobInfoFile << (Castro::rotation_include_domegadt == 1 ? "    " : "[*] ") << "castro.rotation_include_domegadt = " << Castro::rotation_include_domegadt << std::endl;
-jobInfoFile << (Castro::state_in_rotating_frame == 1 ? "    " : "[*] ") << "castro.state_in_rotating_frame = " << Castro::state_in_rotating_frame << std::endl;
-jobInfoFile << (Castro::rot_source_type == 4 ? "    " : "[*] ") << "castro.rot_source_type = " << Castro::rot_source_type << std::endl;
-jobInfoFile << (Castro::implicit_rotation_update == 1 ? "    " : "[*] ") << "castro.implicit_rotation_update = " << Castro::implicit_rotation_update << std::endl;
-jobInfoFile << (Castro::rot_axis == 3 ? "    " : "[*] ") << "castro.rot_axis = " << Castro::rot_axis << std::endl;
-#endif
-#ifdef AMREX_PARTICLES
-jobInfoFile << (Castro::do_tracer_particles == 0 ? "    " : "[*] ") << "castro.do_tracer_particles = " << Castro::do_tracer_particles << std::endl;
+#ifdef GRAVITY
+jobInfoFile << (Castro::use_point_mass == 0 ? "    " : "[*] ") << "castro.use_point_mass = " << Castro::use_point_mass << std::endl;
+jobInfoFile << (Castro::point_mass == 0.0 ? "    " : "[*] ") << "castro.point_mass = " << Castro::point_mass << std::endl;
+jobInfoFile << (Castro::point_mass_fix_solution == 0 ? "    " : "[*] ") << "castro.point_mass_fix_solution = " << Castro::point_mass_fix_solution << std::endl;
 #endif

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -3,16 +3,25 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
-#ifdef GRAVITY
-static int use_point_mass;
-static amrex::Real point_mass;
-static int point_mass_fix_solution;
+#ifdef AMREX_PARTICLES
+static int do_tracer_particles;
 #endif
 #ifdef DIFFUSION
 static int diffuse_temp;
 static amrex::Real diffuse_cutoff_density;
 static amrex::Real diffuse_cutoff_density_hi;
 static amrex::Real diffuse_cond_scale_fac;
+#endif
+#ifdef ROTATION
+static amrex::Real rotational_period;
+static amrex::Real rotational_dPdt;
+static int rotation_include_centrifugal;
+static int rotation_include_coriolis;
+static int rotation_include_domegadt;
+static int state_in_rotating_frame;
+static int rot_source_type;
+static int implicit_rotation_update;
+static int rot_axis;
 #endif
 static int state_interp_order;
 static int lin_limit_state_interp;
@@ -54,6 +63,7 @@ static amrex::Real dual_energy_eta1;
 static amrex::Real dual_energy_eta2;
 static int use_pslope;
 static int limit_fluxes_on_small_dens;
+static int limit_fluxes_on_large_vel;
 static int density_reset_method;
 static int allow_small_energy;
 static int do_sponge;
@@ -136,17 +146,8 @@ static std::string job_name;
 static int output_at_completion;
 static amrex::Real reset_checkpoint_time;
 static int reset_checkpoint_step;
-#ifdef ROTATION
-static amrex::Real rotational_period;
-static amrex::Real rotational_dPdt;
-static int rotation_include_centrifugal;
-static int rotation_include_coriolis;
-static int rotation_include_domegadt;
-static int state_in_rotating_frame;
-static int rot_source_type;
-static int implicit_rotation_update;
-static int rot_axis;
-#endif
-#ifdef AMREX_PARTICLES
-static int do_tracer_particles;
+#ifdef GRAVITY
+static int use_point_mass;
+static amrex::Real point_mass;
+static int point_mass_fix_solution;
 #endif

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -3,16 +3,25 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
-#ifdef GRAVITY
-pp.query("use_point_mass", use_point_mass);
-pp.query("point_mass", point_mass);
-pp.query("point_mass_fix_solution", point_mass_fix_solution);
+#ifdef AMREX_PARTICLES
+pp.query("do_tracer_particles", do_tracer_particles);
 #endif
 #ifdef DIFFUSION
 pp.query("diffuse_temp", diffuse_temp);
 pp.query("diffuse_cutoff_density", diffuse_cutoff_density);
 pp.query("diffuse_cutoff_density_hi", diffuse_cutoff_density_hi);
 pp.query("diffuse_cond_scale_fac", diffuse_cond_scale_fac);
+#endif
+#ifdef ROTATION
+pp.query("rotational_period", rotational_period);
+pp.query("rotational_dPdt", rotational_dPdt);
+pp.query("rotation_include_centrifugal", rotation_include_centrifugal);
+pp.query("rotation_include_coriolis", rotation_include_coriolis);
+pp.query("rotation_include_domegadt", rotation_include_domegadt);
+pp.query("state_in_rotating_frame", state_in_rotating_frame);
+pp.query("rot_source_type", rot_source_type);
+pp.query("implicit_rotation_update", implicit_rotation_update);
+pp.query("rot_axis", rot_axis);
 #endif
 pp.query("state_interp_order", state_interp_order);
 pp.query("lin_limit_state_interp", lin_limit_state_interp);
@@ -54,6 +63,7 @@ pp.query("dual_energy_eta1", dual_energy_eta1);
 pp.query("dual_energy_eta2", dual_energy_eta2);
 pp.query("use_pslope", use_pslope);
 pp.query("limit_fluxes_on_small_dens", limit_fluxes_on_small_dens);
+pp.query("limit_fluxes_on_large_vel", limit_fluxes_on_large_vel);
 pp.query("density_reset_method", density_reset_method);
 pp.query("allow_small_energy", allow_small_energy);
 pp.query("do_sponge", do_sponge);
@@ -136,17 +146,8 @@ pp.query("job_name", job_name);
 pp.query("output_at_completion", output_at_completion);
 pp.query("reset_checkpoint_time", reset_checkpoint_time);
 pp.query("reset_checkpoint_step", reset_checkpoint_step);
-#ifdef ROTATION
-pp.query("rotational_period", rotational_period);
-pp.query("rotational_dPdt", rotational_dPdt);
-pp.query("rotation_include_centrifugal", rotation_include_centrifugal);
-pp.query("rotation_include_coriolis", rotation_include_coriolis);
-pp.query("rotation_include_domegadt", rotation_include_domegadt);
-pp.query("state_in_rotating_frame", state_in_rotating_frame);
-pp.query("rot_source_type", rot_source_type);
-pp.query("implicit_rotation_update", implicit_rotation_update);
-pp.query("rot_axis", rot_axis);
-#endif
-#ifdef AMREX_PARTICLES
-pp.query("do_tracer_particles", do_tracer_particles);
+#ifdef GRAVITY
+pp.query("use_point_mass", use_point_mass);
+pp.query("point_mass", point_mass);
+pp.query("point_mass_fix_solution", point_mass_fix_solution);
 #endif

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1102,6 +1102,19 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
                    dt, AMREX_REAL_ANYD(dx));
           }
 
+          if (limit_fluxes_on_large_vel == 1) {
+#pragma gpu box(nbx)
+              limit_hydro_fluxes_on_large_vel
+                  (AMREX_INT_ANYD(nbx.loVect()), AMREX_INT_ANYD(nbx.hiVect()),
+                   idir_f,
+                   BL_TO_FORTRAN_ANYD(Sborder[mfi]),
+                   BL_TO_FORTRAN_ANYD(q[mfi]),
+                   BL_TO_FORTRAN_ANYD(volume[mfi]),
+                   BL_TO_FORTRAN_ANYD(flux[idir]),
+                   BL_TO_FORTRAN_ANYD(area[idir][mfi]),
+                   dt, AMREX_REAL_ANYD(dx));
+          }
+
 #pragma gpu box(nbx)
           normalize_species_fluxes(AMREX_INT_ANYD(nbx.loVect()), AMREX_INT_ANYD(nbx.hiVect()),
                                    BL_TO_FORTRAN_ANYD(flux[idir]));

--- a/Source/hydro/Castro_hydro_F.H
+++ b/Source/hydro/Castro_hydro_F.H
@@ -155,6 +155,16 @@ extern "C"
      BL_FORT_FAB_ARG_3D(area),
      const amrex::Real dt, const amrex::Real* dx);
 
+  void limit_hydro_fluxes_on_large_vel
+    (const int* lo, const int* hi,
+     const int idir,
+     BL_FORT_FAB_ARG_3D(Sborder),
+     BL_FORT_FAB_ARG_3D(q),
+     BL_FORT_FAB_ARG_3D(volume),
+     BL_FORT_FAB_ARG_3D(flux),
+     BL_FORT_FAB_ARG_3D(area),
+     const amrex::Real dt, const amrex::Real* dx);
+
   void normalize_species_fluxes
     (const int* lo, const int* hi,
      BL_FORT_FAB_ARG_3D(flux));

--- a/Source/hydro/advection_util_nd.F90
+++ b/Source/hydro/advection_util_nd.F90
@@ -1068,8 +1068,6 @@ contains
 
              theta = ONE
 
-             if (uL(UMOM) < ZERO .or. uR(UMOM) < ZERO) cycle
-
              ! Loop over all three momenta, and choose the strictest
              ! limiter among them.
 


### PR DESCRIPTION

## PR summary

This new flux limiter uses the same algorithm as the existing flux limiter that prevents small densities, but uses it to prevent large velocities (specifically, larger than riemann_speed_limit). This is useful for situations where large speeds are being generated in low-density material due to a large momentum flux from an adjacent high density zone.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
