### PR TITLE
Implement flux limiter based on small eint

### DIFF
--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -172,6 +172,9 @@ use_pslope                   int           1                  y
 # Should we limit the density fluxes so that we do not create small densities?
 limit_fluxes_on_small_dens   int           0                  y
 
+# Should we limit the density fluxes so that we do not create small internal energies?
+limit_fluxes_on_small_eint   int           0                  y
+
 # Should we limit the momentum fluxes so that we do not create large velocities?
 limit_fluxes_on_large_vel    int           0                  y
 

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1243,6 +1243,19 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
                    dt, AMREX_REAL_ANYD(dx));
           }
 
+          if (limit_fluxes_on_small_eint == 1) {
+#pragma gpu box(nbx)
+              limit_hydro_fluxes_on_small_eint
+                  (AMREX_INT_ANYD(nbx.loVect()), AMREX_INT_ANYD(nbx.hiVect()),
+                   idir_f,
+                   BL_TO_FORTRAN_ANYD(Sborder[mfi]),
+                   BL_TO_FORTRAN_ANYD(q[mfi]),
+                   BL_TO_FORTRAN_ANYD(volume[mfi]),
+                   BL_TO_FORTRAN_ANYD(flux[idir]),
+                   BL_TO_FORTRAN_ANYD(area[idir][mfi]),
+                   dt, AMREX_REAL_ANYD(dx));
+          }
+
           if (limit_fluxes_on_large_vel == 1) {
 #pragma gpu box(nbx)
               limit_hydro_fluxes_on_large_vel

--- a/Source/hydro/Castro_hydro_F.H
+++ b/Source/hydro/Castro_hydro_F.H
@@ -95,6 +95,16 @@ extern "C"
      BL_FORT_FAB_ARG_3D(area),
      const amrex::Real dt, const amrex::Real* dx);
 
+  void limit_hydro_fluxes_on_small_eint
+    (const int* lo, const int* hi,
+     const int idir,
+     BL_FORT_FAB_ARG_3D(Sborder),
+     BL_FORT_FAB_ARG_3D(q),
+     BL_FORT_FAB_ARG_3D(volume),
+     BL_FORT_FAB_ARG_3D(flux),
+     BL_FORT_FAB_ARG_3D(area),
+     const amrex::Real dt, const amrex::Real* dx);
+
   void limit_hydro_fluxes_on_large_vel
     (const int* lo, const int* hi,
      const int idir,


### PR DESCRIPTION

## PR summary

A new option, castro.limit_fluxes_on_small_eint, is added that limits fluxes if they would generate small/negative internal energies.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
