### PR TITLE
Fix some reduction race conditions and thread-safety issues

### DIFF
--- a/Source/driver/timestep.F90
+++ b/Source/driver/timestep.F90
@@ -145,6 +145,7 @@ contains
     use temperature_integration_module, only: self_heat
     use amrex_fort_module, only : rt => amrex_real
     use extern_probin_module, only: small_x
+    use reduction_module, only: reduce_min
 
     implicit none
 
@@ -164,6 +165,7 @@ contains
     real(rt) :: ydot(neqs)
     type (eos_t)  :: eos_state
     real(rt)      :: rhoninv
+    real(rt) :: dt_tmp
 
     ! Set a floor on the minimum size of a derivative. This floor
     ! is small enough such that it will result in no timestep limiting.
@@ -248,8 +250,9 @@ contains
                 end if
              end do
 
-             dt = min(dt, dtnuc_e * e / dedt)
-             dt = min(dt, dtnuc_X * minval(X / dXdt))
+             dt_tmp = min(dtnuc_e * e / dedt, dtnuc_X * minval(X / dXdt))
+
+             call reduce_min(dt, dt_tmp)
 
           enddo
        enddo
@@ -372,6 +375,7 @@ contains
     use eos_module, only: eos
     use eos_type_module, only: eos_input_re, eos_t
     use amrex_fort_module, only : rt => amrex_real
+    use reduction_module, only: reduce_min
 
     implicit none
 
@@ -401,6 +405,7 @@ contains
     real(rt)         :: tau_X, tau_e
 #endif
     real(rt)         :: tau_CFL
+    real(rt)         :: dt_tmp
 
     real(rt)         :: v(3), c
     type (eos_t)     :: eos_state
@@ -447,7 +452,9 @@ contains
 
                 tau_CFL = minval(dx(1:dim) / (c + v(1:dim)))
 
-                dt_new = min(dt_new, cfl * tau_CFL)
+                dt_tmp = cfl * tau_CFL
+
+                call reduce_min(dt_new, dt_tmp)
 
              endif
 
@@ -480,17 +487,21 @@ contains
                 e_dot = max(abs(e_dot), derivative_floor)
                 tau_e = e_avg / e_dot
 
+                dt_tmp = dt_old
+
                 if (dt_old > dtnuc_e * tau_e) then
 
-                   dt_new = min(dt_new, dtnuc_e * tau_e)
+                   dt_tmp = min(dt_tmp, dtnuc_e * tau_e)
 
                 endif
 
                 if (dt_old > dtnuc_X * tau_X) then
 
-                   dt_new = min(dt_new, dtnuc_X * tau_X)
+                   dt_tmp = min(dt_tmp, dtnuc_X * tau_X)
 
                 endif
+
+                call reduce_min(dt_new, dt_tmp)
 
              endif
 #endif

--- a/Source/gravity/pointmass_nd.F90
+++ b/Source/gravity/pointmass_nd.F90
@@ -77,6 +77,7 @@ contains
 
     use meth_params_module, only: NVAR, URHO
     use prob_params_module, only: center
+    use reduction_module, only: reduce_min
 
     implicit none
 
@@ -97,6 +98,7 @@ contains
     integer            :: kcen, kstart, kend
     integer            :: i, j, k
     integer, parameter :: box_size = 2
+    real(rt)           :: delta_mass_tmp
 
     !$gpu
 
@@ -130,13 +132,17 @@ contains
        do j = lo(2), hi(2)
           do i = lo(1), hi(1)
 
+             delta_mass_tmp = 0.0_rt
+
              if (i >= istart .and. i <= iend .and. &
                  j >= jstart .and. j <= jend .and. &
                  k >= kstart .and. k <= kend) then
 
-                delta_mass = delta_mass + vol(i,j,k) * (uout(i,j,k,URHO)-uin(i,j,k,URHO))
+                delta_mass_tmp = vol(i,j,k) * (uout(i,j,k,URHO)-uin(i,j,k,URHO))
 
              end if
+
+             call reduce_min(delta_mass, delta_mass_tmp)
 
           end do
        end do

