### PR TITLE
Remove src q

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -1077,12 +1077,6 @@ protected:
 
 
 ///
-/// The source terms in primitive form.
-///
-    amrex::MultiFab src_q;
-
-
-///
 /// Source terms to the hydrodynamics solve.
 ///
     amrex::MultiFab sources_for_hydro;

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -354,9 +354,6 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
     q.setVal(0.0);
     qaux.define(grids, dmap, NQAUX, NUM_GROW);
 
-    if (time_integration_method == CornerTransportUpwind || time_integration_method == SimplifiedSpectralDeferredCorrections) {
-      src_q.define(grids, dmap, NQSRC, NUM_GROW);
-    }
 
     if (sdc_order == 4) {
       q_bar.define(grids, dmap, NQ, NUM_GROW);
@@ -463,10 +460,6 @@ Castro::finalize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle)
 
     q.clear();
     qaux.clear();
-
-    if (time_integration_method == CornerTransportUpwind || time_integration_method == SimplifiedSpectralDeferredCorrections) {
-      src_q.clear();
-    }
 
     if (sdc_order == 4) {
       q_bar.clear();

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -47,8 +47,6 @@
 @set: auxiliary NQAUX NQAUX
    gamma_c                QGAMC     None            1                   None
    sound-speed            QC        None            1                   None
-   dpdr                   QDPDR     None            1                   None
-   dpde                   QDPDE     None            1                   None
    gamma_c-gas            QGAMCG    None            1                   RADIATION
    sound-speed-gas        QCG       None            1                   RADIATION
    flux-limiter           QLAMS     None          (ngroups, NGROUPS)    RADIATION

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -168,7 +168,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
       if (oversubscribed) {
           q[mfi].prefetchToDevice();
           qaux[mfi].prefetchToDevice();
-          src_q[mfi].prefetchToDevice();
           volume[mfi].prefetchToDevice();
           Sborder[mfi].prefetchToDevice();
           hydro_source[mfi].prefetchToDevice();
@@ -1414,7 +1413,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
       if (oversubscribed) {
           q[mfi].prefetchToHost();
           qaux[mfi].prefetchToHost();
-          src_q[mfi].prefetchToHost();
           volume[mfi].prefetchToHost();
           Sborder[mfi].prefetchToHost();
           hydro_source[mfi].prefetchToHost();

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -87,6 +87,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 #endif
     FArrayBox dq;
     FArrayBox shk;
+    FArrayBox src_q;
     FArrayBox qxm, qxp;
 #if AMREX_SPACEDIM >= 2
     FArrayBox qym, qyp;
@@ -187,7 +188,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
       Array4<Real const> const q_arr = q.array(mfi);
       Array4<Real const> const qaux_arr = qaux.array(mfi);
-      Array4<Real const> const src_q_arr = src_q.array(mfi);
 
       Array4<Real const> const areax_arr = area[0].array(mfi);
 #if AMREX_SPACEDIM >= 2
@@ -273,6 +273,16 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
       else {
         AMREX_PARALLEL_FOR_3D(obx, i, j, k, { shk_arr(i,j,k) = 0.0; });
       }
+
+      // get the primitive variable hydro sources
+      src_q.resize(obx, NQSRC);
+      Elixir elix_src_q = src_q.elixir();
+      fab_size += src_q.nBytes();
+      Array4<Real> const src_q_arr = src_q.array();
+
+      Array4<Real> const src_arr = sources_for_hydro.array(mfi);
+
+      src_to_prim(obx, q_arr, qaux_arr, src_arr, src_q_arr);
 
       qxm.resize(obx, NQ);
       Elixir elix_qxm = qxm.elixir();

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -56,16 +56,6 @@ Castro::cons_to_prim(const Real time)
                 q_arr,
                 qaux_arr);
 
-        // Convert the source terms expressed as sources to the conserved state to those
-        // expressed as sources for the primitive state.
-        if (time_integration_method == CornerTransportUpwind ||
-            time_integration_method == SimplifiedSpectralDeferredCorrections) {
-
-          Array4<Real> const src_arr = sources_for_hydro.array(mfi);
-          Array4<Real> const src_q_arr = src_q.array(mfi);
-
-          src_to_prim(qbx, q_arr, qaux_arr, src_arr, src_q_arr);
-        }
 
 #ifndef RADIATION
 #ifdef SIMPLIFIED_SDC

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -56,23 +56,6 @@ Castro::cons_to_prim(const Real time)
                 q_arr,
                 qaux_arr);
 
-
-#ifndef RADIATION
-#ifdef SIMPLIFIED_SDC
-#ifdef REACTIONS
-        // Add in the reactions source term; only done in simplified SDC.
-
-        if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
-
-            MultiFab& SDC_react_source = get_new_data(Simplified_SDC_React_Type);
-
-            if (do_react)
-                src_q[mfi].plus<RunOn::Device>(SDC_react_source[mfi],qbx,qbx,0,0,NQSRC);
-
-        }
-#endif
-#endif
-#endif
     }
 
 }

