### PR TITLE
Remove self-gravity define, use GRAVITY always

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -131,14 +131,6 @@ ifeq ($(USE_GRAV), TRUE)
   Bdirs += Source/gravity
   DEFINES += -DGRAVITY
   USE_MLMG = TRUE
-
-  ifndef USE_SELF_GRAV
-    USE_SELF_GRAV = TRUE
-  endif
-
-  ifeq ($(USE_SELF_GRAV), TRUE)
-    DEFINES += -DSELF_GRAVITY
-  endif
 endif
 
 ifeq ($(USE_GR), TRUE)

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -27,7 +27,7 @@ enum StateType { State_Type = 0,
 #ifdef RADIATION
                  Rad_Type,
 #endif
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
                  PhiGrav_Type,
                  Gravity_Type,
 #endif
@@ -769,8 +769,6 @@ public:
                             amrex::MultiFab& ext_src);
 
 #ifdef GRAVITY
-#ifdef SELF_GRAVITY
-
 ///
 /// Construct gravitational field at old timestep
 ///
@@ -791,7 +789,6 @@ public:
 ///
     void construct_new_gravity(int amr_iteration, int amr_ncycle,
 			       amrex::Real time);
-#endif
 
 ///
 /// Construct gravitational source terms at old timestep
@@ -1573,7 +1570,7 @@ public:
 ///
     void expand_state(amrex::MultiFab& S, amrex::Real time, int ng);
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 
 ///
 /// Calculate state in radial direction by averaging
@@ -1716,7 +1713,7 @@ protected:
 ///
     amrex::iMultiFab& build_interior_boundary_mask (int ng);
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     int get_numpts();
 
 
@@ -2004,7 +2001,7 @@ protected:
 
     void write_info ();
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 
 ///
 /// Find the position of the "center" by interpolating from data at cell centers
@@ -2014,9 +2011,7 @@ protected:
 ///
     void define_new_center (amrex::MultiFab& S, amrex::Real time);
     void write_center ();
-#endif
 
-#ifdef GRAVITY
 ///
 /// @param time     current time
 /// @param dt       timestep

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -31,7 +31,7 @@
 #include <AMReX_Particles.H>
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #include "Gravity.H"
 #endif
 
@@ -147,7 +147,7 @@ int          Castro::numBCThreadsMin[3] = {1, 1, 1};
 
 #include <castro_defaults.H>
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 // the gravity object
 Gravity*     Castro::gravity  = 0;
 #endif