--- a/Source/hydro/Castro_ctu_nd.F90
+++ b/Source/hydro/Castro_ctu_nd.F90
@@ -904,8 +904,19 @@ contains
     real(rt) :: loc(3), ang_mom(3), flux(3)
     integer :: domlo(3), domhi(3)
     integer :: i, j, k
+    real(rt) :: mass_lost_tmp, xmom_lost_tmp, ymom_lost_tmp, zmom_lost_tmp
+    real(rt) :: eden_lost_tmp, xang_lost_tmp, yang_lost_tmp, zang_lost_tmp
 
     !$gpu
+
+    mass_lost_tmp = 0.0_rt
+    xmom_lost_tmp = 0.0_rt
+    ymom_lost_tmp = 0.0_rt
+    zmom_lost_tmp = 0.0_rt
+    eden_lost_tmp = 0.0_rt
+    xang_lost_tmp = 0.0_rt
+    yang_lost_tmp = 0.0_rt
+    zang_lost_tmp = 0.0_rt
 
     domlo = domlo_level(:,amr_level)
     domhi = domhi_level(:,amr_level)
@@ -919,17 +930,17 @@ contains
 
              loc = position(i,j,k,ccz=.false.) - center
 
-             call reduce_add(mass_lost, -flux3(i,j,k,URHO))
-             call reduce_add(xmom_lost, -flux3(i,j,k,UMX))
-             call reduce_add(ymom_lost, -flux3(i,j,k,UMY))
-             call reduce_add(zmom_lost, -flux3(i,j,k,UMZ))
-             call reduce_add(eden_lost, -flux3(i,j,k,UEDEN))
+             mass_lost_tmp = mass_lost_tmp - flux3(i,j,k,URHO)
+             xmom_lost_tmp = xmom_lost_tmp - flux3(i,j,k,UMX)
+             ymom_lost_tmp = ymom_lost_tmp - flux3(i,j,k,UMY)
+             zmom_lost_tmp = zmom_lost_tmp - flux3(i,j,k,UMZ)
+             eden_lost_tmp = eden_lost_tmp - flux3(i,j,k,UEDEN)
 
              flux(:) = flux3(i,j,k,UMX:UMZ)
              ang_mom = linear_to_angular_momentum(loc, flux)
-             call reduce_add(xang_lost, -ang_mom(1))
-             call reduce_add(yang_lost, -ang_mom(2))
-             call reduce_add(zang_lost, -ang_mom(3))
+             xang_lost_tmp = xang_lost_tmp - ang_mom(1)
+             yang_lost_tmp = yang_lost_tmp - ang_mom(2)
+             zang_lost_tmp = zang_lost_tmp - ang_mom(3)
 
           enddo
        enddo
@@ -944,17 +955,17 @@ contains
 
              loc = position(i,j,k,ccz=.false.) - center
 
-             call reduce_add(mass_lost, flux3(i,j,k,URHO))
-             call reduce_add(xmom_lost, flux3(i,j,k,UMX))
-             call reduce_add(ymom_lost, flux3(i,j,k,UMY))
-             call reduce_add(zmom_lost, flux3(i,j,k,UMZ))
-             call reduce_add(eden_lost, flux3(i,j,k,UEDEN))
+             mass_lost_tmp = mass_lost_tmp + flux3(i,j,k,URHO)
+             xmom_lost_tmp = xmom_lost_tmp + flux3(i,j,k,UMX)
+             ymom_lost_tmp = ymom_lost_tmp + flux3(i,j,k,UMY)
+             zmom_lost_tmp = zmom_lost_tmp + flux3(i,j,k,UMZ)
+             eden_lost_tmp = eden_lost_tmp + flux3(i,j,k,UEDEN)
 
              flux(:) = flux3(i,j,k,UMX:UMZ)
              ang_mom = linear_to_angular_momentum(loc, flux)
-             call reduce_add(xang_lost, ang_mom(1))
-             call reduce_add(yang_lost, ang_mom(2))
-             call reduce_add(zang_lost, ang_mom(3))
+             xang_lost_tmp = xang_lost_tmp + ang_mom(1)
+             yang_lost_tmp = yang_lost_tmp + ang_mom(2)
+             zang_lost_tmp = zang_lost_tmp + ang_mom(3)
 
           enddo
        enddo
@@ -971,17 +982,17 @@ contains
 
              loc = position(i,j,k,ccy=.false.) - center
 
