### PR TITLE
Replace do_real_eos = 0 with an actual EOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # 20.02
 
+   * The parameter radiation.do_real_eos = 0 has been removed, and its
+     functionality is now enabled with a new equation of state called
+     rad_power_law. This new EOS is only compatible with the pure
+     radiation-diffusion tests, not with castro.do_hydro = 1. (#722)
+
    * Support for neutrino radiation diffusion has been removed.
 
 # 20.01

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M2
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M2
@@ -124,8 +124,6 @@ radiation.hi_bcflag = 0 0 0
 radiation.lo_bcval = 7.5657313567241239e-7   0.0 0.0
 radiation.hi_bcval = 1.4095275679472162e-5  0.0 0.0
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M2.mg
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M2.mg
@@ -145,8 +145,6 @@ radiation.hi_bcval0 = 6.81835171549573965E-014 5.89264374490598366E-013
 1.37837403056099864E-008 1.20077008435698872E-013 0.0000000000000000
 0.0000000000000000
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M2.test
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M2.test
@@ -123,8 +123,6 @@ radiation.hi_bcflag = 0 0 0
 radiation.lo_bcval = 7.5657313567241239e-7   0.0 0.0
 radiation.hi_bcval = 1.4095275679472162e-5  0.0 0.0
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M2.test.multid
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M2.test.multid
@@ -123,8 +123,6 @@ radiation.hi_bcflag = 0 0 0
 radiation.lo_bcval = 7.5657313567241239e-7   0.0 0.0
 radiation.hi_bcval = 1.4095275679472162e-5  0.0 0.0
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M5
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M5
@@ -124,8 +124,6 @@ radiation.hi_bcflag = 0 0 0
 radiation.lo_bcval = 7.5657313567241239e-7   0.0 0.0
 radiation.hi_bcval = 0.0040567429273323397   0.0 0.0
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg
@@ -160,8 +160,6 @@ radiation.hi_bcval0 =  2.81241745447867642E-013 2.43427083781028680E-012
 1.90152165072088103E-003 4.22478249639437597E-004
 3.10661088952744746E-006 1.95926322041350964E-011
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg.test
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg.test
@@ -159,8 +159,6 @@ radiation.hi_bcval0 =  2.81241745447867642E-013 2.43427083781028680E-012
 1.90152165072088103E-003 4.22478249639437597E-004
 3.10661088952744746E-006 1.95926322041350964E-011
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg.test.multid
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg.test.multid
@@ -159,8 +159,6 @@ radiation.hi_bcval0 =  2.81241745447867642E-013 2.43427083781028680E-012
 1.90152165072088103E-003 4.22478249639437597E-004
 3.10661088952744746E-006 1.95926322041350964E-011
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/Rad2Tshock/inputs_y.M5
+++ b/Exec/radiation_tests/Rad2Tshock/inputs_y.M5
@@ -124,8 +124,6 @@ radiation.hi_bcflag = 0 0 0
 radiation.lo_bcval = 0.0 7.5657313567241239e-7   0.0
 radiation.hi_bcval = 0.0 0.0040567429273323397   0.0
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/Rad2Tshock/inputs_z.M5
+++ b/Exec/radiation_tests/Rad2Tshock/inputs_z.M5
@@ -124,8 +124,6 @@ radiation.hi_bcflag = 0 0 0
 radiation.lo_bcval = 0.0 0.0 7.5657313567241239e-7
 radiation.hi_bcval = 0.0 0.0 0.0040567429273323397
 
-radiation.do_real_eos = 1
-
 # Power-law opacities are represented as:
 #
 #    const_kappa * (rho**m) * (temp**(-n)) * (nu**(p))

--- a/Exec/radiation_tests/RadBreakout/inputs.1d
+++ b/Exec/radiation_tests/RadBreakout/inputs.1d
@@ -152,8 +152,6 @@ radiation.hi_bcflag = 0 0 0
 radiation.lo_bcval = 0.0 0.0 0.0
 radiation.hi_bcval = 0.0 0.0 0.0
 
-radiation.do_real_eos = 1
-
 radiation.use_opacity_table_module = 1
 
 # ------------------  INPUTS TO RADIATION SOLVER CLASS  -------------------

--- a/Exec/radiation_tests/RadBreakout/inputs.1d.test
+++ b/Exec/radiation_tests/RadBreakout/inputs.1d.test
@@ -150,8 +150,6 @@ radiation.hi_bcflag = 0 0 0
 radiation.lo_bcval = 0.0 0.0 0.0
 radiation.hi_bcval = 0.0 0.0 0.0
 
-radiation.do_real_eos = 1
-
 radiation.use_opacity_table_module = 1
 
 # ------------------  INPUTS TO RADIATION SOLVER CLASS  -------------------

--- a/Exec/radiation_tests/RadFront/inputs1d
+++ b/Exec/radiation_tests/RadFront/inputs1d
@@ -132,9 +132,6 @@ radiation.hi_bcval = 2.99 0.0 0.0
 #
 # Since the formula is both nonphysical and singular, prop_temp_floor
 # provides a floor for the temperature used in the power-law computation.
-# (Specific heat c_v follows the same convention.)
-
-#radiation.do_real_eos = 0
 
 # Planck mean opacity 
 radiation.const_kappa_p =  1.0e-7

--- a/Exec/radiation_tests/RadFront/inputs2d
+++ b/Exec/radiation_tests/RadFront/inputs2d
@@ -136,9 +136,6 @@ radiation.hi_bcval = 0.0   2.99      0.0
 #
 # Since the formula is both nonphysical and singular, prop_temp_floor
 # provides a floor for the temperature used in the power-law computation.
-# (Specific heat c_v follows the same convention.)
-
-#radiation.do_real_eos = 0
 
 # Planck mean opacity 
 radiation.const_kappa_p =  1.0e-15

--- a/Exec/radiation_tests/RadShestakovBolstad/GNUmakefile
+++ b/Exec/radiation_tests/RadShestakovBolstad/GNUmakefile
@@ -11,7 +11,7 @@ USE_RAD = TRUE
 
 CASTRO_HOME = ../../..
 
-EOS_DIR     := gamma_law
+EOS_DIR     := rad_power_law
 
 NETWORK_DIR := general_null
 NETWORK_INPUTS := gammalaw.net

--- a/Exec/radiation_tests/RadShestakovBolstad/inputs.common
+++ b/Exec/radiation_tests/RadShestakovBolstad/inputs.common
@@ -135,11 +135,6 @@ radiation.hi_bcflag = 0 0 0
 #
 # Since the formula is both nonphysical and singular, prop_temp_floor
 # provides a floor for the temperature used in the power-law computation.
-# (Specific heat c_v follows the same convention.)
-
-radiation.do_real_eos = 0
-
-radiation.const_c_v     =  99968636.6828
 
 radiation.const_kappa_p =  4.0628337e43
 radiation.kappa_p_exp_m =  0.0

--- a/Exec/radiation_tests/RadShestakovBolstad/probin.common
+++ b/Exec/radiation_tests/RadShestakovBolstad/probin.common
@@ -8,6 +8,8 @@
 
 &extern
 
-  eos_gamma = 1.6666666667
+  eos_const_c_v = 99968636.6828d0
+  eos_c_v_exp_m = 0.0d0
+  eos_c_v_exp_n = 0.0d0
 
 /

--- a/Exec/radiation_tests/RadSlope/GNUmakefile
+++ b/Exec/radiation_tests/RadSlope/GNUmakefile
@@ -11,7 +11,7 @@ USE_RAD = TRUE
 
 CASTRO_HOME = ../../..
 
-EOS_DIR     := gamma_law
+EOS_DIR     := rad_power_law
 
 NETWORK_DIR := general_null
 NETWORK_INPUTS := gammalaw.net

--- a/Exec/radiation_tests/RadSlope/inputs
+++ b/Exec/radiation_tests/RadSlope/inputs
@@ -134,11 +134,6 @@ radiation.hi_bcval = 0.0 0.0 0.0
 #
 # Since the formula is both nonphysical and singular, prop_temp_floor
 # provides a floor for the temperature used in the power-law computation.
-# (Specific heat c_v follows the same convention.)
-
-radiation.do_real_eos = 0
-radiation.const_c_v = 1.0e-13
-radiation.c_v_exp_n = 0.0
 
 # Planck mean opacity 
 radiation.const_kappa_p =  0.0

--- a/Exec/radiation_tests/RadSlope/probin
+++ b/Exec/radiation_tests/RadSlope/probin
@@ -5,6 +5,8 @@
 
 &extern
 
-  eos_gamma = 1.6666666667
+  eos_const_c_v = 1.0d-13
+  eos_c_v_exp_m = 0.0d0
+  eos_c_v_exp_n = 0.0d0
 
 /

--- a/Exec/radiation_tests/RadSphere/GNUmakefile
+++ b/Exec/radiation_tests/RadSphere/GNUmakefile
@@ -11,7 +11,7 @@ USE_RAD = TRUE
 
 CASTRO_HOME = ../../..
 
-EOS_DIR     := gamma_law
+EOS_DIR     := rad_power_law
 
 NETWORK_DIR := general_null
 NETWORK_INPUTS := gammalaw.net

--- a/Exec/radiation_tests/RadSphere/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSphere/Prob_nd.F90
@@ -1,8 +1,6 @@
 subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(C, name="amrex_probinit")
 
   use probdata_module
-  use eos_module
-  use eos_type_module, only : eos_t, eos_input_rt
   use network, only : nspec
   use castro_error_module
 
@@ -12,8 +10,6 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(C, name="amrex_pr
   integer, intent(in) :: init, namlen
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
-
-  type(eos_t) :: eos_state
 
   integer :: untin, i
 
@@ -35,20 +31,12 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(C, name="amrex_pr
 
   rho_0 = 1.0             ! not used -- no hydro
   T_0 = 5.797e5           ! 50 eV
+  rhoe_0 = rho_0 * 7.236399881810565625d13
 
   !     Read namelists
   open(newunit=untin,file=probin(1:namlen),form='formatted',status='old')
   read(untin,fortin)
   close(unit=untin)
-
-  eos_state % rho = rho_0
-  eos_state % T   = T_0
-  eos_state % xn  = 0.e0_rt
-  eos_state % xn(1) = 1.e0_rt
-
-  call eos_on_host(eos_input_rt, eos_state)
-
-  rhoe_0 = rho_0 * eos_state % e
 
   !     domain extrema
   xmin = problo(1)

--- a/Exec/radiation_tests/RadSphere/inputs
+++ b/Exec/radiation_tests/RadSphere/inputs
@@ -137,11 +137,6 @@ radiation.hi_bcval0 = 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.
 # Power-law opacities are represented as const_kappa * (rho**m) * (temp**(-n)).
 # Since the formula is both nonphysical and singular, prop_temp_floor
 # provides a floor for the temperature used in the power-law computation.
-# (Specific heat c_v follows the same convention.)
-
-radiation.do_real_eos = 0
-
-radiation.const_c_v     =  1.e+8
 
 radiation.const_kappa_p =  0.0
 radiation.kappa_p_exp_m =  0.0

--- a/Exec/radiation_tests/RadSphere/probin
+++ b/Exec/radiation_tests/RadSphere/probin
@@ -6,6 +6,8 @@
 
 &extern
 
-  eos_gamma = 1.6666666667
+  eos_const_c_v = 1.0d8
+  eos_c_v_exp_m = 0.0d0
+  eos_c_v_exp_n = 0.0d0
 
 /

--- a/Exec/radiation_tests/RadSuOlson/GNUmakefile
+++ b/Exec/radiation_tests/RadSuOlson/GNUmakefile
@@ -11,7 +11,7 @@ USE_RAD = TRUE
 
 CASTRO_HOME = ../../..
 
-EOS_DIR     := gamma_law
+EOS_DIR     := rad_power_law
 
 NETWORK_DIR := general_null
 NETWORK_INPUTS := gammalaw.net

--- a/Exec/radiation_tests/RadSuOlson/Make.package
+++ b/Exec/radiation_tests/RadSuOlson/Make.package
@@ -1,1 +1,0 @@
-ca_F90EXE_sources += probdata.F90

--- a/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
@@ -35,7 +35,6 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
                        state, state_lo, state_hi, &
                        delta, xlo, xhi)
 
-  use probdata_module
   use meth_params_module, only : NVAR, URHO, UMX, UMZ, UEDEN, UEINT, UFS, UTEMP
   use network, only : nspec
 
@@ -82,8 +81,6 @@ end subroutine ca_initdata
 subroutine ca_initrad(level, time, lo, hi, nrad, &
                       rad_state, rad_state_lo, rad_state_hi, &
                       delta, xlo, xhi)
-
-  use probdata_module
 
   use amrex_fort_module, only : rt => amrex_real
 

--- a/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
@@ -1,45 +1,12 @@
 subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amrex_probinit")
 
-  use probdata_module
-  use actual_eos_module, only : gamma_const
-  use amrex_fort_module, only : rt => amrex_real
-  use castro_error_module
+  use amrex_fort_module, only: rt => amrex_real
 
   implicit none
 
   integer, intent(in) :: init, namlen
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
-
-  integer untin, i
-
-  namelist /fortin/ const_c_v, c_v_exp_n
-
-  ! Build "probin" filename -- the name of file containing fortin namelist.
-
-  integer, parameter :: maxlen=127
-  character probin*(maxlen)
-
-  if (namlen .gt. maxlen) then
-     call castro_error("probin file name too long")
-  end if
-
-  do i = 1, namlen
-     probin(i:i) = char(name(i))
-  end do
-
-  ! set namelist defaults
-
-  const_c_v = 8.0744926545150113e-24_rt
-  c_v_exp_n = -3.0_rt
-
-  xmin = problo(1)
-  xmax = probhi(1)
-
-  ! Read namelists
-  open(newunit=untin, file=probin(1:namlen), form='formatted', status='old')
-  read(untin, fortin)
-  close(unit=untin)
 
 end subroutine amrex_probinit
 
@@ -85,7 +52,6 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
                                    state_lo(3):state_hi(3), nscal)
 
   integer :: i, j, k
-  real(rt) :: c_v, eint
 
   do k = lo(3), hi(3)
      do j = lo(2), hi(2)

--- a/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
@@ -57,15 +57,17 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
         do i = lo(1), hi(1)
 
            state(i,j,k,URHO) = 1.0_rt
-           state(i,j,k,UTEMP) = 0.0_rt
            state(i,j,k,UMX:UMZ) = 0.0_rt
 
            ! set the composition to be all in the first species
            state(i,j,k,UFS:UFS-1+nspec) = 0.e0_rt
            state(i,j,k,UFS) = state(i,j,k,URHO)
 
-           state(i,j,k,UEINT) = 0.0_rt
-           state(i,j,k,UEDEN) = 0.0_rt
+           ! Set temperature and energy to arbitrary, positive values
+           ! so that the Castro state checkers are OK.
+           state(i,j,k,UTEMP) = 1.0_rt
+           state(i,j,k,UEINT) = 1.0_rt
+           state(i,j,k,UEDEN) = 1.0_rt
 
         end do
      end do

--- a/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSuOlson/Prob_nd.F90
@@ -65,9 +65,9 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
 
            ! Set temperature and energy to arbitrary, positive values
            ! so that the Castro state checkers are OK.
-           state(i,j,k,UTEMP) = 1.0_rt
-           state(i,j,k,UEINT) = 1.0_rt
-           state(i,j,k,UEDEN) = 1.0_rt
+           state(i,j,k,UTEMP) = 1.0e-50_rt
+           state(i,j,k,UEINT) = 1.0e-50_rt
+           state(i,j,k,UEDEN) = 1.0e-50_rt
 
         end do
      end do

--- a/Exec/radiation_tests/RadSuOlson/inputs
+++ b/Exec/radiation_tests/RadSuOlson/inputs
@@ -136,11 +136,6 @@ radiation.hi_bcval = 0.0 0.0 0.0
 #
 # Since the formula is both nonphysical and singular, prop_temp_floor
 # provides a floor for the temperature used in the power-law computation.
-# (Specific heat c_v follows the same convention.)
-
-radiation.do_real_eos = 0
-radiation.const_c_v = 3.02584e-13
-radiation.c_v_exp_n = -3.0
 
 # Planck mean opacity 
 radiation.const_kappa_p =  1.

--- a/Exec/radiation_tests/RadSuOlson/probdata.F90
+++ b/Exec/radiation_tests/RadSuOlson/probdata.F90
@@ -1,8 +1,0 @@
-module probdata_module
-  
-  use amrex_fort_module, only : rt => amrex_real
-  real(rt)        , save :: const_c_v, c_v_exp_n
-  
-  real(rt)        , save :: xmin,xmax,ymin,ymax,zmin,zmax
-  
-end module probdata_module

--- a/Exec/radiation_tests/RadSuOlson/probin
+++ b/Exec/radiation_tests/RadSuOlson/probin
@@ -1,10 +1,9 @@
 &fortin
-  const_c_v = 3.02584e-13
-  c_v_exp_n = -3.0
+
 /
 
-
 &tagging
+
   denerr = 3
   dengrad = 0.01
   max_denerr_lev = 3
@@ -14,10 +13,13 @@
   pressgrad = 0.01
   max_presserr_lev = 3
   max_pressgrad_lev = 3
+
 /
 
 &extern
 
-  eos_gamma = 1.6666666667
+  eos_const_c_v = 3.02584d-13
+  eos_c_v_exp_m = 0.0d0
+  eos_c_v_exp_n = -3.0d0
 
 /

--- a/Exec/radiation_tests/RadSuOlsonMG/GNUmakefile
+++ b/Exec/radiation_tests/RadSuOlsonMG/GNUmakefile
@@ -11,7 +11,7 @@ USE_RAD = TRUE
 
 CASTRO_HOME = ../../..
 
-EOS_DIR     := gamma_law
+EOS_DIR     := rad_power_law
 
 NETWORK_DIR := general_null
 NETWORK_INPUTS := gammalaw.net

--- a/Exec/radiation_tests/RadSuOlsonMG/inputs.common
+++ b/Exec/radiation_tests/RadSuOlsonMG/inputs.common
@@ -131,11 +131,6 @@ radiation.hi_bcval = 0.0 0.0 0.0
 #
 # Since the formula is both nonphysical and singular, prop_temp_floor
 # provides a floor for the temperature used in the power-law computation.
-# (Specific heat c_v follows the same convention.)
-
-radiation.do_real_eos = 0
-radiation.const_c_v = 3.0262923999999999e-14
-radiation.c_v_exp_n = -3.0
 
 # Planck mean opacity (appears in the source term -- see Howell and
 # Greenough, Eq. 1)

--- a/Exec/radiation_tests/RadSuOlsonMG/probin.common
+++ b/Exec/radiation_tests/RadSuOlsonMG/probin.common
@@ -12,7 +12,7 @@
 
 &extern
 
-  eos_const_c_v = 3.0262923999999999e-14d0
+  eos_const_c_v = 3.0262923999999999d-14
   eos_c_v_exp_m = 0.0d0
   eos_c_v_exp_n = -3.0d0
 

--- a/Exec/radiation_tests/RadSuOlsonMG/probin.common
+++ b/Exec/radiation_tests/RadSuOlsonMG/probin.common
@@ -12,6 +12,8 @@
 
 &extern
 
-  eos_gamma = 1.6666666667
+  eos_const_c_v = 3.0262923999999999e-14d0
+  eos_c_v_exp_m = 0.0d0
+  eos_c_v_exp_n = -3.0d0
 
 /

--- a/Microphysics/EOS/rad_power_law/Make.package
+++ b/Microphysics/EOS/rad_power_law/Make.package
@@ -1,0 +1,1 @@
+F90EXE_sources += rad_power_law.F90

--- a/Microphysics/EOS/rad_power_law/_parameters
+++ b/Microphysics/EOS/rad_power_law/_parameters
@@ -1,0 +1,3 @@
+eos_const_c_v        real     -1.d0
+eos_c_v_exp_m        real      0.d0
+eos_c_v_exp_n        real      0.d0

--- a/Microphysics/EOS/rad_power_law/rad_power_law.F90
+++ b/Microphysics/EOS/rad_power_law/rad_power_law.F90
@@ -1,0 +1,118 @@
+! This is an artificial equation of state used primarily for radiation tests.
+!
+! It is defined by the relationship:
+! c_v = K * rho**m * T**(-n)
+! where K, m, and n are user-defined constant parameters.
+!
+! Ignoring the integration constant, we thus have the relationships:
+! e = K * rho**m * T**(1-n) / (1 - n)
+! T = ((1 - n) * e * rho**(-m) / K)**(1/(1-n))
+!
+! Consequently the only input modes supported are eos_input_rt and eos_input_re.
+! Pressure and Gamma_1 are not defined, so this EOS cannot be used for hydro.
+
+module actual_eos_module
+
+  use amrex_fort_module, only: rt => amrex_real
+  use eos_type_module, only: eos_t, eos_input_rt, eos_input_re
+
+  implicit none
+
+  character (len=64) :: eos_name = "rad_power_law"
+
+  real(rt), allocatable, save :: const_c_v, c_v_exp_m, c_v_exp_n
+
+#ifdef AMREX_USE_CUDA
+  attributes(managed) :: const_c_v, c_v_exp_m, c_v_exp_n
+#endif
+
+contains
+
+  subroutine actual_eos_init
+
+    use extern_probin_module, only: eos_const_c_v, eos_c_v_exp_m, eos_c_v_exp_n
+    use castro_error_module, only: castro_error
+
+    implicit none
+
+    allocate(const_c_v)
+    allocate(c_v_exp_m)
+    allocate(c_v_exp_n)
+
+    const_c_v = eos_const_c_v
+    c_v_exp_m = eos_c_v_exp_m
+    c_v_exp_n = eos_c_v_exp_n
+
+    if (const_c_v .le. 0.e0_rt) then
+       call castro_error("eos_const_c_v must be > 0")
+    end if
+
+    if (c_v_exp_n .eq. 1.0e0_rt) then
+       call castro_error("eos_c_v_exp_n == 1 is unsupported")
+    end if
+
+  end subroutine actual_eos_init
+
+
+
+  subroutine actual_eos_finalize()
+
+    implicit none
+
+    deallocate(const_c_v)
+    deallocate(c_v_exp_m)
+    deallocate(c_v_exp_n)
+
+  end subroutine actual_eos_finalize
+
+
+
+  subroutine actual_eos(input, state)
+
+#ifndef AMREX_USE_GPU
+    use castro_error_module, only: castro_error
+#endif
+
+    implicit none
+
+    integer,      intent(in   ) :: input
+    type (eos_t), intent(inout) :: state
+
+    !$gpu
+
+    select case (input)
+
+    case (eos_input_rt)
+
+       state % cv = const_c_v * state % rho**c_v_exp_m * state % T**(-c_v_exp_n)
+       state % e = const_c_v * state % rho**c_v_exp_m * state % T**(1 - c_v_exp_n) / (1 - c_v_exp_n)
+
+    case (eos_input_re)
+
+       state % T = ((1 - c_v_exp_n) * state % e * state % rho**(-c_v_exp_m) / const_c_v)**(1 / (1 - c_v_exp_n))
+       state % cv = const_c_v * state % rho**c_v_exp_m * state % T**(-c_v_exp_n)
+
+    case default
+
+#ifndef AMREX_USE_GPU
+       call castro_error('EOS: invalid input.')
+#endif
+
+    end select
+
+    ! Set some data to nonsense values so that things intentionally go wrong
+    ! if this EOS is somehow used for hydro.
+
+    state % p    = -1.e0_rt
+    state % gam1 = -1.e0_rt
+    state % cs   = -1.e0_rt
+    state % s    = -1.e0_rt
+    state % h    = -1.e0_rt
+
+    ! Give dpdr a value for the purposes of the composition_derivatives routine.
+
+    state % dPdr = 0.e0_rt
+
+  end subroutine actual_eos
+
+end module actual_eos_module

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3466,10 +3466,6 @@ Castro::computeTemp(MultiFab& State, Real time, int ng)
   }
 #endif
 