@@ -205,7 +205,7 @@ int          Castro::num_state_type = 0;
 void
 Castro::variableCleanUp ()
 {
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
   if (gravity != 0) {
     if (verbose > 1 && ParallelDescriptor::IOProcessor()) {
       std::cout << "Deleting gravity in variableCleanUp..." << '\n';
@@ -555,7 +555,7 @@ Castro::Castro (Amr&            papa,
     }
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 
    // Initialize to zero here in case we run with do_grav = false.
    MultiFab& new_grav_mf = get_new_data(Gravity_Type);
@@ -586,7 +586,7 @@ Castro::Castro (Amr&            papa,
       if (verbose && level == 0 &&  ParallelDescriptor::IOProcessor())
          std::cout << "Setting the gravity type to " << gravity->get_gravity_type() << std::endl;
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
       if (gravity->get_gravity_type() == "PoissonGrav" && gravity->NoComposite() != 0 && gravity->NoSync() == 0)
       {
 	  std::cerr << "Error: not meaningful to have gravity.no_sync == 0 without having gravity.no_composite == 0.";
@@ -816,7 +816,7 @@ Castro::initMFs()
 	}
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 	if (do_grav && gravity->get_gravity_type() == "PoissonGrav" && gravity->NoSync() == 0) {
 	    phi_reg.define(grids, dmap, crse_ratio, level, 1);
 	    phi_reg.setVal(0.0);
@@ -1219,7 +1219,7 @@ Castro::initData ()
 #endif // MAESTRO_INIT
 
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #if (BL_SPACEDIM > 1)
     if ( (level == 0) && (spherical_star == 1) ) {
        const int nc = S_new.nComp();
@@ -1898,7 +1898,7 @@ Castro::post_timestep (int iteration)
         if (sum_int_test || sum_per_test)
 	  sum_integrated_quantities();
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
         if (moving_center) write_center();
 #endif
     }
@@ -1948,7 +1948,7 @@ Castro::post_restart ()
    ParticlePostRestart(parent->theRestartFile());
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     if (do_grav)
     {
         if (level == 0)
@@ -2038,7 +2038,7 @@ Castro::postCoarseTimeStep (Real cumtime)
     // postCoarseTimeStep() is only called by level 0.
     BL_ASSERT(level == 0);
     AmrLevel::postCoarseTimeStep(cumtime);
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     if (do_grav)
         gravity->set_mass_offset(cumtime, 0);
 #endif
@@ -2139,7 +2139,7 @@ Castro::post_regrid (int lbase,
     }
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     if (do_grav)
     {
 
@@ -2222,7 +2222,7 @@ Castro::post_init (Real stop_time)
     for (int k = finest_level-1; k>= 0; k--)
         getLevel(k).avgDown();
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 
     if (do_grav) {
 
@@ -2337,7 +2337,7 @@ Castro::post_init (Real stop_time)
         if (sum_int_test || sum_per_test)
 	  sum_integrated_quantities();
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     if (level == 0 && moving_center == 1)
        write_center();
 #endif
@@ -2352,7 +2352,7 @@ Castro::post_grown_restart ()
     if (level > 0)
         return;
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     if (do_grav) {
 	int finest_level = parent->finestLevel();
 	Real cur_time = state[State_Type].curTime();
@@ -2527,7 +2527,7 @@ Castro::reflux(int crse_level, int fine_level)
 
     const Real strt = ParallelDescriptor::second();
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     int nlevs = fine_level - crse_level + 1;
 
     Vector<std::unique_ptr<MultiFab> > drho(nlevs);
@@ -2574,7 +2574,7 @@ Castro::reflux(int crse_level, int fine_level)
 
 	// Store the density change, for the gravity sync.
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 	int ilev = lev - crse_level - 1;
 
 	if (do_grav && gravity->get_gravity_type() == "PoissonGrav" && gravity->NoSync() == 0) {
@@ -2689,7 +2689,7 @@ Castro::reflux(int crse_level, int fine_level)
 
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 	if (do_grav && gravity->get_gravity_type() == "PoissonGrav" && gravity->NoSync() == 0)  {
 
 	    reg = &getLevel(lev).phi_reg;
@@ -2718,7 +2718,7 @@ Castro::reflux(int crse_level, int fine_level)
 
     // Do the sync solve across all levels.
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     if (do_grav && gravity->get_gravity_type() == "PoissonGrav" && gravity->NoSync() == 0)
 	gravity->gravity_sync(crse_level, fine_level, amrex::GetVecOfPtrs(drho), amrex::GetVecOfPtrs(dphi));
 #endif
@@ -2845,7 +2845,7 @@ Castro::avgDown ()
 
   avgDown(State_Type);
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
   avgDown(Gravity_Type);
   avgDown(PhiGrav_Type);
 #endif
@@ -3638,7 +3638,7 @@ Castro::swap_state_time_levels(const Real dt)
 
 
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 int
 Castro::get_numpts ()
 {

--- a/Source/driver/Castro_F.H
+++ b/Source/driver/Castro_F.H
@@ -53,7 +53,7 @@ extern "C"
   void prob_params_pretty_print(int* jobinfo_file_name, const int* jobinfo_file_length);
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #if (BL_SPACEDIM > 1)
   void get_numpts_1d(int* numpts_1d);
   void set_numpts_1d(int* numpts_1d);
@@ -124,7 +124,7 @@ extern "C"
   void ca_deallocate_sponge_params();
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #if (BL_SPACEDIM > 1)
   void ca_compute_avgstate
     (const int* lo, const int* hi,
@@ -341,10 +341,8 @@ extern "C"
     (const int* lo, const int* hi,
      const int* domlo, const int* domhi,
      const BL_FORT_FAB_ARG_3D(s_old),
-#ifdef SELF_GRAVITY
      const BL_FORT_FAB_ARG_3D(phi),
      const BL_FORT_FAB_ARG_3D(grav),
-#endif
      BL_FORT_FAB_ARG_3D(source),
      const amrex::Real* dx, const amrex::Real dt, const amrex::Real time);
 
@@ -353,12 +351,10 @@ extern "C"
      const int* domlo, const int* domhi,
      const BL_FORT_FAB_ARG_3D(S_old),
      const BL_FORT_FAB_ARG_3D(S_new),
-#ifdef SELF_GRAVITY
      const BL_FORT_FAB_ARG_3D(phi_old),
      const BL_FORT_FAB_ARG_3D(phi_new),
      const BL_FORT_FAB_ARG_3D(grav_old),
      const BL_FORT_FAB_ARG_3D(grav_new),
-#endif
      const BL_FORT_FAB_ARG_3D(volume),
      const BL_FORT_FAB_ARG_3D(xflux),
      const BL_FORT_FAB_ARG_3D(yflux),

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -6,7 +6,7 @@
 #include "Radiation.H"
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #include "Gravity.H"
 #endif
 
@@ -159,7 +159,7 @@ Castro::advance (Real time,
     advance_aux(time, dt);
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #if (BL_SPACEDIM > 1)
     // We do this again here because the solution will have changed
     if ( (level == 0) && (spherical_star == 1) ) {
@@ -222,7 +222,7 @@ Castro::initialize_do_advance(Real time, Real dt, int amr_iteration, int amr_ncy
       for (int i = 0; i < n_lost; i++)
 	material_lost_through_boundary_temp[i] = 0.0;
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     if (moving_center == 1)
         define_new_center(get_old_data(State_Type), time);
 
@@ -378,7 +378,7 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
     lamborder.define(grids, dmap, Radiation::nGroups, NUM_GROW);
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     // If we're on level 0, update the maximum density used in the gravity solver
     // for setting the tolerances. This will be used in all level solves to follow.
     // This must be done before the swap because it relies on the new data.
@@ -432,7 +432,7 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
 
     swap_state_time_levels(dt);
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     if (do_grav)
 	gravity->swapTimeLevels(level);
 #endif

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -6,7 +6,7 @@
 #include "Radiation.H"
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #include "Gravity.H"
 #endif
 
@@ -85,7 +85,7 @@ Castro::do_advance_ctu(Real time,
     // interface state, an explict source will be traced there as
     // needed.
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     construct_old_gravity(amr_iteration, amr_ncycle, prev_time);
 #endif
 
@@ -145,14 +145,14 @@ Castro::do_advance_ctu(Real time,
     // if we are done with the update do the source correction and
     // then the second half of the reactions
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     // Must define new value of "center" before we call new gravity
     // solve or external source routine
     if (moving_center == 1)
       define_new_center(S_new, time);
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     // We need to make the new radial data now so that we can use it when we
     // FillPatch in creating the new source.
 
@@ -166,7 +166,7 @@ Castro::do_advance_ctu(Real time,
 
     // Construct and apply new-time source terms.
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     construct_new_gravity(amr_iteration, amr_ncycle, cur_time);
 #endif
 
@@ -478,7 +478,7 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
 
             swap_state_time_levels(0.0);
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
             if (do_grav) {
                 gravity->swapTimeLevels(level);
             }

--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -6,7 +6,7 @@
 #include "Radiation.H"
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #include "Gravity.H"
 #endif
 
@@ -91,7 +91,7 @@ Castro::do_advance_sdc (Real time,
       // using the current stage's starting point.
 
       // TODO: this is not using the density at the current stage
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
       construct_old_gravity(amr_iteration, amr_ncycle, prev_time);
 #endif
 

--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -18,7 +18,7 @@
 #include "Radiation.H"
 #endif
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #include "Gravity.H"
 #endif
 
@@ -137,7 +137,7 @@ Castro::restart (Amr&     papa,
     AmrLevel::restart(papa,is,bReadSpecial);
 
     if (input_version == 0) { // old checkpoint without PhiGrav_Type
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
       state[PhiGrav_Type].restart(desc_lst[PhiGrav_Type], state[Gravity_Type]);
 #endif
     }
@@ -453,7 +453,7 @@ Castro::restart (Amr&     papa,
     if (grown_factor > 1 && level == 1)
         getLevel(0).avgDown();
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #if (BL_SPACEDIM > 1)
     if ( (level == 0) && (spherical_star == 1) ) {
        MultiFab& S_new = get_new_data(State_Type);
@@ -530,7 +530,7 @@ Castro::set_state_in_checkpoint (Vector<int>& state_in_checkpoint)
     state_in_checkpoint[i] = 1;
 
   for (int i=0; i<num_state_type; ++i) {
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     if (input_version == 0 && i == PhiGrav_Type) {
       // We are reading an old checkpoint with no PhiGrav_Type
       state_in_checkpoint[i] = 0;

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -336,7 +336,7 @@ Castro::variableSetUp ()
 			 StateDescriptor::Point,ngrow_state,NUM_STATE,
 			 interp,state_data_extrap,store_in_checkpoint);
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
   store_in_checkpoint = true;
   desc_lst.addDescriptor(PhiGrav_Type, IndexType::TheCellType(),
 			 StateDescriptor::Point, 1, 1,
@@ -532,7 +532,7 @@ Castro::variableSetUp ()
 			bcs,
 			BndryFunc(ca_denfill,ca_hypfill));
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
   set_scalar_bc(bc,phys_bc);
   desc_lst.setComponent(PhiGrav_Type,0,"phiGrav",bc,BndryFunc(ca_phigravfill));
   set_x_vel_bc(bc,phys_bc);
@@ -743,7 +743,7 @@ Castro::variableSetUp ()
   //
   // Gravitational forcing
   //
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
   //    derive_lst.add("rhog",IndexType::TheCellType(),1,
   //                   BL_FORT_PROC_CALL(CA_RHOG,ca_rhog),the_same_box);
   //    derive_lst.addComponent("rhog",desc_lst,State_Type,Density,1);
@@ -888,7 +888,7 @@ Castro::variableSetUp ()
   derive_lst.addComponent("angular_momentum_z",desc_lst,State_Type,Density,1);
   derive_lst.addComponent("angular_momentum_z",desc_lst,State_Type,Xmom,3);
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
   derive_lst.add("maggrav",IndexType::TheCellType(),1,ca_dermaggrav,the_same_box);
   derive_lst.addComponent("maggrav",desc_lst,Gravity_Type,0,3);
 #endif

--- a/Source/driver/sum_integrated_quantities.cpp
+++ b/Source/driver/sum_integrated_quantities.cpp
@@ -3,7 +3,7 @@
 #include <Castro.H>
 #include <Castro_F.H>
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #include <Gravity.H>
 #endif
 
@@ -30,7 +30,7 @@ Castro::sum_integrated_quantities ()
     Real rho_e       = 0.0;
     Real rho_K       = 0.0;
     Real rho_E       = 0.0;
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
     Real rho_phi     = 0.0;
     Real total_energy = 0.0;
 #endif
@@ -66,7 +66,7 @@ Castro::sum_integrated_quantities ()
        rho_e += ca_lev.volWgtSum("rho_e", time, local_flag);
        rho_K += ca_lev.volWgtSum("kineng", time, local_flag);
        rho_E += ca_lev.volWgtSum("rho_E", time, local_flag);
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
         if (gravity->get_gravity_type() == "PoissonGrav")
                rho_phi += ca_lev.volProductSum("density", "phiGrav", time, local_flag);
 #endif
@@ -77,13 +77,13 @@ Castro::sum_integrated_quantities ()
     {
 
 #ifdef HYBRID_MOMENTUM
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
        const int nfoo = 14;
 #else
        const int nfoo = 13;
 #endif
 #else
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
        const int nfoo = 11;
 #else
        const int nfoo = 10;
@@ -94,7 +94,7 @@ Castro::sum_integrated_quantities ()
 #ifdef HYBRID_MOMENTUM
 			  hyb_mom[0], hyb_mom[1], hyb_mom[2],
 #endif
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 			  rho_e, rho_K, rho_E, rho_phi};
 #else
 			  rho_e, rho_K, rho_E};
@@ -127,7 +127,7 @@ Castro::sum_integrated_quantities ()
 	    rho_e      = foo[i++];
 	    rho_K      = foo[i++];
             rho_E      = foo[i++];
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 	    rho_phi    = foo[i++];
 
 	    // Total energy is -1/2 * rho * phi + rho * E for self-gravity,
@@ -155,7 +155,7 @@ Castro::sum_integrated_quantities ()
 	    std::cout << "TIME= " << time << " RHO*e       = "   << rho_e     << '\n';
 	    std::cout << "TIME= " << time << " RHO*K       = "   << rho_K     << '\n';
 	    std::cout << "TIME= " << time << " RHO*E       = "   << rho_E     << '\n';
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 	    std::cout << "TIME= " << time << " RHO*PHI     = "   << rho_phi   << '\n';
 	    std::cout << "TIME= " << time << " TOTAL ENERGY= "   << total_energy << '\n';
 #endif
@@ -182,7 +182,7 @@ Castro::sum_integrated_quantities ()
 		      data_log1 << std::setw(datwidth) <<  "         rho_K";
 		      data_log1 << std::setw(datwidth) <<  "         rho_e";
 		      data_log1 << std::setw(datwidth) <<  "         rho_E";
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 		      data_log1 << std::setw(datwidth) <<  "       rho_phi";
 		      data_log1 << std::setw(datwidth) <<  "  total energy";
 #endif
@@ -206,7 +206,7 @@ Castro::sum_integrated_quantities ()
 		  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_K;
 		  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_e;
 		  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_E;
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 		  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_phi;
 		  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << total_energy;
 #endif

--- a/Source/driver/sum_utils.cpp
+++ b/Source/driver/sum_utils.cpp
@@ -3,7 +3,7 @@
 #include <Castro.H>
 #include <Castro_F.H>
 
-#ifdef SELF_GRAVITY
+#ifdef GRAVITY
 #include <Gravity.H>
 #include <Gravity_F.H>
 #endif

--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -1,7 +1,6 @@
 #include "Castro.H"
 #include "Castro_F.H"
 
-#ifdef SELF_GRAVITY
 #include "Gravity.H"
 
 using namespace amrex;
@@ -225,7 +224,6 @@ Castro::construct_new_gravity(int amr_iteration, int amr_ncycle, Real time)
     }
 
 }
-#endif
 
 void Castro::construct_old_gravity_source(MultiFab& source, MultiFab& state, Real time, Real dt)
 {
@@ -233,10 +231,8 @@ void Castro::construct_old_gravity_source(MultiFab& source, MultiFab& state, Rea
 
     const Real strt_time = ParallelDescriptor::second();
 
-#ifdef SELF_GRAVITY
     const MultiFab& phi_old = get_old_data(PhiGrav_Type);
     const MultiFab& grav_old = get_old_data(Gravity_Type);
-#endif
 
     if (!do_grav) return;
 
@@ -257,10 +253,8 @@ void Castro::construct_old_gravity_source(MultiFab& source, MultiFab& state, Rea
 	ca_gsrc(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
 		AMREX_INT_ANYD(domlo), AMREX_INT_ANYD(domhi),
 		BL_TO_FORTRAN_ANYD(state[mfi]),
-#ifdef SELF_GRAVITY
 		BL_TO_FORTRAN_ANYD(phi_old[mfi]),
 		BL_TO_FORTRAN_ANYD(grav_old[mfi]),
-#endif
 		BL_TO_FORTRAN_ANYD(source[mfi]),
 		AMREX_REAL_ANYD(dx), dt, time);
 
@@ -291,13 +285,11 @@ void Castro::construct_new_gravity_source(MultiFab& source, MultiFab& state_old,
 
     const Real strt_time = ParallelDescriptor::second();
 
-#ifdef SELF_GRAVITY
     MultiFab& phi_old = get_old_data(PhiGrav_Type);
     MultiFab& phi_new = get_new_data(PhiGrav_Type);
 
     MultiFab& grav_old = get_old_data(Gravity_Type);
     MultiFab& grav_new = get_new_data(Gravity_Type);
-#endif
 
     if (!do_grav) return;
 
@@ -318,12 +310,10 @@ void Castro::construct_new_gravity_source(MultiFab& source, MultiFab& state_old,
 			AMREX_INT_ANYD(domlo), AMREX_INT_ANYD(domhi),
 			BL_TO_FORTRAN_ANYD(state_old[mfi]),
 			BL_TO_FORTRAN_ANYD(state_new[mfi]),
-#ifdef SELF_GRAVITY
 			BL_TO_FORTRAN_ANYD(phi_old[mfi]),
 			BL_TO_FORTRAN_ANYD(phi_new[mfi]),
 			BL_TO_FORTRAN_ANYD(grav_old[mfi]),
 			BL_TO_FORTRAN_ANYD(grav_new[mfi]),
-#endif
 			BL_TO_FORTRAN_ANYD(volume[mfi]),
 			BL_TO_FORTRAN_ANYD((*mass_fluxes[0])[mfi]),
 			BL_TO_FORTRAN_ANYD((*mass_fluxes[1])[mfi]),

--- a/Source/gravity/Make.package
+++ b/Source/gravity/Make.package
@@ -1,23 +1,19 @@
 # sources used with gravity
 # this is included if USE_GRAV = TRUE
 
-ifeq ($(USE_SELF_GRAV), TRUE)
-  CEXE_sources += Gravity.cpp
-  CEXE_headers += Gravity.H
-  FEXE_headers += Gravity_F.H
-endif
+CEXE_sources += Gravity.cpp
+CEXE_headers += Gravity.H
+FEXE_headers += Gravity_F.H
 
 CEXE_sources += Castro_gravity.cpp
 
 CEXE_sources += Castro_pointmass.cpp
 ca_F90EXE_sources += pointmass_nd.F90
 
-ifeq ($(USE_GRAV), TRUE)
-  ca_F90EXE_sources += prescribe_phi_nd.F90
-  ca_F90EXE_sources += prescribe_grav_nd.F90
-  ca_F90EXE_sources += Gravity_nd.F90
-  ca_F90EXE_sources += gravity_sources_nd.F90
-endif
+ca_F90EXE_sources += prescribe_phi_nd.F90
+ca_F90EXE_sources += prescribe_grav_nd.F90
+ca_F90EXE_sources += Gravity_nd.F90
+ca_F90EXE_sources += gravity_sources_nd.F90
 
 ca_f90EXE_sources += Gravity_$(DIM)d.f90
 


### PR DESCRIPTION

## PR summary

This PR closes #157 by removing the SELF_GRAVITY ifdef -- we revert back to the previous behavior where GRAVITY is the only relevant define.

Also, I'm including a centralization on the approach for grav_source_type = 4 based on g, not phi. The mechanism based on phi is slightly better at conservation in the presence of coarse-fine boundaries, but the difference between the two methods is quite small in absolute terms -- both are very good -- and it is better to only have one method so that we don't have to worry when switching between different gravity implementations (not all of them define phi).

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