-             call reduce_add(mass_lost, -flux2(i,j,k,URHO))
-             call reduce_add(xmom_lost, -flux2(i,j,k,UMX))
-             call reduce_add(ymom_lost, -flux2(i,j,k,UMY))
-             call reduce_add(zmom_lost, -flux2(i,j,k,UMZ))
-             call reduce_add(eden_lost, -flux2(i,j,k,UEDEN))
+             mass_lost_tmp = mass_lost_tmp - flux2(i,j,k,URHO)
+             xmom_lost_tmp = xmom_lost_tmp - flux2(i,j,k,UMX)
+             ymom_lost_tmp = ymom_lost_tmp - flux2(i,j,k,UMY)
+             zmom_lost_tmp = zmom_lost_tmp - flux2(i,j,k,UMZ)
+             eden_lost_tmp = eden_lost_tmp - flux2(i,j,k,UEDEN)
 
              flux(:) = flux2(i,j,k,UMX:UMZ)
              ang_mom = linear_to_angular_momentum(loc, flux)
-             call reduce_add(xang_lost, -ang_mom(1))
-             call reduce_add(yang_lost, -ang_mom(2))
-             call reduce_add(zang_lost, -ang_mom(3))
+             xang_lost_tmp = xang_lost_tmp - ang_mom(1)
+             yang_lost_tmp = yang_lost_tmp - ang_mom(2)
+             zang_lost_tmp = zang_lost_tmp - ang_mom(3)
 
           enddo
        enddo
@@ -996,17 +1007,17 @@ contains
 
              loc = position(i,j,k,ccy=.false.) - center
 
-             call reduce_add(mass_lost, flux2(i,j,k,URHO))
-             call reduce_add(xmom_lost, flux2(i,j,k,UMX))
-             call reduce_add(ymom_lost, flux2(i,j,k,UMY))
-             call reduce_add(zmom_lost, flux2(i,j,k,UMZ))
-             call reduce_add(eden_lost, flux2(i,j,k,UEDEN))
+             mass_lost_tmp = mass_lost_tmp + flux2(i,j,k,URHO)
+             xmom_lost_tmp = xmom_lost_tmp + flux2(i,j,k,UMX)
+             ymom_lost_tmp = ymom_lost_tmp + flux2(i,j,k,UMY)
+             zmom_lost_tmp = zmom_lost_tmp + flux2(i,j,k,UMZ)
+             eden_lost_tmp = eden_lost_tmp + flux2(i,j,k,UEDEN)
 
              flux(:) = flux2(i,j,k,UMX:UMZ)
              ang_mom = linear_to_angular_momentum(loc, flux)
-             call reduce_add(xang_lost, ang_mom(1))
-             call reduce_add(yang_lost, ang_mom(2))
-             call reduce_add(zang_lost, ang_mom(3))
+             xang_lost_tmp = xang_lost_tmp + ang_mom(1)
+             yang_lost_tmp = yang_lost_tmp + ang_mom(2)
+             zang_lost_tmp = zang_lost_tmp + ang_mom(3)
 
           enddo
        enddo
@@ -1022,17 +1033,17 @@ contains
 
              loc = position(i,j,k,ccx=.false.) - center
 
-             call reduce_add(mass_lost, -flux1(i,j,k,URHO))
-             call reduce_add(xmom_lost, -flux1(i,j,k,UMX))
-             call reduce_add(ymom_lost, -flux1(i,j,k,UMY))
-             call reduce_add(zmom_lost, -flux1(i,j,k,UMZ))
-             call reduce_add(eden_lost, -flux1(i,j,k,UEDEN))
+             mass_lost_tmp = mass_lost_tmp - flux1(i,j,k,URHO)
+             xmom_lost_tmp = xmom_lost_tmp - flux1(i,j,k,UMX)
+             ymom_lost_tmp = ymom_lost_tmp - flux1(i,j,k,UMY)
+             zmom_lost_tmp = zmom_lost_tmp - flux1(i,j,k,UMZ)
+             eden_lost_tmp = eden_lost_tmp - flux1(i,j,k,UEDEN)
 
              flux(:) = flux1(i,j,k,UMX:UMZ)
              ang_mom = linear_to_angular_momentum(loc, flux)
