### PR TITLE
Alias GradPhiPhysBCFunct to amrex::PhysBCFunctNoOp

### DIFF
--- a/Source/gravity/Gravity.H
+++ b/Source/gravity/Gravity.H
@@ -541,22 +541,6 @@ private:
 /// @class GradPhiPhysBCFunct
 /// @brief A physical boundary condition function for grad phi
 ///
-class GradPhiPhysBCFunct
-    : public amrex::PhysBCFunctBase
-{
-public:
-    GradPhiPhysBCFunct ();
+using GradPhiPhysBCFunct = amrex::PhysBCFunctNoOp;
 
-///
-/// We should never need to actually fill physical ghost zones for
-/// grad phi, so this does nothing
-///
-/// @param mf       MultiFab
-/// @param dcomp    destonation component
-/// @param ncomp    Number of components
-/// @param time     Current time
-/// @param bccomp   Boundary conditions component
-///
-    virtual void FillBoundary (amrex::MultiFab& mf, int dcomp, int ncomp, amrex::Real time, int bccomp);
-};
 #endif

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -2547,21 +2547,6 @@ Gravity::sanity_check (int level)
     }
 }
 
-// Instantiate the necessary functions to call InterpFromCoarseLevel on grad_phi.
-
-GradPhiPhysBCFunct::GradPhiPhysBCFunct () { }
-
-void
-GradPhiPhysBCFunct::FillBoundary (MultiFab& mf, int dcomp, int scomp, Real time, int bccomp)
-{
-    BL_PROFILE("GradPhiPhysBCFunct::FillBoundary");
-
-    // We should never need to actually fill physical ghost zones for grad_phi.
-    // So we do not need to do anything here.
-
-    return;
-}
-
 void
 Gravity::update_max_rhs()
 {


### PR DESCRIPTION
Instead of defining our own no-op class derived from amrex::PhysBCFunctBase to be used by FillPatch, we can use amrex::PhysBCFunctNoOp.  This works with the current master and development branches of amrex.  And this prepares Castro for a future change in AMReX.
