### PR TITLE
remove plm_well_balanced and update use_pslope

### DIFF
--- a/Exec/gravity_tests/hse_convergence/convergence_plm.sh
+++ b/Exec/gravity_tests/hse_convergence/convergence_plm.sh
@@ -3,33 +3,13 @@
 
 EXEC=./Castro1d.gnu.MPI.ex
 
-## ppm
 
-ofile=ppm.converge.out
+## plm
 
-${EXEC} inputs.ppm.64 >& 64.out
-pfile=`ls -t | grep -i hse_64_plt | head -1` 
-fextrema.gnu.ex -v magvel ${pfile} | grep -i magvel > ${ofile}
-
-${EXEC} inputs.ppm.128 >& 128.out
-pfile=`ls -t | grep -i hse_128_plt | head -1` 
-fextrema.gnu.ex -v magvel ${pfile} | grep -i magvel >> ${ofile}
-
-${EXEC} inputs.ppm.256 >& 256.out
-pfile=`ls -t | grep -i hse_256_plt | head -1` 
-fextrema.gnu.ex -v magvel ${pfile} | grep -i magvel >> ${ofile}
-
-${EXEC} inputs.ppm.512 >& 512.out
-pfile=`ls -t | grep -i hse_512_plt | head -1` 
-fextrema.gnu.ex -v magvel ${pfile} | grep -i magvel >> ${ofile}
-
-
-## ppm + grav_source_type = 4
-
-ofile=ppm-grav4.converge.out
+ofile=plm.converge.out
 
 RUNPARAMS="