--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -145,8 +145,6 @@ Castro::ctoprim(const Box& bx,
 #ifdef TRUE_SDC
     q_arr(i,j,k,QGC) = eos_state.gam1;
 #endif
-    qaux_arr(i,j,k,QDPDR) = eos_state.dpdr_e;
-    qaux_arr(i,j,k,QDPDE) = eos_state.dpde;
 
 #ifdef RADIATION
     qaux_arr(i,j,k,QGAMCG) = eos_state.gam1;
@@ -185,49 +183,6 @@ Castro::ctoprim(const Box& bx,
 #endif
 
   });
-}
-
-
-void
-Castro::src_to_prim(const Box& bx,
-                    Array4<Real const> const q_arr,
-                    Array4<Real const> const qaux_arr,
-                    Array4<Real const> const src,
-                    Array4<Real> const srcQ)
-{
-
-  AMREX_PARALLEL_FOR_3D(bx, i, j, k,
-  {
-
-
-      for (int n = 0; n < NQSRC; ++n) {
-        srcQ(i,j,k,n) = 0.0_rt;
-      }
-
-      Real rhoinv = 1.0_rt / q_arr(i,j,k,QRHO);
-
-      srcQ(i,j,k,QRHO) = src(i,j,k,URHO);
-      srcQ(i,j,k,QU) = (src(i,j,k,UMX) - q_arr(i,j,k,QU) * srcQ(i,j,k,QRHO)) * rhoinv;
-      srcQ(i,j,k,QV) = (src(i,j,k,UMY) - q_arr(i,j,k,QV) * srcQ(i,j,k,QRHO)) * rhoinv;
-      srcQ(i,j,k,QW) = (src(i,j,k,UMZ) - q_arr(i,j,k,QW) * srcQ(i,j,k,QRHO)) * rhoinv;
-      srcQ(i,j,k,QREINT) = src(i,j,k,UEINT);
-      srcQ(i,j,k,QPRES ) = qaux_arr(i,j,k,QDPDE) *
-        (srcQ(i,j,k,QREINT) - q_arr(i,j,k,QREINT)*srcQ(i,j,k,QRHO)*rhoinv) *
-        rhoinv + qaux_arr(i,j,k,QDPDR)*srcQ(i,j,k,QRHO);
-
-#ifdef PRIM_SPECIES_HAVE_SOURCES
-      for (int ipassive = 0; ipassive < npassive; ++ipassive) {
-        int n = upassmap(ipassive);
-        int iq = qpassmap(ipassive);
-
-       // we may not be including the ability to have species sources,
-       //  so check to make sure that we are < NQSRC
-        srcQ(i,j,k,iq) = (src(i,j,k,n) - q_arr(i,j,k,iq) * srcQ(i,j,k,QRHO) ) /
-          q_arr(i,j,k,QRHO);
-      }
-#endif
-  });
-
 }
 
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This removes the src_q multifab and instead converts the conserved state sources to primitive state sources FAB by FAB just before they are needed (in the creation of the interface states).  This saves on memory from the MF as well as allows us to eliminate two entries in qaux (QDPDE and QDPDR).  The trade-off is we now do an EOS call.

Answers may change because of the additional EOS call.


## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