-#ifdef RADIATION
-  FArrayBox temp;
-#endif
-
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -3486,49 +3482,23 @@ Castro::computeTemp(MultiFab& State, Real time, int ng)
 
       const Box& bx = mfi.growntilebox(num_ghost);
 
-#ifdef RADIATION
-      if (Radiation::do_real_eos == 0) {
-	temp.resize(bx);
-
-        Array4<Real> state_arr = State.array(mfi);
-        Array4<Real> temp_arr = temp.array();
-        int ecomp = Eint;
-
-        AMREX_PARALLEL_FOR_3D(bx, i, j, k, { temp_arr(i,j,k) = state_arr(i,j,k,ecomp); });
-
-#pragma gpu box(bx) sync
-	ca_compute_temp_given_rhoe
-            (AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
-             BL_TO_FORTRAN_ANYD(temp),
-             BL_TO_FORTRAN_ANYD(State[mfi]),
-             0);
-
-        int tcomp = Temp;
-        AMREX_PARALLEL_FOR_3D(bx, i, j, k, { state_arr(i,j,k,tcomp) = temp_arr(i,j,k); });
-      } else {
-#endif
-
-        // general EOS version
+      // general EOS version
 
 #ifdef TRUE_SDC
-        if (sdc_order == 4) {
+      if (sdc_order == 4) {
           // note, this is working on a growntilebox, but we will not have
           // valid cell-centers in the very last ghost cell
           ca_compute_temp(AMREX_ARLIM_ANYD(bx.loVect()), AMREX_ARLIM_ANYD(bx.hiVect()),
                           BL_TO_FORTRAN_ANYD(Stemp[mfi]));
-        } else {
+      } else {
 #endif
 #pragma gpu box(bx)
           ca_compute_temp(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
                           BL_TO_FORTRAN_ANYD(State[mfi]));
 #ifdef TRUE_SDC
-        }
+      }
 #endif
 
-#ifdef RADIATION
-      }
-      Elixir temp_elix = temp.elixir();
-#endif
   }
 
 #ifdef TRUE_SDC

