### PR TITLE
allow the ambient stuff to apply only in certain directions

### DIFF
--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -233,6 +233,9 @@ hse_reflect_vels             int           0                  y
 # fills physical domain boundaries with the ambient state
 fill_ambient_bc              int           0                  y
 
+# which direction do we do ambient BCs?  -1 = all, 0 = x, 1 = y, 2 = z
+ambient_fill_dir             int           -1                 y
+
 # clamps the ambient material to the ambient temperature
 clamp_ambient_temp           int           0                  y
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

A new parameter, ambient_fill_dir, is introduced to allow the ambient BCs to only apply to outflow in a particular direction.  -1 means all directions, while 0=x, 1=y, 2=z.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