-castro.grav_source_type=4
+castro.ppm_type=0
 """
 
 ${EXEC} inputs.ppm.64 ${RUNPARAMS} >& 64.out
@@ -49,13 +29,43 @@ pfile=`ls -t | grep -i hse_512_plt | head -1`
 fextrema.gnu.ex -v magvel ${pfile} | grep -i magvel >> ${ofile}
 
 
-## ppm + reflect
+## plm + reflect
 
-ofile=ppm-reflect.converge.out
+ofile=plm-reflect.converge.out
 
 RUNPARAMS="
+castro.ppm_type=0
 castro.lo_bc=3
 castro.hi_bc=3
+"""
+
+${EXEC} inputs.ppm.64 ${RUNPARAMS} >& 64.out
+pfile=`ls -t | grep -i hse_64_plt | head -1` 
+fextrema.gnu.ex -v magvel ${pfile} | grep -i magvel > ${ofile}
+
+${EXEC} inputs.ppm.128 ${RUNPARAMS} >& 128.out
+pfile=`ls -t | grep -i hse_128_plt | head -1` 
+fextrema.gnu.ex -v magvel ${pfile} | grep -i magvel >> ${ofile}
+
+${EXEC} inputs.ppm.256 ${RUNPARAMS} >& 256.out
+pfile=`ls -t | grep -i hse_256_plt | head -1` 
+fextrema.gnu.ex -v magvel ${pfile} | grep -i magvel >> ${ofile}
+
+${EXEC} inputs.ppm.512 ${RUNPARAMS} >& 512.out
+pfile=`ls -t | grep -i hse_512_plt | head -1` 
+fextrema.gnu.ex -v magvel ${pfile} | grep -i magvel >> ${ofile}
+
+
+
+## plm + reflect + nopslope
+
+ofile=plm-reflect-nopslope.converge.out
+
+RUNPARAMS="
+castro.ppm_type=0
+castro.lo_bc=3
+castro.hi_bc=3
+castro.use_pslope=0
 """
 
 ${EXEC} inputs.ppm.64 ${RUNPARAMS} >& 64.out

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -104,10 +104,6 @@ plm_iorder                   int           2                  y
 # 1 = 2nd order MC, 2 = 4th order MC
 plm_limiter                  int           2                  y
 
-# for piecewise linear, MOL or SDC, do well-balanced reconstruction on
-# pressure
-plm_well_balanced            int           0                  y
-
 # do we drop from our regular Riemann solver to HLL when we
 # are in shocks to avoid the odd-even decoupling instability?
 hybrid_riemann               int           0                  y
@@ -166,7 +162,8 @@ dual_energy_eta1             Real          1.0e0              y
 dual_energy_eta2             Real          1.0e-4             y
 
 # for the piecewise linear reconstruction, do we subtract off :math:`(\rho g)`
-# from the pressure before limiting?
+# from the pressure before limiting?  This is a well-balanced method that
+# does well with HSE
 use_pslope                   int           1                  y
 
 # Should we limit the density fluxes so that we do not create small densities?

--- a/Source/hydro/Castro_mol.cpp
+++ b/Source/hydro/Castro_mol.cpp
@@ -31,8 +31,6 @@ Castro::mol_plm_reconstruct(const Box& bx,
   Real lconst_grav = 0.0_rt;
 #endif
 
-  int lplm_well_balanced = plm_well_balanced;
-
   for (int n = 0; n < NQ; n++) {
     // piecewise linear slopes
     uslope(bx, idir,
@@ -51,71 +49,32 @@ Castro::mol_plm_reconstruct(const Box& bx,
 
    if (idir == 0) {
 
-     if (lplm_well_balanced == 1 && n == QPRES && idir == AMREX_SPACEDIM-1) {
+     // left state at i+1/2 interface
+     qm(i+1,j,k,n) = q_arr(i,j,k,n) + 0.5_rt*dq(i,j,k,n);
 
-       // left state at i+1/2 interface
-       qm(i+1,j,k,n) = q_arr(i,j,k,n) + 0.5_rt*dq(i,j,k,n) +
-         0.5_rt*dx[0]*q_arr(i,j,k,QRHO)*lconst_grav;
+     // right state at i-1/2 interface
+     qp(i,j,k,n) = q_arr(i,j,k,n) - 0.5_rt*dq(i,j,k,n);
 
-       // right state at i-1/2 interface
-       qp(i,j,k,n) = q_arr(i,j,k,n) - 0.5_rt*dq(i,j,k,n) -
-         0.5_rt*dx[0]*q_arr(i,j,k,QRHO)*lconst_grav;
-
-     } else {
-       // left state at i+1/2 interface
-       qm(i+1,j,k,n) = q_arr(i,j,k,n) + 0.5_rt*dq(i,j,k,n);
-
-       // right state at i-1/2 interface
-       qp(i,j,k,n) = q_arr(i,j,k,n) - 0.5_rt*dq(i,j,k,n);
-
-     }
 
 #if AMREX_SPACEDIM >= 2
    } else if (idir == 1) {
 
-     if (lplm_well_balanced == 1 && n == QPRES && idir == AMREX_SPACEDIM-1) {
+     // left state at j+1/2 interface
+     qm(i,j+1,k,n) = q_arr(i,j,k,n) + 0.5_rt*dq(i,j,k,n);
 
-       // left state at i+1/2 interface
-       qm(i,j+1,k,n) = q_arr(i,j,k,n) + 0.5_rt*dq(i,j,k,n) +
-         0.5_rt*dx[1]*q_arr(i,j,k,QRHO)*lconst_grav;
-
-       // right state at i-1/2 interface
-       qp(i,j,k,n) = q_arr(i,j,k,n) - 0.5_rt*dq(i,j,k,n) -
-         0.5_rt*dx[1]*q_arr(i,j,k,QRHO)*lconst_grav;
-
-     } else {
-
-       // left state at j+1/2 interface
-       qm(i,j+1,k,n) = q_arr(i,j,k,n) + 0.5_rt*dq(i,j,k,n);
-
-       // right state at j-1/2 interface
-       qp(i,j,k,n) = q_arr(i,j,k,n) - 0.5_rt*dq(i,j,k,n);
-
-     }
+     // right state at j-1/2 interface
+     qp(i,j,k,n) = q_arr(i,j,k,n) - 0.5_rt*dq(i,j,k,n);
 #endif
 
 #if AMREX_SPACEDIM == 3
    } else {
 
-     if (lplm_well_balanced == 1 && n == QPRES && idir == AMREX_SPACEDIM-1) {
+     // left state at k+1/2 interface
+     qm(i,j,k+1,n) = q_arr(i,j,k,n) + 0.5_rt*dq(i,j,k,n);
 
-       // left state at i+1/2 interface
-       qm(i,j,k+1,n) = q_arr(i,j,k,n) + 0.5_rt*dq(i,j,k,n) +
-         0.5_rt*dx[2]*q_arr(i,j,k,QRHO)*lconst_grav;
+     // right state at k-1/2 interface
+     qp(i,j,k,n) = q_arr(i,j,k,n) - 0.5_rt*dq(i,j,k,n);
 
-       // right state at i-1/2 interface
-       qp(i,j,k,n) = q_arr(i,j,k,n) - 0.5_rt*dq(i,j,k,n) -
-         0.5_rt*dx[2]*q_arr(i,j,k,QRHO)*lconst_grav;
-
-     } else {
-
-       // left state at k+1/2 interface
-       qm(i,j,k+1,n) = q_arr(i,j,k,n) + 0.5_rt*dq(i,j,k,n);
-
-       // right state at k-1/2 interface
-       qp(i,j,k,n) = q_arr(i,j,k,n) - 0.5_rt*dq(i,j,k,n);
-
-     }
 #endif
    }
 


### PR DESCRIPTION
now use_pslope always uses zone i for the HSE reference point

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- please summarize your PR here.  If it addresses any issues, reference
 them by issue # here as well -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