--- a/Source/driver/Castro_util.F90
+++ b/Source/driver/Castro_util.F90
@@ -311,7 +311,7 @@ contains
                    rho_eint = u(i,j,k,UEDEN) - u(i,j,k,URHO) * ke
 
                    ! Reset (e from e) if it's greater than eta * E.
-                   if (rho_eint .gt. ZERO .and. rho_eint / u(i,j,k,UEDEN) .gt. dual_energy_eta2) then
+                   if (rho_eint .gt. ZERO .and. rho_eint .gt. dual_energy_eta2 * u(i,j,k,UEDEN) ) then
 
                       u(i,j,k,UEINT) = rho_eint
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -698,12 +698,4 @@ beta                         Real          1.0                n
 
 @namespace: radiation Radiation static
 
-do_real_eos                  int           1                  y
-
-const_c_v                    Real         -1.0                y
-
-c_v_exp_m                    Real          0.0                y
-
-c_v_exp_n                    Real          0.0                y
-
 prop_temp_floor              Real          0.0                y

--- a/Source/driver/meth_params.F90
+++ b/Source/driver/meth_params.F90
@@ -213,10 +213,6 @@ module meth_params_module
   character (len=:), allocatable, save :: gravity_type
   real(rt), allocatable, save :: const_grav
   integer,  allocatable, save :: get_g_from_phi
