### PR TITLE
one-sided stencils for PPM at symmetry boundary

### DIFF
--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -156,9 +156,147 @@ Castro::ctu_ppm_states(const Box& bx, const Box& vbx,
 
 #endif
     }
+
+    // special care for reflecting BCs
+    const int* lo_bc = phys_bc.lo();
+    const int* hi_bc = phys_bc.hi();
+
+    const auto domlo = geom.Domain().loVect3d();
+    const auto domhi = geom.Domain().hiVect3d();
+
+    bool lo_bc_test = lo_bc[idir] == Symmetry;
+    bool hi_bc_test = hi_bc[idir] == Symmetry;
+
+    // we have to do this after the loops above, since here we will
+    // consider interfaces, not zones
+
+    if (idir == 0) {
+      if (lo_bc_test) {
+
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k,
+        {
+
+          // reset the left state at domlo(0) if needed -- it is outside the domain
+          if (i == domlo[0]) {
+            for (int n = 0; n < NQ; n++) {
+              if (n == QU) {
+                qxm(i,j,k,QU) = -qxp(i,j,k,QU);
+              } else {
+                qxm(i,j,k,n) = qxp(i,j,k,n);
+              }
+            }
+          }
+        });
+
+      }
+
+      if (hi_bc_test) {
+
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k,
+        {
+
+          // reset the right state at domhi(0)+1 if needed -- it is outside the domain
+          if (i == domhi[0]+1) {
+            for (int n = 0; n < NQ; n++) {
+              if (n == QU) {
+                qxp(i,j,k,QU) = -qxm(i,j,k,QU);
+              } else {
+                qxp(i,j,k,n) = qxm(i,j,k,n);
+              }
+            }
+          }
+        });
+
+      }
+
+#if AMREX_SPACEDIM >= 2
+    } else if (idir == 1) {
+
+      if (lo_bc_test) {
+
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k,
+        {
+
+          // reset the left state at domlo(0) if needed -- it is outside the domain
+          if (j == domlo[1]) {
+            for (int n = 0; n < NQ; n++) {
+              if (n == QV) {
+                qym(i,j,k,QV) = -qyp(i,j,k,QV);
+              } else {
+                qym(i,j,k,n) = -qyp(i,j,k,n);
+              }
+            }
+          }
+        });
+
+      }
+
+      if (hi_bc_test) {
+
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k,
+        {
+
+          // reset the right state at domhi(0)+1 if needed -- it is outside the domain
+          if (j == domhi[1]+1) {
+            for (int n = 0; n < NQ; n++) {
+              if (n == QV) {
+                qyp(i,j,k,QV) = -qym(i,j,k,QV);
+              } else {
+                qyp(i,j,k,n) = qym(i,j,k,n);
+              }
+            }
+          }
+        });
+
+      }
+
+#endif
+#if AMREX_SPACEDIM == 3
+    } else {
+
+      if (lo_bc_test) {
+
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k,
+        {
+
+          // reset the left state at domlo(0) if needed -- it is outside the domain
+          if (k == domlo[2]) {
+            for (int n = 0; n < NQ; n++) {
+              if (n == QW) {
+                qzm(i,j,k,QW) = -qzp(i,j,k,QW);
+              } else {
+                qzm(i,j,k,n) = qzp(i,j,k,n);
+              }
+            }
+          }
+        });
+
+      }
+
+      if (hi_bc_test) {
+
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k,
+        {
+
+          // reset the right state at domhi(0)+1 if needed -- it is outside the domain
+          if (k == domhi[2]+1) {
+            for (int n = 0; n < NQ; n++) {
+              if (n == QW) {
+                qzp(i,j,k,QW) = -qzm(i,j,k,QW);
+              } else {
+                qzp(i,j,k,n) = qzm(i,j,k,n);
+              }
+            }
+          }
+        });
+
+      }
+#endif
+
+    }
+
   }
 }
-
 
 #ifdef RADIATION
 void

