### PR TITLE
fix nuclear burning dt estimator with simplified SDC

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1510,32 +1510,14 @@ Castro::estTimeStep (Real dt_old)
             {
                 const Box& box = mfi.validbox();
 
-                if (state[State_Type].hasOldData() && state[Reactions_Type].hasOldData()) {
-
-                    MultiFab& S_old = get_old_data(State_Type);
-                    MultiFab& R_old = get_old_data(Reactions_Type);
-
 #pragma gpu box(box)
-                    ca_estdt_burning(AMREX_INT_ANYD(box.loVect()), AMREX_INT_ANYD(box.hiVect()),
-                                     BL_TO_FORTRAN_ANYD(S_old[mfi]),
-                                     BL_TO_FORTRAN_ANYD(S_new[mfi]),
-                                     BL_TO_FORTRAN_ANYD(R_old[mfi]),
-                                     BL_TO_FORTRAN_ANYD(R_new[mfi]),
-                                     AMREX_REAL_ANYD(dx), AMREX_MFITER_REDUCE_MIN(&dt));
-
-                } else {
-
-#pragma gpu box(box)
-                    ca_estdt_burning(AMREX_INT_ANYD(box.loVect()), AMREX_INT_ANYD(box.hiVect()),
-                                     BL_TO_FORTRAN_ANYD(S_new[mfi]),
-                                     BL_TO_FORTRAN_ANYD(S_new[mfi]),
-                                     BL_TO_FORTRAN_ANYD(R_new[mfi]),
-                                     BL_TO_FORTRAN_ANYD(R_new[mfi]),
-                                     AMREX_REAL_ANYD(dx), AMREX_MFITER_REDUCE_MIN(&dt));
-
-                }
+                ca_estdt_burning(AMREX_INT_ANYD(box.loVect()), AMREX_INT_ANYD(box.hiVect()),
+                                 BL_TO_FORTRAN_ANYD(S_new[mfi]),
+                                 BL_TO_FORTRAN_ANYD(R_new[mfi]),
+                                 AMREX_REAL_ANYD(dx), AMREX_MFITER_REDUCE_MIN(&dt));
 
             }
+
             estdt_burn = std::min(estdt_burn,dt);
         }
 

--- a/Source/driver/Castro_F.H
+++ b/Source/driver/Castro_F.H
@@ -246,9 +246,7 @@ extern "C"
 #ifdef REACTIONS
     void ca_estdt_burning
     (const int* lo, const int* hi,
-     const BL_FORT_FAB_ARG_3D(state_old),
      const BL_FORT_FAB_ARG_3D(state_new),
-     const BL_FORT_FAB_ARG_3D(reactions_old),
      const BL_FORT_FAB_ARG_3D(reactions_new),
      const amrex::Real* dx, amrex::Real* dt);
 #endif

--- a/Source/driver/timestep.F90
+++ b/Source/driver/timestep.F90
@@ -120,9 +120,8 @@ contains
 
 #ifdef REACTIONS
 
-  subroutine ca_estdt_burning(lo, hi, sold, so_lo, so_hi, &
+  subroutine ca_estdt_burning(lo, hi, &
                               snew, sn_lo, sn_hi, &
-                              rold, ro_lo, ro_hi, &
                               rnew, rn_lo, rn_hi, &
                               dx, dt) &
                               bind(C, name="ca_estdt_burning")
@@ -149,14 +148,10 @@ contains
 
     implicit none
 
-    integer,  intent(in) :: so_lo(3), so_hi(3)
     integer,  intent(in) :: sn_lo(3), sn_hi(3)
-    integer,  intent(in) :: ro_lo(3), ro_hi(3)
     integer,  intent(in) :: rn_lo(3), rn_hi(3)
     integer,  intent(in) :: lo(3), hi(3)
-    real(rt), intent(in) :: sold(so_lo(1):so_hi(1),so_lo(2):so_hi(2),so_lo(3):so_hi(3),NVAR)
     real(rt), intent(in) :: snew(sn_lo(1):sn_hi(1),sn_lo(2):sn_hi(2),sn_lo(3):sn_hi(3),NVAR)
-    real(rt), intent(in) :: rold(ro_lo(1):ro_hi(1),ro_lo(2):ro_hi(2),ro_lo(3):ro_hi(3),nspec+2)
     real(rt), intent(in) :: rnew(rn_lo(1):rn_hi(1),rn_lo(2):rn_hi(2),rn_lo(3):rn_hi(3),nspec+2)
     real(rt), intent(in) :: dx(3)
     real(rt), intent(inout) :: dt
@@ -165,10 +160,10 @@ contains
     integer       :: i, j, k
     integer       :: n
 
-    type (burn_t) :: state_old, state_new
+    type (burn_t) :: state_new
     real(rt) :: ydot(neqs)
     type (eos_t)  :: eos_state
-    real(rt)      :: rhooinv, rhoninv
+    real(rt)      :: rhoninv
 
     ! Set a floor on the minimum size of a derivative. This floor
     ! is small enough such that it will result in no timestep limiting.
@@ -206,16 +201,7 @@ contains
        do j = lo(2), hi(2)
           do i = lo(1), hi(1)
 
-             rhooinv = ONE / sold(i,j,k,URHO)
              rhoninv = ONE / snew(i,j,k,URHO)
-
-             state_old % rho = sold(i,j,k,URHO)
-             state_old % T   = sold(i,j,k,UTEMP)
-             state_old % e   = sold(i,j,k,UEINT) * rhooinv
-             state_old % xn  = sold(i,j,k,UFS:UFS+nspec-1) * rhooinv
-#if naux > 0
-             state_old % aux = sold(i,j,k,UFX:UFX+naux-1) * rhooinv
-#endif
 
              state_new % rho = snew(i,j,k,URHO)
              state_new % T   = snew(i,j,k,UTEMP)

--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -452,6 +452,13 @@ Castro::react_state(Real time, Real dt)
 
     }
 
+    // For the ca_check_timestep routine, we need to have both the old
+    // and new burn defined, so we simply do a copy here
+    MultiFab& R_old = get_old_data(Reactions_Type);
+    MultiFab& R_new = get_new_data(Reactions_Type);
+    MultiFab::Copy(R_new, R_old, 0, 0, R_new.nComp(), R_new.nGrow());
+
+
     if (burn_success)
         return true;
     else


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- please summarize your PR here.  If it addresses any issues, reference
 them by issue # here as well -->

The simplified-SDC solver didn't fill the new time reactions, so the ca_check_timestep routine was accessing invalid data when computing the nuclear burning timestep.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