-  integer,  allocatable, save :: do_real_eos
-  real(rt), allocatable, save :: const_c_v
-  real(rt), allocatable, save :: c_v_exp_m
-  real(rt), allocatable, save :: c_v_exp_n
   real(rt), allocatable, save :: prop_temp_floor
 
 #ifdef AMREX_USE_CUDA
@@ -346,10 +342,6 @@ attributes(managed) :: track_grid_losses
 
 attributes(managed) :: const_grav
 attributes(managed) :: get_g_from_phi
-attributes(managed) :: do_real_eos
-attributes(managed) :: const_c_v
-attributes(managed) :: c_v_exp_m
-attributes(managed) :: c_v_exp_n
 attributes(managed) :: prop_temp_floor
 #endif
 
@@ -473,10 +465,6 @@ attributes(managed) :: prop_temp_floor
   !$acc create(track_grid_losses) &
   !$acc create(const_grav) &
   !$acc create(get_g_from_phi) &
-  !$acc create(do_real_eos) &
-  !$acc create(const_c_v) &
-  !$acc create(c_v_exp_m) &
-  !$acc create(c_v_exp_n) &
   !$acc create(prop_temp_floor)
 
   ! End the declarations of the ParmParse parameters
@@ -516,30 +504,6 @@ contains
 #endif
     allocate(xl_ext, yl_ext, zl_ext, xr_ext, yr_ext, zr_ext)
 
