### PR TITLE
Move Microphysics to a new external subdirectory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Microphysics"]
-	path = Microphysics
+	path = external/Microphysics
 	url = https://github.com/starkiller-astro/Microphysics.git

--- a/Docs/source/getting_started.rst
+++ b/Docs/source/getting_started.rst
@@ -92,7 +92,7 @@ is installed on your machine—we recommend version 1.7.x or higher.
 
    Then, set the ``MICROPHYSICS_HOME`` environment variable to point to
    the ``Microphysics/`` directory, and Castro will look there instead
-   of in its local ``Microphysics/`` subdirectory.
+   of in its local ``external/Microphysics/`` subdirectory.
 
 Building the Code
 =================

--- a/Docs/source/software.rst
+++ b/Docs/source/software.rst
@@ -58,7 +58,7 @@ division between C++ and Fortran.
 
    -  ``unit_tests/``: test problems that exercise primarily a single module
 
--  ``Microphysics/``: contains directories for different default
+-  ``external/Microphysics/``: contains directories for different default
    microphysics (these are all implemented in Fortran)
 
    -  ``conductivity/``: the thermal conductivity

--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -9,7 +9,7 @@ BLAS_LIBRARY ?= -lopenblas
 
 TOP := $(CASTRO_HOME)
 
-MICROPHYSICS_HOME ?= $(TOP)/Microphysics
+MICROPHYSICS_HOME ?= $(TOP)/external/Microphysics
 
 # Check to make sure that Microphysics actually exists,
 # using an arbitrary file that must exist to check.


### PR DESCRIPTION

## PR summary

This PR proposes to adopt a trend where external dependencies of Castro all live in the `external/` subdirectory, and moves Microphysics there.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