--- a/Source/hydro/Castro_mol.cpp
+++ b/Source/hydro/Castro_mol.cpp
@@ -277,31 +277,37 @@ Castro::mol_ppm_reconstruct(const Box& bx,
   AMREX_PARALLEL_FOR_4D(bx, NQ, i, j, k, n,
   {
 
-    Real s[5];
+    Real s[7];
     Real flat = flatn_arr(i,j,k);
     Real sm;
     Real sp;
 
     if (idir == 0) {
+      s[im3] = q_arr(i-3,j,k,n);
       s[im2] = q_arr(i-2,j,k,n);
       s[im1] = q_arr(i-1,j,k,n);
       s[i0]  = q_arr(i,j,k,n);
       s[ip1] = q_arr(i+1,j,k,n);
       s[ip2] = q_arr(i+2,j,k,n);
+      s[ip3] = q_arr(i+3,j,k,n);
 
     } else if (idir == 1) {
+      s[im3] = q_arr(i,j-3,k,n);
       s[im2] = q_arr(i,j-2,k,n);
       s[im1] = q_arr(i,j-1,k,n);
       s[i0]  = q_arr(i,j,k,n);
       s[ip1] = q_arr(i,j+1,k,n);
       s[ip2] = q_arr(i,j+2,k,n);
+      s[ip3] = q_arr(i,j+3,k,n);
 
     } else {
+      s[im3] = q_arr(i,j,k-3,n);
       s[im2] = q_arr(i,j,k-2,n);
       s[im1] = q_arr(i,j,k-1,n);
       s[i0]  = q_arr(i,j,k,n);
       s[ip1] = q_arr(i,j,k+1,n);
       s[ip2] = q_arr(i,j,k+2,n);
+      s[ip3] = q_arr(i,j,k+3,n);
 
     }
 

--- a/Source/hydro/Castro_mol.cpp
+++ b/Source/hydro/Castro_mol.cpp
@@ -274,6 +274,17 @@ Castro::mol_ppm_reconstruct(const Box& bx,
                             Array4<Real> const qm,
                             Array4<Real> const qp) {
 
+  // special care for reflecting BCs
+  const int* lo_bc = phys_bc.lo();
+  const int* hi_bc = phys_bc.hi();
+
+  const auto domlo = geom.Domain().loVect3d();
+  const auto domhi = geom.Domain().hiVect3d();
+
+  bool lo_bc_test = lo_bc[idir] == Symmetry;
+  bool hi_bc_test = hi_bc[idir] == Symmetry;
+
+
   AMREX_PARALLEL_FOR_4D(bx, NQ, i, j, k, n,
   {
 
@@ -314,7 +325,9 @@ Castro::mol_ppm_reconstruct(const Box& bx,
 
     }
 
-    ppm_reconstruct(s, flat, sm, sp);
+    ppm_reconstruct(s, i, j, k, idir,
+                    lo_bc_test, hi_bc_test, domlo, domhi,
+                    flat, sm, sp);
 
     if (idir == 0) {
       // right state at i-1/2

--- a/Source/hydro/Castro_mol.cpp
+++ b/Source/hydro/Castro_mol.cpp
@@ -277,12 +277,13 @@ Castro::mol_ppm_reconstruct(const Box& bx,
   AMREX_PARALLEL_FOR_4D(bx, NQ, i, j, k, n,
   {
 
-    Real s[7];
+    Real s[8];
     Real flat = flatn_arr(i,j,k);
     Real sm;
     Real sp;
 
     if (idir == 0) {
+      s[im4] = q_arr(i-4,j,k,n);
       s[im3] = q_arr(i-3,j,k,n);
       s[im2] = q_arr(i-2,j,k,n);
       s[im1] = q_arr(i-1,j,k,n);
@@ -292,6 +293,7 @@ Castro::mol_ppm_reconstruct(const Box& bx,
       s[ip3] = q_arr(i+3,j,k,n);
 
     } else if (idir == 1) {
+      s[im4] = q_arr(i,j-4,k,n);
       s[im3] = q_arr(i,j-3,k,n);
       s[im2] = q_arr(i,j-2,k,n);
       s[im1] = q_arr(i,j-1,k,n);
@@ -301,6 +303,7 @@ Castro::mol_ppm_reconstruct(const Box& bx,
       s[ip3] = q_arr(i,j+3,k,n);
 
     } else {
+      s[im4] = q_arr(i,j,k-4,n);
       s[im3] = q_arr(i,j,k-3,n);
       s[im2] = q_arr(i,j,k-2,n);
       s[im1] = q_arr(i,j,k-1,n);

--- a/Source/hydro/Castro_mol.cpp
+++ b/Source/hydro/Castro_mol.cpp
@@ -288,13 +288,12 @@ Castro::mol_ppm_reconstruct(const Box& bx,
   AMREX_PARALLEL_FOR_4D(bx, NQ, i, j, k, n,
   {
 
-    Real s[8];
+    Real s[7];
     Real flat = flatn_arr(i,j,k);
     Real sm;
     Real sp;
 
     if (idir == 0) {
-      s[im4] = q_arr(i-4,j,k,n);
       s[im3] = q_arr(i-3,j,k,n);
       s[im2] = q_arr(i-2,j,k,n);
       s[im1] = q_arr(i-1,j,k,n);
@@ -304,7 +303,6 @@ Castro::mol_ppm_reconstruct(const Box& bx,
       s[ip3] = q_arr(i+3,j,k,n);
 
     } else if (idir == 1) {
-      s[im4] = q_arr(i,j-4,k,n);
       s[im3] = q_arr(i,j-3,k,n);
       s[im2] = q_arr(i,j-2,k,n);
       s[im1] = q_arr(i,j-1,k,n);
@@ -314,7 +312,6 @@ Castro::mol_ppm_reconstruct(const Box& bx,
       s[ip3] = q_arr(i,j+3,k,n);
 
     } else {
-      s[im4] = q_arr(i,j,k-4,n);
       s[im3] = q_arr(i,j,k-3,n);
       s[im2] = q_arr(i,j,k-2,n);
       s[im1] = q_arr(i,j,k-1,n);

--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -47,7 +47,7 @@ ppm_reconstruct(const Real* s,
 
   } else if (hi_bc_test && ((idir == 0 && i == domhi[0]) ||
                             (idir == 1 && j == domhi[1]) ||
-                            (idir == 2 && j == domhi[2]))) {
+                            (idir == 2 && k == domhi[2]))) {
 
     // use a stencil for when the current zone is on the right physical boundary
     // then the left interface is one zone away from the physical boundary
@@ -99,7 +99,7 @@ ppm_reconstruct(const Real* s,
 
   } else if (hi_bc_test && ((idir == 0 && i == domhi[0]) ||
                             (idir == 1 && j == domhi[1]) ||
-                            (idir == 2 && j == domhi[2]))) {
+                            (idir == 2 && k == domhi[2]))) {
 
     // use a stencil for when the current zone is on the right physical boundary
     // then the right interface is on the physical boundary

--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -6,44 +6,91 @@
 
 using namespace amrex;
 
-constexpr int im3 = 0
-constexpr int im2 = 1;
-constexpr int im1 = 2;
-constexpr int i0 = 3;
-constexpr int ip1 = 4;
-constexpr int ip2 = 5;
-constexpr int ip3 = 6;
+constexpr int im4 = 0;
+constexpr int im3 = 1;
+constexpr int im2 = 2;
+constexpr int im1 = 3;
+constexpr int i0 = 4;
+constexpr int ip1 = 5;
+constexpr int ip2 = 6;
+constexpr int ip3 = 7;
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void
 ppm_reconstruct(const Real* s,
+                const int i, const int j, const int k, const int idir,
                 const Real flatn, Real& sm, Real& sp) {
 
   // This routine does the reconstruction of the zone data into a parabola.
 
-  // Compute van Leer slopes
+  // special care for reflecting BCs
+  const int* lo_bc = phys_bc.lo();
+  const int* hi_bc = phys_bc.hi();
 
-  Real dsl = 2.0_rt * (s[im1] - s[im2]);
-  Real dsr = 2.0_rt * (s[i0] - s[im1]);
+  const auto domlo = geom.Domain().loVect3d();
+  const auto domhi = geom.Domain().hiVect3d();
 
-  Real dsvl_l = 0.0_rt;
-  if (dsl*dsr > 0.0_rt) {
-    Real dsc = 0.5_rt * (s[i0] - s[im2]);
-    dsvl_l = std::copysign(1.0_rt, dsc) * amrex::min(std::abs(dsc),amrex::min(std::abs(dsl),std::abs(dsr)));
+  bool lo_bc_test = lo_bc[idir] == Symmetry;
+  bool hi_bc_test = hi_bc[idir] == Symmetry;
+
+  if (lo_bc_test && ((idir == 0 && i == domlo[0]+1) ||
+                     (idir == 1 && j == domlo[1]+1) ||
+                     (idir == 2 && k == domlo[2]+1))) {
+
+    // use a stencil for the interface that is one zone from the left
+    // physical boundary, MC Eq. 22
+    sm  = (1.0_rt/12.0_rt)*(3.0_rt*s[im1] + 13.0_rt*s[i0] - 5.0_rt*s[ip1] + s[ip2]);
+
+  } else if (lo_bc_test && ((idir == 0 && i == domlo[0]) ||
+                            (idir == 1 && j == domlo[1]) ||
+                            (idir == 2 && k == domlo[2]))) {
+
+    // use a stencil for when the interface is on the left physical
+    // boundary, MC Eq. 21
+    sm = (1.0_rt/12.0_rt)*(25.0_rt*s[i0] - 23.0_rt*s[ip1] + 13.0_rt*s[ip2] - 3.0_rt*s[ip3]);
+
+  } else if (hi_bc_test && ((idir == 0 && i == domhi[0]) ||
+                            (idir == 1 && j == domhi[1]) ||
+                            (idir == 2 && j == domhi[2]))) {
+
+    // use a stencil for the interface that is one zone from the right
+    // physical boundary, MC Eq. 22
+    sm = (1.0_rt/12.0_rt)*(3.0_rt*s[i0] + 13.0_rt*s[im1] - 5.0_rt*s[im2] + s[im3]);
+
+  } else if (hi_bc_test && ((idir == 0 && i == domhi[0]+1) ||
+                            (idir == 1 && j == domhi[1]+1) ||
+                            (idir == 2 && j == domhi[2]+1))) {
+
+    // use a stencil for when the interface is on the right physical
+    // boundary MC Eq. 21
+    sm = (1.0_rt/12.0_rt)*(25.0_rt*s[im1] - 23.0_rt*s[im2] + 13.0_rt*s[im3] - 3.0_rt*s[im4]);
+
+  } else {
+
+    // Compute van Leer slopes
+
+    Real dsl = 2.0_rt * (s[im1] - s[im2]);
+    Real dsr = 2.0_rt * (s[i0] - s[im1]);
+
+    Real dsvl_l = 0.0_rt;
+    if (dsl*dsr > 0.0_rt) {
+      Real dsc = 0.5_rt * (s[i0] - s[im2]);
+      dsvl_l = std::copysign(1.0_rt, dsc) * amrex::min(std::abs(dsc),amrex::min(std::abs(dsl),std::abs(dsr)));
+    }
+
+    dsl = 2.0_rt * (s[i0] - s[im1]);
+    dsr = 2.0_rt * (s[ip1] - s[i0]);
+
+    Real dsvl_r = 0.0_rt;
+    if (dsl*dsr > 0.0_rt) {
+      Real dsc = 0.5_rt * (s[ip1] - s[im1]);
+      dsvl_r = std::copysign(1.0_rt, dsc) * amrex::min(std::abs(dsc),amrex::min(std::abs(dsl),std::abs(dsr)));
+    }
+
+    // Interpolate s to edges
+
+    sm = 0.5_rt * (s[i0] + s[im1]) - (1.0_rt/6.0_rt) * (dsvl_r - dsvl_l);
   }
-
-  dsl = 2.0_rt * (s[i0] - s[im1]);
-  dsr = 2.0_rt * (s[ip1] - s[i0]);
-
-  Real dsvl_r = 0.0_rt;
-  if (dsl*dsr > 0.0_rt) {
-    Real dsc = 0.5_rt * (s[ip1] - s[im1]);
-    dsvl_r = std::copysign(1.0_rt, dsc) * amrex::min(std::abs(dsc),amrex::min(std::abs(dsl),std::abs(dsr)));
-  }
-
-  // Interpolate s to edges
-
-  sm = 0.5_rt * (s[i0] + s[im1]) - (1.0_rt/6.0_rt) * (dsvl_r - dsvl_l);
 
   // Make sure sedge lies in between adjacent cell-centered values
 

--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -6,11 +6,13 @@
 
 using namespace amrex;
 
-constexpr int im2 = 0;
-constexpr int im1 = 1;
-constexpr int i0 = 2;
-constexpr int ip1 = 3;
-constexpr int ip2 = 4;
+constexpr int im3 = 0
+constexpr int im2 = 1;
+constexpr int im1 = 2;
+constexpr int i0 = 3;
+constexpr int ip1 = 4;
+constexpr int ip2 = 5;
+constexpr int ip3 = 6;
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void

--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -19,19 +19,12 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void
 ppm_reconstruct(const Real* s,
                 const int i, const int j, const int k, const int idir,
+                const bool lo_bc_test, const bool hi_bc_test,
+                GpuArray<int, 3> const domlo, GpuArray<int, 3> const domhi,
                 const Real flatn, Real& sm, Real& sp) {
 
   // This routine does the reconstruction of the zone data into a parabola.
 
-  // special care for reflecting BCs
-  const int* lo_bc = phys_bc.lo();
-  const int* hi_bc = phys_bc.hi();
-
-  const auto domlo = geom.Domain().loVect3d();
-  const auto domhi = geom.Domain().hiVect3d();
-
-  bool lo_bc_test = lo_bc[idir] == Symmetry;
-  bool hi_bc_test = hi_bc[idir] == Symmetry;
 
   if (lo_bc_test && ((idir == 0 && i == domlo[0]+1) ||
                      (idir == 1 && j == domlo[1]+1) ||

--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -6,14 +6,13 @@
 
 using namespace amrex;
 
-constexpr int im4 = 0;
-constexpr int im3 = 1;
-constexpr int im2 = 2;
-constexpr int im1 = 3;
-constexpr int i0 = 4;
-constexpr int ip1 = 5;
-constexpr int ip2 = 6;
-constexpr int ip3 = 7;
+constexpr int im3 = 0;
+constexpr int im2 = 1;
+constexpr int im1 = 2;
+constexpr int i0 = 3;
+constexpr int ip1 = 4;
+constexpr int ip2 = 5;
+constexpr int ip3 = 6;
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void
@@ -24,39 +23,35 @@ ppm_reconstruct(const Real* s,
                 const Real flatn, Real& sm, Real& sp) {
 
   // This routine does the reconstruction of the zone data into a parabola.
+  // Note the i, j, k here refer to zone centers, not interfaces
 
+  // first we compute s_{i-1/2} -- the left interface value for zone i
 
-  if (lo_bc_test && ((idir == 0 && i == domlo[0]+1) ||
-                     (idir == 1 && j == domlo[1]+1) ||
-                     (idir == 2 && k == domlo[2]+1))) {
+  if (lo_bc_test && ((idir == 0 && i == domlo[0]) ||
+                     (idir == 1 && j == domlo[1]) ||
+                     (idir == 2 && k == domlo[2]))) {
 
-    // use a stencil for the interface that is one zone from the left
-    // physical boundary, MC Eq. 22
-    sm  = (1.0_rt/12.0_rt)*(3.0_rt*s[im1] + 13.0_rt*s[i0] - 5.0_rt*s[ip1] + s[ip2]);
-
-  } else if (lo_bc_test && ((idir == 0 && i == domlo[0]) ||
-                            (idir == 1 && j == domlo[1]) ||
-                            (idir == 2 && k == domlo[2]))) {
-
-    // use a stencil for when the interface is on the left physical
-    // boundary, MC Eq. 21
+    // use a stencil for when the current zone is on the left physical
+    // boundary.  Then the left interface is on the physical boundary,
+    // MC Eq. 21
     sm = (1.0_rt/12.0_rt)*(25.0_rt*s[i0] - 23.0_rt*s[ip1] + 13.0_rt*s[ip2] - 3.0_rt*s[ip3]);
+
+  } else if (lo_bc_test && ((idir == 0 && i == domlo[0]+1) ||
+                            (idir == 1 && j == domlo[1]+1) ||
+                            (idir == 2 && k == domlo[2]+1))) {
+
+    // use a stencil for when the current zone is one zone away from
+    // the left physical boundary, and then the left interface is one
+    // zone away from the boundary, MC Eq. 22
+    sm  = (1.0_rt/12.0_rt)*(3.0_rt*s[im1] + 13.0_rt*s[i0] - 5.0_rt*s[ip1] + s[ip2]);
 
   } else if (hi_bc_test && ((idir == 0 && i == domhi[0]) ||
                             (idir == 1 && j == domhi[1]) ||
                             (idir == 2 && j == domhi[2]))) {
 
-    // use a stencil for the interface that is one zone from the right
-    // physical boundary, MC Eq. 22
+    // use a stencil for when the current zone is on the right physical boundary
+    // then the left interface is one zone away from the physical boundary
     sm = (1.0_rt/12.0_rt)*(3.0_rt*s[i0] + 13.0_rt*s[im1] - 5.0_rt*s[im2] + s[im3]);
-
-  } else if (hi_bc_test && ((idir == 0 && i == domhi[0]+1) ||
-                            (idir == 1 && j == domhi[1]+1) ||
-                            (idir == 2 && j == domhi[2]+1))) {
-
-    // use a stencil for when the interface is on the right physical
-    // boundary MC Eq. 21
-    sm = (1.0_rt/12.0_rt)*(25.0_rt*s[im1] - 23.0_rt*s[im2] + 13.0_rt*s[im3] - 3.0_rt*s[im4]);
 
   } else {
 
@@ -91,29 +86,61 @@ ppm_reconstruct(const Real* s,
   sm = amrex::min(sm, amrex::max(s[i0], s[im1]));
 
 
-  // Compute van Leer slopes
+  // now we compute s_{i+1/2} -- the right interface value for zone i
 
-  dsl = 2.0_rt * (s[i0] - s[im1]);
-  dsr = 2.0_rt * (s[ip1] - s[i0]);
+  if (lo_bc_test && ((idir == 0 && i == domlo[0]) ||
+                     (idir == 1 && j == domlo[1]) ||
+                     (idir == 2 && k == domlo[2]))) {
 
-  dsvl_l = 0.0_rt;
-  if (dsl*dsr > 0.0_rt) {
-    Real dsc = 0.5_rt * (s[ip1] - s[im1]);
-    dsvl_l = std::copysign(1.0_rt, dsc) * amrex::min(std::abs(dsc), amrex::min(std::abs(dsl),std::abs(dsr)));
+    // use a stencil for when the current zone is on the left physical
+    // boundary.  Then the right interface is one zone away from the
+    // physical boundary,
+    sp = (1.0_rt/12.0_rt)*(3.0_rt*s[i0] + 13.0_rt*s[ip1] - 5.0_rt*s[ip2] + s[ip3]);
+
+  } else if (hi_bc_test && ((idir == 0 && i == domhi[0]) ||
+                            (idir == 1 && j == domhi[1]) ||
+                            (idir == 2 && j == domhi[2]))) {
+
+    // use a stencil for when the current zone is on the right physical boundary
+    // then the right interface is on the physical boundary
+    sp = (1.0_rt/12.0_rt)*(25.0_rt*s[i0] - 23.0_rt*s[im1] + 13.0_rt*s[im2] - 3.0_rt*s[im3]);
+
+  } else if (hi_bc_test && ((idir == 0 && i == domhi[0]-1) ||
+                            (idir == 1 && j == domhi[1]-1) ||
+                            (idir == 2 && k == domhi[2]-1))) {
+
+    // use a stencil for when the current zone is one zone away from
+    // the right physical boundary, and then the right interface is one
+    // zone away from the boundary
+    sp  = (1.0_rt/12.0_rt)*(3.0_rt*s[ip1] + 13.0_rt*s[i0] - 5.0_rt*s[im1] + s[im2]);
+
+  } else {
+
+    // Compute van Leer slopes
+
+    Real dsl = 2.0_rt * (s[i0] - s[im1]);
+    Real dsr = 2.0_rt * (s[ip1] - s[i0]);
+
+    Real dsvl_l = 0.0_rt;
+    if (dsl*dsr > 0.0_rt) {
+      Real dsc = 0.5_rt * (s[ip1] - s[im1]);
+      dsvl_l = std::copysign(1.0_rt, dsc) * amrex::min(std::abs(dsc), amrex::min(std::abs(dsl),std::abs(dsr)));
+    }
+
+    dsl = 2.0_rt * (s[ip1] - s[i0]);
+    dsr = 2.0_rt * (s[ip2] - s[ip1]);
+
+    Real dsvl_r = 0.0_rt;
+    if (dsl*dsr > 0.0_rt) {
+      Real dsc = 0.5_rt * (s[ip2] - s[i0]);
+      dsvl_r = std::copysign(1.0_rt, dsc) * amrex::min(std::abs(dsc), amrex::min(std::abs(dsl),std::abs(dsr)));
+    }
+
+    // Interpolate s to edges
+
+    sp = 0.5_rt * (s[ip1] + s[i0]) - (1.0_rt/6.0_rt) * (dsvl_r - dsvl_l);
+
   }
-
-  dsl = 2.0_rt * (s[ip1] - s[i0]);
-  dsr = 2.0_rt * (s[ip2] - s[ip1]);
-
-  dsvl_r = 0.0_rt;
-  if (dsl*dsr > 0.0_rt) {
-    Real dsc = 0.5_rt * (s[ip2] - s[i0]);
-    dsvl_r = std::copysign(1.0_rt, dsc) * amrex::min(std::abs(dsc), amrex::min(std::abs(dsl),std::abs(dsr)));
-  }
-
-  // Interpolate s to edges
-
-  sp = 0.5_rt * (s[ip1] + s[i0]) - (1.0_rt/6.0_rt) * (dsvl_r - dsvl_l);
 
   // Make sure sedge lies in between adjacent cell-centered values
 

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -155,7 +155,7 @@ Castro::trace_ppm(const Box& bx,
 
     // do the parabolic reconstruction and compute the
     // integrals under the characteristic waves
-    Real s[7];
+    Real s[8];
     Real flat = flatn(i,j,k);
     Real sm;
     Real sp;
@@ -168,6 +168,7 @@ Castro::trace_ppm(const Box& bx,
       if (n == QTEMP) continue;
 
       if (idir == 0) {
+        s[im4] = q_arr(i-4,j,k,n);
         s[im3] = q_arr(i-3,j,k,n);
         s[im2] = q_arr(i-2,j,k,n);
         s[im1] = q_arr(i-1,j,k,n);
@@ -177,6 +178,7 @@ Castro::trace_ppm(const Box& bx,
         s[ip3] = q_arr(i+3,j,k,n);
 
       } else if (idir == 1) {
+        s[im4] = q_arr(i,j-4,k,n);
         s[im3] = q_arr(i,j-3,k,n);
         s[im2] = q_arr(i,j-2,k,n);
         s[im1] = q_arr(i,j-1,k,n);
@@ -186,6 +188,7 @@ Castro::trace_ppm(const Box& bx,
         s[ip3] = q_arr(i,j+3,k,n);
 
       } else {
+        s[im4] = q_arr(i,j,k-4,n);
         s[im3] = q_arr(i,j,k-3,n);
         s[im2] = q_arr(i,j,k-2,n);
         s[im1] = q_arr(i,j,k-1,n);
@@ -207,6 +210,7 @@ Castro::trace_ppm(const Box& bx,
     Real Im_gc[3];
 
     if (idir == 0) {
+        s[im4] = qaux_arr(i-4,j,k,QGAMC);
         s[im3] = qaux_arr(i-3,j,k,QGAMC);
         s[im2] = qaux_arr(i-2,j,k,QGAMC);
         s[im1] = qaux_arr(i-1,j,k,QGAMC);
@@ -216,6 +220,7 @@ Castro::trace_ppm(const Box& bx,
         s[ip3] = qaux_arr(i+3,j,k,QGAMC);
 
     } else if (idir == 1) {
+        s[im4] = qaux_arr(i,j-4,k,QGAMC);
         s[im3] = qaux_arr(i,j-3,k,QGAMC);
         s[im2] = qaux_arr(i,j-2,k,QGAMC);
         s[im1] = qaux_arr(i,j-1,k,QGAMC);
@@ -225,6 +230,7 @@ Castro::trace_ppm(const Box& bx,
         s[ip3] = qaux_arr(i,j+3,k,QGAMC);
 
     } else {
+        s[im4] = qaux_arr(i,j,k-4,QGAMC);
         s[im3] = qaux_arr(i,j,k-3,QGAMC);
         s[im2] = qaux_arr(i,j,k-2,QGAMC);
         s[im1] = qaux_arr(i,j,k-1,QGAMC);
@@ -278,6 +284,7 @@ Castro::trace_ppm(const Box& bx,
       if (do_trace) {
 
         if (idir == 0) {
+          s[im4] = srcQ(i-4,j,k,n);
           s[im3] = srcQ(i-3,j,k,n);
           s[im2] = srcQ(i-2,j,k,n);
           s[im1] = srcQ(i-1,j,k,n);
@@ -287,6 +294,7 @@ Castro::trace_ppm(const Box& bx,
           s[ip3] = srcQ(i+3,j,k,n);
 
         } else if (idir == 1) {
+          s[im4] = srcQ(i,j-4,k,n);
           s[im3] = srcQ(i,j-3,k,n);
           s[im2] = srcQ(i,j-2,k,n);
           s[im1] = srcQ(i,j-1,k,n);
@@ -296,6 +304,7 @@ Castro::trace_ppm(const Box& bx,
           s[ip3] = srcQ(i,j+3,k,n);
 
         } else {
+          s[im4] = srcQ(i,j,k-4,n);
           s[im3] = srcQ(i,j,k-3,n);
           s[im2] = srcQ(i,j,k-2,n);
           s[im1] = srcQ(i,j,k-1,n);

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -137,6 +137,16 @@ Castro::trace_ppm(const Box& bx,
     qpass_map_p[n] = qpass_map[n];
   }
 
+  // special care for reflecting BCs
+  const int* lo_bc = phys_bc.lo();
+  const int* hi_bc = phys_bc.hi();
+
+  const auto domlo = geom.Domain().loVect3d();
+  const auto domhi = geom.Domain().hiVect3d();
+
+  bool lo_bc_test = lo_bc[idir] == Symmetry;
+  bool hi_bc_test = hi_bc[idir] == Symmetry;
+
   // Trace to left and right edges using upwind PPM
   AMREX_PARALLEL_FOR_3D(bx, i, j, k,
   {
@@ -199,7 +209,9 @@ Castro::trace_ppm(const Box& bx,
 
       }
 
-      ppm_reconstruct(s, flat, sm, sp);
+      ppm_reconstruct(s, i, j, k, idir,
+                      lo_bc_test, hi_bc_test, domlo, domhi,
+                      flat, sm, sp);
       ppm_int_profile(sm, sp, s[i0], un, cc, dtdx, Ip[n], Im[n]);
 
     }
@@ -242,7 +254,9 @@ Castro::trace_ppm(const Box& bx,
     }
 
 
-    ppm_reconstruct(s, flat, sm, sp);
+    ppm_reconstruct(s, i, j, k, idir,
+                    lo_bc_test, hi_bc_test, domlo, domhi,
+                    flat, sm, sp);
     ppm_int_profile(sm, sp, s[i0], un, cc, dtdx, Ip_gc, Im_gc);
 
 
@@ -315,7 +329,9 @@ Castro::trace_ppm(const Box& bx,
 
         }
 
-        ppm_reconstruct(s, flat, sm, sp);
+        ppm_reconstruct(s, i, j, k, idir,
+                        lo_bc_test, hi_bc_test, domlo, domhi,
+                        flat, sm, sp);
         ppm_int_profile(sm, sp, s[i0], un, cc, dtdx, Ip_src[n], Im_src[n]);
 
       } else {

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -165,7 +165,7 @@ Castro::trace_ppm(const Box& bx,
 
     // do the parabolic reconstruction and compute the
     // integrals under the characteristic waves
-    Real s[8];
+    Real s[7];
     Real flat = flatn(i,j,k);
     Real sm;
     Real sp;
@@ -178,7 +178,6 @@ Castro::trace_ppm(const Box& bx,
       if (n == QTEMP) continue;
 
       if (idir == 0) {
-        s[im4] = q_arr(i-4,j,k,n);
         s[im3] = q_arr(i-3,j,k,n);
         s[im2] = q_arr(i-2,j,k,n);
         s[im1] = q_arr(i-1,j,k,n);
@@ -188,7 +187,6 @@ Castro::trace_ppm(const Box& bx,
         s[ip3] = q_arr(i+3,j,k,n);
 
       } else if (idir == 1) {
-        s[im4] = q_arr(i,j-4,k,n);
         s[im3] = q_arr(i,j-3,k,n);
         s[im2] = q_arr(i,j-2,k,n);
         s[im1] = q_arr(i,j-1,k,n);
@@ -198,7 +196,6 @@ Castro::trace_ppm(const Box& bx,
         s[ip3] = q_arr(i,j+3,k,n);
 
       } else {
-        s[im4] = q_arr(i,j,k-4,n);
         s[im3] = q_arr(i,j,k-3,n);
         s[im2] = q_arr(i,j,k-2,n);
         s[im1] = q_arr(i,j,k-1,n);
@@ -222,7 +219,6 @@ Castro::trace_ppm(const Box& bx,
     Real Im_gc[3];
 
     if (idir == 0) {
-        s[im4] = qaux_arr(i-4,j,k,QGAMC);
         s[im3] = qaux_arr(i-3,j,k,QGAMC);
         s[im2] = qaux_arr(i-2,j,k,QGAMC);
         s[im1] = qaux_arr(i-1,j,k,QGAMC);
@@ -232,7 +228,6 @@ Castro::trace_ppm(const Box& bx,
         s[ip3] = qaux_arr(i+3,j,k,QGAMC);
 
     } else if (idir == 1) {
-        s[im4] = qaux_arr(i,j-4,k,QGAMC);
         s[im3] = qaux_arr(i,j-3,k,QGAMC);
         s[im2] = qaux_arr(i,j-2,k,QGAMC);
         s[im1] = qaux_arr(i,j-1,k,QGAMC);
@@ -242,7 +237,6 @@ Castro::trace_ppm(const Box& bx,
         s[ip3] = qaux_arr(i,j+3,k,QGAMC);
 
     } else {
-        s[im4] = qaux_arr(i,j,k-4,QGAMC);
         s[im3] = qaux_arr(i,j,k-3,QGAMC);
         s[im2] = qaux_arr(i,j,k-2,QGAMC);
         s[im1] = qaux_arr(i,j,k-1,QGAMC);
@@ -298,7 +292,6 @@ Castro::trace_ppm(const Box& bx,
       if (do_trace) {
 
         if (idir == 0) {
-          s[im4] = srcQ(i-4,j,k,n);
           s[im3] = srcQ(i-3,j,k,n);
           s[im2] = srcQ(i-2,j,k,n);
           s[im1] = srcQ(i-1,j,k,n);
@@ -308,7 +301,6 @@ Castro::trace_ppm(const Box& bx,
           s[ip3] = srcQ(i+3,j,k,n);
 
         } else if (idir == 1) {
-          s[im4] = srcQ(i,j-4,k,n);
           s[im3] = srcQ(i,j-3,k,n);
           s[im2] = srcQ(i,j-2,k,n);
           s[im1] = srcQ(i,j-1,k,n);
@@ -318,7 +310,6 @@ Castro::trace_ppm(const Box& bx,
           s[ip3] = srcQ(i,j+3,k,n);
 
         } else {
-          s[im4] = srcQ(i,j,k-4,n);
           s[im3] = srcQ(i,j,k-3,n);
           s[im2] = srcQ(i,j,k-2,n);
           s[im1] = srcQ(i,j,k-1,n);

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -155,7 +155,7 @@ Castro::trace_ppm(const Box& bx,
 
     // do the parabolic reconstruction and compute the
     // integrals under the characteristic waves
-    Real s[5];
+    Real s[7];
     Real flat = flatn(i,j,k);
     Real sm;
     Real sp;
@@ -168,25 +168,31 @@ Castro::trace_ppm(const Box& bx,
       if (n == QTEMP) continue;
 
       if (idir == 0) {
+        s[im3] = q_arr(i-3,j,k,n);
         s[im2] = q_arr(i-2,j,k,n);
         s[im1] = q_arr(i-1,j,k,n);
         s[i0]  = q_arr(i,j,k,n);
         s[ip1] = q_arr(i+1,j,k,n);
         s[ip2] = q_arr(i+2,j,k,n);
+        s[ip3] = q_arr(i+3,j,k,n);
 
       } else if (idir == 1) {
+        s[im3] = q_arr(i,j-3,k,n);
         s[im2] = q_arr(i,j-2,k,n);
         s[im1] = q_arr(i,j-1,k,n);
         s[i0]  = q_arr(i,j,k,n);
         s[ip1] = q_arr(i,j+1,k,n);
         s[ip2] = q_arr(i,j+2,k,n);
+        s[ip3] = q_arr(i,j+3,k,n);
 
       } else {
+        s[im3] = q_arr(i,j,k-3,n);
         s[im2] = q_arr(i,j,k-2,n);
         s[im1] = q_arr(i,j,k-1,n);
         s[i0]  = q_arr(i,j,k,n);
         s[ip1] = q_arr(i,j,k+1,n);
         s[ip2] = q_arr(i,j,k+2,n);
+        s[ip3] = q_arr(i,j,k+3,n);
 
       }
 
@@ -201,25 +207,31 @@ Castro::trace_ppm(const Box& bx,
     Real Im_gc[3];
 
     if (idir == 0) {
+        s[im3] = qaux_arr(i-3,j,k,QGAMC);
         s[im2] = qaux_arr(i-2,j,k,QGAMC);
         s[im1] = qaux_arr(i-1,j,k,QGAMC);
         s[i0]  = qaux_arr(i,j,k,QGAMC);
         s[ip1] = qaux_arr(i+1,j,k,QGAMC);
         s[ip2] = qaux_arr(i+2,j,k,QGAMC);
+        s[ip3] = qaux_arr(i+3,j,k,QGAMC);
 
     } else if (idir == 1) {
+        s[im3] = qaux_arr(i,j-3,k,QGAMC);
         s[im2] = qaux_arr(i,j-2,k,QGAMC);
         s[im1] = qaux_arr(i,j-1,k,QGAMC);
         s[i0]  = qaux_arr(i,j,k,QGAMC);
         s[ip1] = qaux_arr(i,j+1,k,QGAMC);
         s[ip2] = qaux_arr(i,j+2,k,QGAMC);
+        s[ip3] = qaux_arr(i,j+3,k,QGAMC);
 
     } else {
+        s[im3] = qaux_arr(i,j,k-3,QGAMC);
         s[im2] = qaux_arr(i,j,k-2,QGAMC);
         s[im1] = qaux_arr(i,j,k-1,QGAMC);
         s[i0]  = qaux_arr(i,j,k,QGAMC);
         s[ip1] = qaux_arr(i,j,k+1,QGAMC);
         s[ip2] = qaux_arr(i,j,k+2,QGAMC);
+        s[ip3] = qaux_arr(i,j,k+3,QGAMC);
 
     }
 
@@ -266,25 +278,31 @@ Castro::trace_ppm(const Box& bx,
       if (do_trace) {
 
         if (idir == 0) {
+          s[im3] = srcQ(i-3,j,k,n);
           s[im2] = srcQ(i-2,j,k,n);
           s[im1] = srcQ(i-1,j,k,n);
           s[i0]  = srcQ(i,j,k,n);
           s[ip1] = srcQ(i+1,j,k,n);
           s[ip2] = srcQ(i+2,j,k,n);
+          s[ip3] = srcQ(i+3,j,k,n);
 
         } else if (idir == 1) {
+          s[im3] = srcQ(i,j-3,k,n);
           s[im2] = srcQ(i,j-2,k,n);
           s[im1] = srcQ(i,j-1,k,n);
           s[i0]  = srcQ(i,j,k,n);
           s[ip1] = srcQ(i,j+1,k,n);
           s[ip2] = srcQ(i,j+2,k,n);
+          s[ip3] = srcQ(i,j+3,k,n);
 
         } else {
+          s[im3] = srcQ(i,j,k-3,n);
           s[im2] = srcQ(i,j,k-2,n);
           s[im1] = srcQ(i,j,k-1,n);
           s[i0]  = srcQ(i,j,k,n);
           s[ip1] = srcQ(i,j,k+1,n);
           s[ip2] = srcQ(i,j,k+2,n);
+          s[ip3] = srcQ(i,j,k+3,n);
 
         }
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This replaces the cubic interpolant that finds the initial edge states for PPM with a one-sided version at symmetry boundaries.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