-    allocate(character(len=1)::gravity_type)
-    gravity_type = "fillme";
-    allocate(const_grav)
-    const_grav = 0.0_rt;
-    allocate(get_g_from_phi)
-    get_g_from_phi = 0;
-
-    call amrex_parmparse_build(pp, "gravity")
-    call pp%query("gravity_type", gravity_type)
-    call pp%query("const_grav", const_grav)
-    call pp%query("get_g_from_phi", get_g_from_phi)
-    call amrex_parmparse_destroy(pp)
-
-
-#ifdef DIFFUSION
-    allocate(diffuse_temp)
-    diffuse_temp = 0;
-    allocate(diffuse_cutoff_density)
-    diffuse_cutoff_density = -1.e200_rt;
-    allocate(diffuse_cutoff_density_hi)
-    diffuse_cutoff_density_hi = -1.e200_rt;
-    allocate(diffuse_cond_scale_fac)
-    diffuse_cond_scale_fac = 1.0_rt;
-#endif
 #ifdef ROTATION
     allocate(rot_period)
     rot_period = -1.e200_rt;
@@ -718,14 +682,18 @@ contains
     allocate(point_mass_fix_solution)
     point_mass_fix_solution = 0;
 #endif
+#ifdef DIFFUSION
+    allocate(diffuse_temp)
+    diffuse_temp = 0;
+    allocate(diffuse_cutoff_density)
+    diffuse_cutoff_density = -1.e200_rt;
+    allocate(diffuse_cutoff_density_hi)
+    diffuse_cutoff_density_hi = -1.e200_rt;
+    allocate(diffuse_cond_scale_fac)
+    diffuse_cond_scale_fac = 1.0_rt;
+#endif
 
     call amrex_parmparse_build(pp, "castro")
