### PR TITLE
Implement Edd_factor in C++

### DIFF
--- a/Source/radiation/Make.package
+++ b/Source/radiation/Make.package
@@ -42,6 +42,7 @@ ca_f90EXE_sources += RadPlotvar_$(DIM)d.f90
 ca_F90EXE_sources += rad_params.F90
 ca_F90EXE_sources += blackbody.F90
 ca_F90EXE_sources += Rad_nd.F90
+CEXE_headers += fluxlimiter.H
 ca_F90EXE_sources += fluxlimiter.F90
 ca_F90EXE_sources += RadHydro_nd.F90
 ca_F90EXE_sources += filter.F90

--- a/Source/radiation/Radiation.H
+++ b/Source/radiation/Radiation.H
@@ -72,11 +72,11 @@ public:
   int inner_convergence_check;
   amrex::Real delta_e_rat_dt_tol; ///< energy change tolerance for adjusting timestep
   amrex::Real delta_T_rat_dt_tol; ///< T change tolerance for adjusting timestep
-  int limiter;          ///< 0: no limiter, 2: Lev-Pom limiter
-                        ///< 12: Bruenn, 22: square root, 32: Minerbo
-  int closure;      ///< 0: \f$f = \lambda\f$, 1: \f$f = 1/3\f$,
-                    ///< 2: \f$f = 1-2\lambda\f$, 3: \f$f = \lambda+(\lambda R)^2\f$
-                    ///< 4: \f$f = 1/3 + 2/3 (\lambda R)^2\f$
+  static int limiter;          ///< 0: no limiter, 2: Lev-Pom limiter
+                               ///< 12: Bruenn, 22: square root, 32: Minerbo
+  static int closure;      ///< 0: \f$f = \lambda\f$, 1: \f$f = 1/3\f$,
+                           ///< 2: \f$f = 1-2\lambda\f$, 3: \f$f = \lambda+(\lambda R)^2\f$
+                           ///< 4: \f$f = 1/3 + 2/3 (\lambda R)^2\f$
   int update_planck;     ///< after this number of iterations, lag planck
   int update_rosseland;  ///< after this number of iterations, lag rosseland
   int update_opacity;

--- a/Source/radiation/Radiation.cpp
+++ b/Source/radiation/Radiation.cpp
@@ -53,6 +53,8 @@ int Radiation::filter_lambda_S = 0;
 int Radiation::filter_prim_int = 0;
 int Radiation::filter_prim_T = 4;
 int Radiation::filter_prim_S = 0;
+int Radiation::limiter = -1;
+int Radiation::closure = -1;
 
 // These physical constants get their values in the Radiation constructor:
 Real Radiation::convert_MeV_erg = 0.0;

--- a/Source/radiation/fluxlimiter.H
+++ b/Source/radiation/fluxlimiter.H
@@ -1,0 +1,88 @@
+#ifndef _fluxlimiter_H_
+#define _fluxlimiter_H_
+
+#include <AMReX_REAL.H>
+
+using namespace amrex;
+
+AMREX_GPU_HOST_DEVICE inline
+amrex::Real Edd_factor(Real lambda, int limiter, int closure)
+{
+
+    Real f;
+
+    if (closure == 0) {
+        f = lambda;
+    }
+    else if (closure == 1) {
+        f = 1.0_rt / 3.0_rt;
+    }
+    else if (closure == 2) {
+        f = 1.e0_rt - 2.e0_rt * lambda;
+    }
+    else if (closure == 3) { // lambda + (lambda*R)**2
+        if (limiter == 0) { // no limiter
+            f = 1.0_rt / 3.0_rt;
+        }
+        else if (limiter < 10) { // approximate LP, [123]
+            f = 0.5e0_rt * amrex::max(0.0_rt, (1.e0_rt - 3.e0_rt*  lambda)) + 
+                std::sqrt(amrex::max(0.0_rt, (1.e0_rt - 3.e0_rt * lambda)) *
+                          (1.e0_rt + 5.e0_rt * lambda));
+            f = lambda + f * f;
+        }
+        else if (limiter < 20) { // Bruenn, 1[123]
+            f = 1.0e0_rt - 5.e0_rt * lambda + 9.e0_rt * lambda * lambda;
+        }
+        else if (limiter < 30) { // Larsen's square root, 2[123]
+            f = 1.0e0_rt + lambda - 9.e0_rt * lambda * lambda;
+        }
+        else if (limiter < 40) { // Minerbo
+            if (lambda > 2.0_rt / 9.0_rt) {
+                f = 1.0_rt / 3.0_rt;
+            }
+            else {
+                f = 1.e0_rt + 3.e0_rt * lambda - 2.e0_rt * std::sqrt(2.e0_rt * lambda);
+            }
+        }
+#ifndef AMREX_USE_GPU
+        else {
+            amrex::Error("Unknown limiter");
+        }
+#endif
+    }
+    else if (closure == 4) { // 1/3 + 2/3*(lambda*R)**2
+        if (limiter == 0) { // no limiter
+            f = 1.0_rt / 3.0_rt;
+        }
+        else if (limiter < 10) { // approximate LP, [123]
+            f = amrex::max(0.0_rt, (1.e0_rt - 3.e0_rt * lambda)) +
+                 std::sqrt(amrex::max(0.0_rt, (1.e0_rt - 3.e0_rt * lambda)) *
+                           (1.e0_rt + 5.e0_rt * lambda));
+            f = (1.0_rt / 3.0_rt) + (1.0_rt / 6.0_rt) * f * f;
+        }
+        else if (limiter < 20) { // Bruenn, 1[123]
+            f = (1.0_rt / 3.0_rt) + (2.0_rt / 3.0_rt) * (1.0e0_rt - 6.e0_rt * lambda + 9.e0_rt * lambda * lambda);
+        }
+        else if (limiter < 30) { // Larsen's square root, 2[123]
+            f = (1.0_rt / 3.0_rt) + (2.0_rt / 3.0_rt) * (1.0e0_rt - 9.e0_rt * lambda * lambda);
+        }
+        else if (limiter < 40) { // Minerbo
+            if (lambda > 2.0_rt / 9.0_rt) {
+                f = (5.0_rt / 9.0_rt) - (2.0_rt / 3.0_rt) * lambda;
+            }
+            else {
+                f = (1.0_rt / 3.0_rt) + (2.0_rt / 3.0_rt) * (1.e0_rt + 2.e0_rt * lambda - 2.e0_rt * std::sqrt(2.e0_rt * lambda));
+            }
+        }
+#ifndef AMREX_USE_GPU
+        else {
+            amrex::Error("Unknown limiter");
+        }
+#endif
+    }
+
+    return f;
+
+}
+
+#endif


### PR DESCRIPTION
## PR summary

Since we don't have an easy way to access `limiter` and `closure` in device code, these are parameters to the function (for now, at any rate). Also, those variables are made static members of the `Radiation` class so that we can make local copies of them for lambda captures.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
