### PR TITLE
Set compute_new_dt_on_regrid by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # 20.01
 
+   * The AMR parameter amr.compute_new_dt_on_regrid is now on by
+     default. This avoids crashes that result from the CFL number
+     being too large after regridding, because we update the
+     timestep after seeing that larger velocity. You can still opt
+     to set this off if you want to in your inputs file. (#720)
+
    * We have added calls into Hypre that only exist as of version
      2.15.0, so that is the new minimum requirement for Castro
      radiation. Note that Hypre is now hosted on GitHub at

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -200,6 +200,10 @@ int          Castro::Knapsack_Weight_Type = -1;
 int          Castro::SDC_Source_Type = -1;
 int          Castro::num_state_type = 0;
 
+namespace amrex {
+    extern int compute_new_dt_on_regrid;
+}
+
 // Castro::variableSetUp is in Castro_setup.cpp
 // variableCleanUp is called once at the end of a simulation
 void
@@ -504,6 +508,12 @@ Castro::read_params ()
     {
 	for (int i=0; i<BL_SPACEDIM; i++) hydro_tile_size[i] = tilesize[i];
     }
+
+    // Override Amr defaults. Note: this function is called after Amr::Initialize()
+    // in Amr::InitAmr(), right before the ParmParse checks, so if the user opts to
+    // override our overriding, they can do so.
+
+    compute_new_dt_on_regrid = 1;
 
 }
 


### PR DESCRIPTION

## PR summary

The AMR parameter `amr.compute_new_dt_on_regrid` is now on by default; closes #356. This avoids crashes that result from the CFL number being too large after regridding, because we update the timestep after seeing that larger velocity.

The user can still opt to set this off if they want to, since the location where we're setting it in Castro occurs before the Amr ParmParse of this parameter.

## PR checklist

- [ ] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