-#ifdef DIFFUSION
-    call pp%query("diffuse_temp", diffuse_temp)
-    call pp%query("diffuse_cutoff_density", diffuse_cutoff_density)
-    call pp%query("diffuse_cutoff_density_hi", diffuse_cutoff_density_hi)
-    call pp%query("diffuse_cond_scale_fac", diffuse_cond_scale_fac)
-#endif
 #ifdef ROTATION
     call pp%query("rotational_period", rot_period)
     call pp%query("rotational_dPdt", rot_period_dot)
@@ -817,26 +785,34 @@ contains
     call pp%query("point_mass", point_mass)
     call pp%query("point_mass_fix_solution", point_mass_fix_solution)
 #endif
+#ifdef DIFFUSION
+    call pp%query("diffuse_temp", diffuse_temp)
+    call pp%query("diffuse_cutoff_density", diffuse_cutoff_density)
+    call pp%query("diffuse_cutoff_density_hi", diffuse_cutoff_density_hi)
+    call pp%query("diffuse_cond_scale_fac", diffuse_cond_scale_fac)
+#endif
     call amrex_parmparse_destroy(pp)
 
 
-    allocate(do_real_eos)
-    do_real_eos = 1;
-    allocate(const_c_v)
-    const_c_v = -1.0_rt;
-    allocate(c_v_exp_m)
-    c_v_exp_m = 0.0_rt;
-    allocate(c_v_exp_n)
-    c_v_exp_n = 0.0_rt;
     allocate(prop_temp_floor)
     prop_temp_floor = 0.0_rt;
 
     call amrex_parmparse_build(pp, "radiation")
-    call pp%query("do_real_eos", do_real_eos)
-    call pp%query("const_c_v", const_c_v)
-    call pp%query("c_v_exp_m", c_v_exp_m)
-    call pp%query("c_v_exp_n", c_v_exp_n)
     call pp%query("prop_temp_floor", prop_temp_floor)
+    call amrex_parmparse_destroy(pp)
+
+
+    allocate(character(len=1)::gravity_type)
+    gravity_type = "fillme";
+    allocate(const_grav)
+    const_grav = 0.0_rt;
+    allocate(get_g_from_phi)
+    get_g_from_phi = 0;
+
+    call amrex_parmparse_build(pp, "gravity")
+    call pp%query("gravity_type", gravity_type)
+    call pp%query("const_grav", const_grav)
+    call pp%query("get_g_from_phi", get_g_from_phi)
     call amrex_parmparse_destroy(pp)
 
 
@@ -871,8 +847,7 @@ contains
     !$acc device(rot_axis, use_point_mass, point_mass) &
     !$acc device(point_mass_fix_solution, do_acc, grown_factor) &
     !$acc device(track_grid_losses, const_grav) &
-    !$acc device(get_g_from_phi, do_real_eos, const_c_v) &
-    !$acc device(c_v_exp_m, c_v_exp_n, prop_temp_floor)
+    !$acc device(get_g_from_phi, prop_temp_floor)
 
 
 #ifdef GRAVITY
@@ -1258,18 +1233,6 @@ contains
     end if
     if (allocated(get_g_from_phi)) then
         deallocate(get_g_from_phi)
-    end if
-    if (allocated(do_real_eos)) then
-        deallocate(do_real_eos)
-    end if
-    if (allocated(const_c_v)) then
-        deallocate(const_c_v)
-    end if
-    if (allocated(c_v_exp_m)) then
-        deallocate(c_v_exp_m)
-    end if
-    if (allocated(c_v_exp_n)) then
-        deallocate(c_v_exp_n)
     end if
     if (allocated(prop_temp_floor)) then
         deallocate(prop_temp_floor)

--- a/Source/driver/param_includes/castro_defaults.H
+++ b/Source/driver/param_includes/castro_defaults.H
@@ -3,14 +3,19 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
+#ifdef AMREX_PARTICLES
+int         Castro::do_tracer_particles = 0;
+#endif
+#ifdef GRAVITY
+int         Castro::use_point_mass = 0;
+amrex::Real Castro::point_mass = 0.0;
+int         Castro::point_mass_fix_solution = 0;
+#endif
 #ifdef DIFFUSION
 int         Castro::diffuse_temp = 0;
 amrex::Real Castro::diffuse_cutoff_density = -1.e200;
 amrex::Real Castro::diffuse_cutoff_density_hi = -1.e200;
 amrex::Real Castro::diffuse_cond_scale_fac = 1.0;
-#endif
-#ifdef AMREX_PARTICLES
-int         Castro::do_tracer_particles = 0;
 #endif
 int         Castro::state_interp_order = 1;
 int         Castro::lin_limit_state_interp = 0;
@@ -153,9 +158,4 @@ int         Castro::state_in_rotating_frame = 1;
 int         Castro::rot_source_type = 4;
 int         Castro::implicit_rotation_update = 1;
 int         Castro::rot_axis = 3;
-#endif
-#ifdef GRAVITY
-int         Castro::use_point_mass = 0;
-amrex::Real Castro::point_mass = 0.0;
-int         Castro::point_mass_fix_solution = 0;
 #endif

