### PR TITLE
Remove integrate_Planck option, always integrate by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # 20.02
 
+   * The option radiation.integrate_planck has been removed; it was only
+     used by one test. By default we always do the full integral of the
+     Planck function. (#740)
+
    * Most of the radiation test problems have been moved over to a new
      opacity directory, rad_power_law, and all of the parameters that
      controlled the behavior of the power law opacity have been moved

--- a/Exec/radiation_tests/RadSphere/inputs
+++ b/Exec/radiation_tests/RadSphere/inputs
@@ -80,8 +80,6 @@ radiation.accelerate = 0
 
 radiation.nGroups = 60
 
-radiation.integrate_Planck = 0
-
 radiation.Er_Lorentz_term = 0
 radiation.do_fspace_advection = 0
 

--- a/Source/radiation/MGFLD.cpp
+++ b/Source/radiation/MGFLD.cpp
@@ -271,7 +271,7 @@ void Radiation::eos_opacity_emissivity(const MultiFab& S_new,
            BL_TO_FORTRAN_ANYD(kappa_p[mfi]),
            BL_TO_FORTRAN_ANYD(dkdT[mfi]),
            PFcoef.dataPtr(), 
-           use_WiensLaw, integrate_Planck, Tf_Wien);
+           use_WiensLaw, Tf_Wien);
   }    
 
   if (ngrow == 0 && !lag_opac) {

--- a/Source/radiation/RAD_F.H
+++ b/Source/radiation/RAD_F.H
@@ -322,7 +322,7 @@ extern "C"
     const BL_FORT_FAB_ARG_3D(kappa_p),
     const BL_FORT_FAB_ARG_3D(dkdT),
     const amrex::Real* PFcoef, 
-    int use_WiensLaw, int integrate_Planck,
+    int use_WiensLaw,
     amrex::Real Tf);
 }
 

--- a/Source/radiation/Rad_nd.F90
+++ b/Source/radiation/Rad_nd.F90
@@ -1074,7 +1074,7 @@ contains
                                    T, T_lo, T_hi, &
                                    kap, kap_lo, kap_hi, &
                                    dkdT, dkdT_lo, dkdT_hi, &
-                                   pfc, use_WiensLaw, integrate_Planck, Tf) &
+                                   pfc, use_WiensLaw, Tf) &
                                    bind(C, name='ca_compute_emissivity')
 
     use amrex_fort_module, only: rt => amrex_real
@@ -1096,7 +1096,7 @@ contains
     real(rt), intent(in   ) :: kap(kap_lo(1):kap_hi(1),kap_lo(2):kap_hi(2),kap_lo(3):kap_hi(3),0:ngroups-1)
     real(rt), intent(in   ) :: dkdT(dkdT_lo(1):dkdT_hi(1),dkdT_lo(2):dkdT_hi(2),dkdT_lo(3):dkdT_hi(3),0:ngroups-1)
     real(rt), intent(in   ) :: pfc(0:ngroups-1)
-    integer,  intent(in   ), value :: use_WiensLaw, integrate_Planck
+    integer,  intent(in   ), value :: use_WiensLaw
     real(rt), intent(in   ), value :: Tf
 
     integer  :: i, j, k, g
@@ -1173,7 +1173,7 @@ contains
           end do
        end do
 
-    else if (integrate_Planck > 0) then
+    else
 
        xnu_full = xnu(0:ngroups)
        xnu_full(0) = 0.e0_rt
@@ -1199,41 +1199,6 @@ contains
 
                 end do
 
-             end do
-          end do
-       end do
-
-    else
-
-       cB = 8.e0_rt*pi*hplanck / clight**3
-       cdBdT = 8.e0_rt*pi*hplanck**2 / (kboltz*clight**3)
-
-       do g = 0, ngroups-1
-          nu = nugroup(g)
-          dnu = dnugroup(g)
-
-          do k = lo(3), hi(3)
-             do j = lo(2), hi(2)
-                do i = lo(1), hi(1)
-
-                   Teff = max(T(i,j,k), 1.e-50_rt)
-                   nubar = hplanck * nu / (kboltz * Teff)
-                   if (nubar > 100.e0_rt) then
-                      Bg = 0.e0_rt
-                      dBdT = 0.e0_rt
-                   else if (nubar < 1.e-15_rt) then
-                      Bg = 0.e0_rt
-                      dBdT = 0.e0_rt           
-                   else
-                      expnubar = exp(nubar)
-                      Bg = cB * nu**3 / (expnubar - 1.e0_rt) * dnu
-                      dBdT = cdBdT * nu**4 / Teff**2 * expnubar / (expnubar - 1.e0_rt)**2 * dnu
-                   end if
-
-                   jg(i,j,k,g) = Bg * kap(i,j,k,g)
-                   djdT(i,j,k,g) = dkdT(i,j,k,g) * Bg + dBdT * kap(i,j,k,g)
-
-                end do
              end do
           end do
        end do

--- a/Source/radiation/Radiation.H
+++ b/Source/radiation/Radiation.H
@@ -653,8 +653,6 @@ public:
 ///
 /// </ Shestakov-Bolstad>
 ///
-  int integrate_Planck;
-
 
 ///
 /// @param relative_in

--- a/Source/radiation/Radiation.cpp
+++ b/Source/radiation/Radiation.cpp
@@ -503,9 +503,6 @@ Radiation::Radiation(Amr* Parent, Castro* castro, int restart)
 
   underfac = 1.0;    pp.query("underfac", underfac);
 
-  integrate_Planck = 1;
-  pp.query("integrate_Planck", integrate_Planck);
-
   use_WiensLaw = 0;
   pp.query("use_WiensLaw", use_WiensLaw);
   Tf_Wien = -1.0;


### PR DESCRIPTION
## PR summary

There existed an option to turn off the normal behavior of integrating the Planck function to get the blackbody spectrum at each group center. This was only used in the RadSphere test, and the alternative was to evalute the Planck function as piecewise constant within each energy group. This introduces code complexity without any obvious gain; we still get reasonable results using the more general expression, and reduce the number of code paths to maintain.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
