### PR TITLE
Extrapolate borders

### DIFF
--- a/Source/radiation/RAD_1D.F90
+++ b/Source/radiation/RAD_1D.F90
@@ -175,19 +175,4 @@ subroutine rfface(fine, &
   fine(fbox_l1) = crse(cbox_l1)
 end subroutine rfface
 
-subroutine bextrp(f, fbox_l1, fbox_h1, reg_l1, reg_h1) bind(C, name="bextrp")
-  use amrex_fort_module, only : rt => amrex_real
-  implicit none
-  integer :: fbox_l1, fbox_h1
-  integer ::  reg_l1,  reg_h1
-  real(rt)         :: f(fbox_l1:fbox_h1)
-  integer :: i
-
-  !     i direction first:
-  i = reg_l1
-  f(i-1) = 2.e0_rt * f(i) - f(i+1)
-  i = reg_h1
-  f(i+1) = 2.e0_rt * f(i) - f(i-1)
-end subroutine bextrp
-
 end module rad_module

--- a/Source/radiation/RAD_2D.F90
+++ b/Source/radiation/RAD_2D.F90
@@ -222,33 +222,4 @@ subroutine rfface(fine, &
   endif
 end subroutine rfface
 
-
-subroutine bextrp(f, fbox_l1, fbox_l2, fbox_h1, fbox_h2, &
-                  reg_l1, reg_l2, reg_h1, reg_h2) bind(C, name="bextrp")
-
-  use amrex_fort_module, only : rt => amrex_real
-  integer :: fbox_l1, fbox_l2, fbox_h1, fbox_h2
-  integer ::  reg_l1,  reg_l2,  reg_h1,  reg_h2
-  real(rt)         :: f(fbox_l1:fbox_h1,fbox_l2:fbox_h2)
-  integer :: i, j
-
-  !     i direction first:
-  do j = reg_l2, reg_h2
-     i = reg_l1
-     f(i-1,j) = 2.e0_rt * f(i,j) - f(i+1,j)
-     i = reg_h1
-     f(i+1,j) = 2.e0_rt * f(i,j) - f(i-1,j)
-  enddo
-
-  !     j direction second, including corners:
-  do i = reg_l1 - 1, reg_h1 + 1
-     j = reg_l2
-     f(i,j-1) = 2.e0_rt * f(i,j) - f(i,j+1)
-     j = reg_h2
-     f(i,j+1) = 2.e0_rt * f(i,j) - f(i,j-1)
-  enddo
-
-  !  corner results are the same whichever direction we extrapolate first
-end subroutine bextrp
-
 end module rad_module

--- a/Source/radiation/RAD_3D.F90
+++ b/Source/radiation/RAD_3D.F90
@@ -240,49 +240,5 @@ subroutine rfface(fine, &
   endif
 end subroutine rfface
 
-
-subroutine bextrp( &
-                  f, fbox_l1, fbox_l2, fbox_l3, fbox_h1, fbox_h2, fbox_h3, &
-                  reg_l1, reg_l2, reg_l3, reg_h1, reg_h2, reg_h3) bind(C, name="bextrp")
-
-  use amrex_fort_module, only : rt => amrex_real
-  integer :: fbox_l1, fbox_l2, fbox_l3, fbox_h1, fbox_h2, fbox_h3
-  integer ::  reg_l1,  reg_l2,  reg_l3,  reg_h1,  reg_h2,  reg_h3
-  real(rt)         :: f(fbox_l1:fbox_h1,fbox_l2:fbox_h2,fbox_l3:fbox_h3)
-  integer :: i, j, k
-
-  !     i direction first:
-  do k = reg_l3, reg_h3
-     do j = reg_l2, reg_h2
-        i = reg_l1
-        f(i-1,j,k) = 2.e0_rt * f(i,j,k) - f(i+1,j,k)
-        i = reg_h1
-        f(i+1,j,k) = 2.e0_rt * f(i,j,k) - f(i-1,j,k)
-     enddo
-  enddo
-
-  !     j direction second, including edges:
-  do k = reg_l3, reg_h3
-     do i = reg_l1 - 1, reg_h1 + 1
-        j = reg_l2
-        f(i,j-1,k) = 2.e0_rt * f(i,j,k) - f(i,j+1,k)
-        j = reg_h2
-        f(i,j+1,k) = 2.e0_rt * f(i,j,k) - f(i,j-1,k)
-     enddo
-  enddo
-
-  !     k direction third, including corners:
-  do j = reg_l2 - 1, reg_h2 + 1
-     do i = reg_l1 - 1, reg_h1 + 1
-        k = reg_l3
-        f(i,j,k-1) = 2.e0_rt * f(i,j,k) - f(i,j,k+1)
-        k = reg_h3
-        f(i,j,k+1) = 2.e0_rt * f(i,j,k) - f(i,j,k-1)
-     enddo
-  enddo
-
-  !   corner results are the same whichever direction we extrapolate first
-end subroutine bextrp
-
 end module rad_module
 

--- a/Source/radiation/RAD_F.H
+++ b/Source/radiation/RAD_F.H
@@ -607,8 +607,9 @@ extern "C" {
                       int* tfab, ARLIM_P(dlo), ARLIM_P(dhi),
                       const amrex::Real* dx, const amrex::Real* xlo, const amrex::Real& time);
 
-  void bextrp(BL_FORT_FAB_ARG(f), 
-              ARLIM_P(reglo), ARLIM_P(reghi));
+    void bextrp(const int* lo, const int* hi,
+                const int* vlo, const int* vhi,
+                BL_FORT_FAB_ARG_3D(f));
 
   // neutrino routines below
 


### PR DESCRIPTION

## PR summary

This gets extrapolateBorders dimension agnostic and GPU friendly. The previous approach was not zone-local, so I've rewritten the algorithm such that ghost zones don't depend on other ghost zones.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