--- a/Source/driver/param_includes/castro_job_info_tests.H
+++ b/Source/driver/param_includes/castro_job_info_tests.H
@@ -1,11 +1,16 @@
+#ifdef AMREX_PARTICLES
+jobInfoFile << (Castro::do_tracer_particles == 0 ? "    " : "[*] ") << "castro.do_tracer_particles = " << Castro::do_tracer_particles << std::endl;
+#endif
+#ifdef GRAVITY
+jobInfoFile << (Castro::use_point_mass == 0 ? "    " : "[*] ") << "castro.use_point_mass = " << Castro::use_point_mass << std::endl;
+jobInfoFile << (Castro::point_mass == 0.0 ? "    " : "[*] ") << "castro.point_mass = " << Castro::point_mass << std::endl;
+jobInfoFile << (Castro::point_mass_fix_solution == 0 ? "    " : "[*] ") << "castro.point_mass_fix_solution = " << Castro::point_mass_fix_solution << std::endl;
+#endif
 #ifdef DIFFUSION
 jobInfoFile << (Castro::diffuse_temp == 0 ? "    " : "[*] ") << "castro.diffuse_temp = " << Castro::diffuse_temp << std::endl;
 jobInfoFile << (Castro::diffuse_cutoff_density == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density = " << Castro::diffuse_cutoff_density << std::endl;
 jobInfoFile << (Castro::diffuse_cutoff_density_hi == -1.e200 ? "    " : "[*] ") << "castro.diffuse_cutoff_density_hi = " << Castro::diffuse_cutoff_density_hi << std::endl;
 jobInfoFile << (Castro::diffuse_cond_scale_fac == 1.0 ? "    " : "[*] ") << "castro.diffuse_cond_scale_fac = " << Castro::diffuse_cond_scale_fac << std::endl;
-#endif
-#ifdef AMREX_PARTICLES
-jobInfoFile << (Castro::do_tracer_particles == 0 ? "    " : "[*] ") << "castro.do_tracer_particles = " << Castro::do_tracer_particles << std::endl;
 #endif
 jobInfoFile << (Castro::state_interp_order == 1 ? "    " : "[*] ") << "castro.state_interp_order = " << Castro::state_interp_order << std::endl;
 jobInfoFile << (Castro::lin_limit_state_interp == 0 ? "    " : "[*] ") << "castro.lin_limit_state_interp = " << Castro::lin_limit_state_interp << std::endl;
@@ -140,9 +145,4 @@ jobInfoFile << (Castro::state_in_rotating_frame == 1 ? "    " : "[*] ") << "cast
 jobInfoFile << (Castro::rot_source_type == 4 ? "    " : "[*] ") << "castro.rot_source_type = " << Castro::rot_source_type << std::endl;
 jobInfoFile << (Castro::implicit_rotation_update == 1 ? "    " : "[*] ") << "castro.implicit_rotation_update = " << Castro::implicit_rotation_update << std::endl;
 jobInfoFile << (Castro::rot_axis == 3 ? "    " : "[*] ") << "castro.rot_axis = " << Castro::rot_axis << std::endl;
-#endif
-#ifdef GRAVITY
-jobInfoFile << (Castro::use_point_mass == 0 ? "    " : "[*] ") << "castro.use_point_mass = " << Castro::use_point_mass << std::endl;
-jobInfoFile << (Castro::point_mass == 0.0 ? "    " : "[*] ") << "castro.point_mass = " << Castro::point_mass << std::endl;
-jobInfoFile << (Castro::point_mass_fix_solution == 0 ? "    " : "[*] ") << "castro.point_mass_fix_solution = " << Castro::point_mass_fix_solution << std::endl;
 #endif

--- a/Source/driver/param_includes/castro_params.H
+++ b/Source/driver/param_includes/castro_params.H
@@ -3,14 +3,19 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
+#ifdef AMREX_PARTICLES
+static int do_tracer_particles;
+#endif
+#ifdef GRAVITY
+static int use_point_mass;
+static amrex::Real point_mass;
+static int point_mass_fix_solution;
+#endif
 #ifdef DIFFUSION
 static int diffuse_temp;
 static amrex::Real diffuse_cutoff_density;
 static amrex::Real diffuse_cutoff_density_hi;
 static amrex::Real diffuse_cond_scale_fac;
-#endif
-#ifdef AMREX_PARTICLES
-static int do_tracer_particles;
 #endif
 static int state_interp_order;
 static int lin_limit_state_interp;
@@ -145,9 +150,4 @@ static int state_in_rotating_frame;
 static int rot_source_type;
 static int implicit_rotation_update;
 static int rot_axis;
-#endif
-#ifdef GRAVITY
-static int use_point_mass;
-static amrex::Real point_mass;
-static int point_mass_fix_solution;
 #endif

--- a/Source/driver/param_includes/castro_queries.H
+++ b/Source/driver/param_includes/castro_queries.H
@@ -3,14 +3,19 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
+#ifdef AMREX_PARTICLES
+pp.query("do_tracer_particles", do_tracer_particles);
+#endif
+#ifdef GRAVITY
+pp.query("use_point_mass", use_point_mass);
+pp.query("point_mass", point_mass);
+pp.query("point_mass_fix_solution", point_mass_fix_solution);
+#endif
 #ifdef DIFFUSION
 pp.query("diffuse_temp", diffuse_temp);
 pp.query("diffuse_cutoff_density", diffuse_cutoff_density);
 pp.query("diffuse_cutoff_density_hi", diffuse_cutoff_density_hi);
 pp.query("diffuse_cond_scale_fac", diffuse_cond_scale_fac);
-#endif
-#ifdef AMREX_PARTICLES
-pp.query("do_tracer_particles", do_tracer_particles);
 #endif
 pp.query("state_interp_order", state_interp_order);
 pp.query("lin_limit_state_interp", lin_limit_state_interp);
@@ -145,9 +150,4 @@ pp.query("state_in_rotating_frame", state_in_rotating_frame);
 pp.query("rot_source_type", rot_source_type);
 pp.query("implicit_rotation_update", implicit_rotation_update);
 pp.query("rot_axis", rot_axis);
-#endif
-#ifdef GRAVITY
-pp.query("use_point_mass", use_point_mass);
-pp.query("point_mass", point_mass);
-pp.query("point_mass_fix_solution", point_mass_fix_solution);
 #endif

--- a/Source/driver/param_includes/radiation_defaults.H
+++ b/Source/driver/param_includes/radiation_defaults.H
@@ -3,8 +3,4 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
-int         Radiation::do_real_eos = 1;
-amrex::Real Radiation::const_c_v = -1.0;
-amrex::Real Radiation::c_v_exp_m = 0.0;
-amrex::Real Radiation::c_v_exp_n = 0.0;
 amrex::Real Radiation::prop_temp_floor = 0.0;

--- a/Source/driver/param_includes/radiation_job_info_tests.H
+++ b/Source/driver/param_includes/radiation_job_info_tests.H
@@ -1,5 +1,1 @@
-jobInfoFile << (Radiation::do_real_eos == 1 ? "    " : "[*] ") << "radiation.do_real_eos = " << Radiation::do_real_eos << std::endl;
-jobInfoFile << (Radiation::const_c_v == -1.0 ? "    " : "[*] ") << "radiation.const_c_v = " << Radiation::const_c_v << std::endl;
-jobInfoFile << (Radiation::c_v_exp_m == 0.0 ? "    " : "[*] ") << "radiation.c_v_exp_m = " << Radiation::c_v_exp_m << std::endl;
-jobInfoFile << (Radiation::c_v_exp_n == 0.0 ? "    " : "[*] ") << "radiation.c_v_exp_n = " << Radiation::c_v_exp_n << std::endl;
 jobInfoFile << (Radiation::prop_temp_floor == 0.0 ? "    " : "[*] ") << "radiation.prop_temp_floor = " << Radiation::prop_temp_floor << std::endl;

--- a/Source/driver/param_includes/radiation_params.H
+++ b/Source/driver/param_includes/radiation_params.H
@@ -3,8 +3,4 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
-static int do_real_eos;
-static amrex::Real const_c_v;
-static amrex::Real c_v_exp_m;
-static amrex::Real c_v_exp_n;
 static amrex::Real prop_temp_floor;

--- a/Source/driver/param_includes/radiation_queries.H
+++ b/Source/driver/param_includes/radiation_queries.H
@@ -3,8 +3,4 @@
 // or add runtime parameters, please edit _cpp_parameters and then run
 // mk_params.sh
 
-pp.query("do_real_eos", do_real_eos);
-pp.query("const_c_v", const_c_v);
-pp.query("c_v_exp_m", c_v_exp_m);
-pp.query("c_v_exp_n", c_v_exp_n);
 pp.query("prop_temp_floor", prop_temp_floor);

--- a/Source/radiation/Castro_radiation.cpp
+++ b/Source/radiation/Castro_radiation.cpp
@@ -19,10 +19,8 @@ Castro::final_radiation_call (MultiFab& S_new, int iteration, int ncycle)
 	  return;
 	}
 	