-             call reduce_add(xang_lost, -ang_mom(1))
-             call reduce_add(yang_lost, -ang_mom(2))
-             call reduce_add(zang_lost, -ang_mom(3))
+             xang_lost_tmp = xang_lost_tmp - ang_mom(1)
+             yang_lost_tmp = yang_lost_tmp - ang_mom(2)
+             zang_lost_tmp = zang_lost_tmp - ang_mom(3)
 
           enddo
        enddo
@@ -1047,22 +1058,31 @@ contains
 
              loc = position(i,j,k,ccx=.false.) - center
 
-             call reduce_add(mass_lost, flux1(i,j,k,URHO))
-             call reduce_add(xmom_lost, flux1(i,j,k,UMX))
-             call reduce_add(ymom_lost, flux1(i,j,k,UMY))
-             call reduce_add(zmom_lost, flux1(i,j,k,UMZ))
-             call reduce_add(eden_lost, flux1(i,j,k,UEDEN))
+             mass_lost_tmp = mass_lost_tmp + flux1(i,j,k,URHO)
+             xmom_lost_tmp = xmom_lost_tmp + flux1(i,j,k,UMX)
+             ymom_lost_tmp = ymom_lost_tmp + flux1(i,j,k,UMY)
+             zmom_lost_tmp = zmom_lost_tmp + flux1(i,j,k,UMZ)
+             eden_lost_tmp = eden_lost_tmp + flux1(i,j,k,UEDEN)
 
              flux(:) = flux1(i,j,k,UMX:UMZ)
              ang_mom = linear_to_angular_momentum(loc, flux)
-             call reduce_add(xang_lost, ang_mom(1))
-             call reduce_add(yang_lost, ang_mom(2))
-             call reduce_add(zang_lost, ang_mom(3))
+             xang_lost_tmp = xang_lost_tmp + ang_mom(1)
+             yang_lost_tmp = yang_lost_tmp + ang_mom(2)
+             zang_lost_tmp = zang_lost_tmp + ang_mom(3)
 
           enddo
        enddo
 
     endif
+
+    call reduce_add(mass_lost, mass_lost_tmp)
+    call reduce_add(xmom_lost, xmom_lost_tmp)
+    call reduce_add(ymom_lost, ymom_lost_tmp)
+    call reduce_add(zmom_lost, zmom_lost_tmp)
+    call reduce_add(eden_lost, eden_lost_tmp)
+    call reduce_add(xang_lost, xang_lost_tmp)
+    call reduce_add(yang_lost, yang_lost_tmp)
+    call reduce_add(zang_lost, zang_lost_tmp)
 
   end subroutine ca_track_grid_losses
 

--- a/Source/hydro/advection_util_nd.F90
+++ b/Source/hydro/advection_util_nd.F90
@@ -34,6 +34,7 @@ contains
     real(rt) :: max_dens, old_rho
     real(rt) :: uold(NVAR), unew(NVAR)
     integer  :: num_positive_zones
+    real(rt) :: frac_change_tmp
 
     !$gpu
 
@@ -42,6 +43,8 @@ contains
     do k = lo(3), hi(3)
        do j = lo(2), hi(2)
           do i = lo(1), hi(1)
+
+             frac_change_tmp = 1.0_rt
 
              if (state(i,j,k,URHO) .eq. ZERO) then
 
@@ -160,10 +163,14 @@ contains
                 ! Store the maximum (negative) fractional change in the density from this reset.
 
                 if (old_rho < ZERO) then
-                   call reduce_min(frac_change, (state(i,j,k,URHO) - old_rho) / old_rho)
+                   frac_change_tmp = 1.0_rt
+                else
+                   frac_change_tmp = (state(i,j,k,URHO) - old_rho) / old_rho
                 end if
 
              end if
+
+             call reduce_min(frac_change, frac_change_tmp)
 
           end do
        end do


### PR DESCRIPTION

## PR summary

Thread-safe reductions in the CUDA build have two requirements: (1) we must use the corresponding function in reduction.F90, such as reduce_add, otherwise there will be a race condition among CUDA threads; (2) we cannot call functions like reduce_add in a conditional branch that is true for some threads but not others (otherwise there could be a code hang).

Fixes #728 

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