-	if (radiation->do_real_eos > 0) {
-	  Castro::computeTemp(S_new, state[State_Type].curTime(), S_new.nGrow());
-	} 
-	
+        Castro::computeTemp(S_new, state[State_Type].curTime(), S_new.nGrow());
+
 	if (Radiation::filter_prim_int > 0 && Radiation::filter_prim_T>0 
 	    && iteration==ncycle) {
 	    int nstep = parent->levelSteps(0);

--- a/Source/radiation/MGFLD.cpp
+++ b/Source/radiation/MGFLD.cpp
@@ -1147,17 +1147,13 @@ void Radiation::bisect_matter(MultiFab& rhoe_new, MultiFab& temp_new,
 	   BL_TO_FORTRAN_ANYD(Ye_new[mfi]),
 	   BL_TO_FORTRAN_ANYD(S_new[mfi]));
 #else
-      if (do_real_eos > 0) {
+
 #pragma gpu box(bx) sync
 	ca_get_rhoe
             (AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
              BL_TO_FORTRAN_ANYD(rhoe_new[mfi]),
              BL_TO_FORTRAN_ANYD(temp_new[mfi]), 
              BL_TO_FORTRAN_ANYD(S_new[mfi]));
-      }
-      else {
-	  amrex::Abort("do_real_eos == 0 not supported in bisect_matter");
-      }
 #endif
   }
 }
@@ -1212,8 +1208,6 @@ void Radiation::inelastic_scattering(int level)
 	    }
 	}
 
-	if (do_real_eos > 0) {
-	  castro->computeTemp(S_new, castro->state[State_Type].curTime(), S_new.nGrow());
-	}
+        castro->computeTemp(S_new, castro->state[State_Type].curTime(), S_new.nGrow());
     }
 }

--- a/Source/radiation/Radiation.cpp
+++ b/Source/radiation/Radiation.cpp
@@ -647,18 +647,6 @@ Radiation::Radiation(Amr* Parent, Castro* castro, int restart)
     std::cout << "temp_floor    = " << temp_floor << std::endl;
   }
 
-  if (SolverType == MGFLDSolver) {
-      if (do_real_eos != 1) {
-          amrex::Abort("MGFLD solver only supports do_real_eos == 1");
-      }
-  }
-
-  if (do_real_eos == 0) {
-      if (const_c_v <= 0.0) {
-          amrex::Abort("do_real_eos == 0 requires const_c_v > 0");
-      }
-  }
-
   if (verbose > 2) {
     Vector<int> temp;
     if (pp.queryarr("spot",temp,0,BL_SPACEDIM)) {

--- a/sphinx_docs/source/radiation.rst
+++ b/sphinx_docs/source/radiation.rst
@@ -92,16 +92,14 @@ this will interpret the RADIATION preprocessor variable and
 disable the radiation portion of the EOS [1]_ If you have your own EOS, you
 can put it in Microphysics.
 
-EOS Parameters
-~~~~~~~~~~~~~~
+There is also an artificial EOS that is used for several test cases called
 
-The following parameters affect how the radiation solver used the EOS:
+::
 
--  radiation.do_real_eos = 1
+   EOS_DIR := rad_power_law
 
-   Usually you do not want to change this from the default. Setting
-   this to 0 is only for contrived tests that assume the
-   specific heat is in the form of a power-law,
+This EOS should only be used for pure radiation-diffusion tests (i.e.
+``castro.do_hydro = 0``). It defines the specific heat as a power law,
 
    .. math:: c_v = \mathrm{const}\ \rho^m T^{-n}
 


### PR DESCRIPTION

## PR summary

This PR adds an EOS, `rad_power_law`, which replaces the functionality previously provided by `radiation.do_real_eos = 0`. The EOS defines `c_v` as before, and can only be called in (rho, T) and (rho, e) modes. It does not define hydrodynamic variables like pressure, so it cannot be used in conjunction with `castro.do_hydro = 1`. This sets us up for merging the radiation and non-radiation EOS interfaces.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated
- [x] if appropriate, this change is described in the docs
