### PR TITLE
Switch to AMReX ReduceOps reduction approach

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -956,14 +956,15 @@ Castro::initData ()
        // within any small limits
        computeTemp(S_new, cur_time, S_new.nGrow());
 
-       int init_failed_rho = 0;
-       int init_failed_T = 0;
+       ReduceOps<ReduceOpSum, ReduceOpSum> reduce_op;
+       ReduceData<int, int> reduce_data(reduce_op);
+       using ReduceTuple = typename decltype(reduce_data)::Type;
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:init_failed_rho,init_failed_T)
+#pragma omp parallel
 #endif
        for (MFIter mfi(S_new, TilingIfNotGPU()); mfi.isValid(); ++mfi)
-         {
+       {
            const Box& bx = mfi.tilebox();
 
            auto S_arr = S_new.array(mfi);
@@ -971,33 +972,37 @@ Castro::initData ()
            Real lsmall_temp = small_temp;
            Real lsmall_dens = small_dens;
 
-           int* init_failed_rho_d = AMREX_MFITER_REDUCE_SUM(&init_failed_rho);
-           int* init_failed_T_d = AMREX_MFITER_REDUCE_SUM(&init_failed_T);
-
-           AMREX_PARALLEL_FOR_3D(bx, i, j, k,
+           reduce_op.eval(bx, reduce_data,
+           [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
            {
+               // if the problem tried to initialize a thermodynamic
+               // state that is at or below small_temp, then we abort.
+               // This is dangerous and we should recommend a smaller
+               // small_temp
+               int T_failed = 0;
+               if (S_arr(i,j,k,UTEMP) < lsmall_temp * 1.001) {
+                   T_failed = 1;
+               }
 
-             // if the problem tried to initialize a thermodynamic
-             // state that is at or below small_temp, then we abort.
-             // This is dangerous and we should recommend a smaller
-             // small_temp
-             if (S_arr(i,j,k,UTEMP) < lsmall_temp * 1.001) {
-                 Gpu::Atomic::Add(init_failed_T_d, 1);
-             }
+               int rho_failed = 0;
+               if (S_arr(i,j,k,URHO) < lsmall_dens * 1.001) {
+                   rho_failed = 1;
+               }
 
-             if (S_arr(i,j,k,URHO) < lsmall_dens * 1.001) {
-                 Gpu::Atomic::Add(init_failed_rho_d, 1);
-             }
-
+               return {T_failed, rho_failed};
            });
 
-         }
+       }
 
-       if (init_failed_rho != 0.0) {
+       ReduceTuple hv = reduce_data.value();
+       int init_failed_T   = amrex::get<0>(hv);
+       int init_failed_rho = amrex::get<1>(hv);
+
+       if (init_failed_rho != 0) {
          amrex::Error("Error: initial data has rho <~ small_dens");
        }
 
-       if (init_failed_T != 0.0) {
+       if (init_failed_T != 0) {
          amrex::Error("Error: initial data has T <~ small_temp");
        }
 

--- a/Source/driver/sum_utils.cpp
+++ b/Source/driver/sum_utils.cpp
@@ -28,10 +28,12 @@ Castro::volWgtSum (const std::string& name,
         MultiFab::Multiply(*mf, mask, 0, 0, 1, 0);
     }
 
-    Real sum = 0.0;
+    ReduceOps<ReduceOpSum> reduce_op;
+    ReduceData<Real> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:sum)
+#pragma omp parallel
 #endif    
     for (MFIter mfi(*mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -45,13 +47,16 @@ Castro::volWgtSum (const std::string& name,
         // whatever quantity is passed in, not strictly the "mass".
         //
 
-        Real* sum_d = AMREX_MFITER_REDUCE_SUM(&sum);
-
-        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(box, i, j, k,
+        reduce_op.eval(box, reduce_data,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
         {
-            Gpu::Atomic::Add(sum_d, fab(i,j,k) * vol(i,j,k));
+            return {fab(i,j,k) * vol(i,j,k)};
         });
+
     }
+
+    ReduceTuple hv = reduce_data.value();
+    Real sum = amrex::get<0>(hv);
 
     if (!local)
         ParallelDescriptor::ReduceRealSum(sum);
@@ -76,10 +81,12 @@ Castro::volWgtSquaredSum (const std::string& name,
         MultiFab::Multiply(*mf, mask, 0, 0, 1, 0);
     }
 
-    Real sum = 0.0;
+    ReduceOps<ReduceOpSum> reduce_op;
+    ReduceData<Real> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:sum)
+#pragma omp parallel
 #endif    
     for (MFIter mfi(*mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -93,13 +100,16 @@ Castro::volWgtSquaredSum (const std::string& name,
         // whatever quantity is passed in, not strictly the "mass".
         //
 
-        Real* sum_d = AMREX_MFITER_REDUCE_SUM(&sum);
-
-        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(box, i, j, k,
+        reduce_op.eval(box, reduce_data,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
         {
-            Gpu::Atomic::Add(sum_d, fab(i,j,k) * fab(i,j,k) * vol(i,j,k));
+            return {fab(i,j,k) * fab(i,j,k) * vol(i,j,k)};
         });
+
     }
+
+    ReduceTuple hv = reduce_data.value();
+    Real sum = amrex::get<0>(hv);
 
     if (!local)
         ParallelDescriptor::ReduceRealSum(sum);
@@ -125,13 +135,15 @@ Castro::locWgtSum (const std::string& name,
         MultiFab::Multiply(*mf, mask, 0, 0, 1, 0);
     }
 
-    Real sum = 0.0;
+    ReduceOps<ReduceOpSum> reduce_op;
+    ReduceData<Real> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
 
     auto dx     = geom.CellSizeArray();
     auto problo = geom.ProbLoArray();
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:sum)
+#pragma omp parallel
 #endif    
     for (MFIter mfi(*mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -144,9 +156,8 @@ Castro::locWgtSum (const std::string& name,
         // whatever quantity is passed in, not strictly the "mass".
         //
 
-        Real* sum_d = AMREX_MFITER_REDUCE_SUM(&sum);
-
-        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(box, i, j, k,
+        reduce_op.eval(box, reduce_data,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
         {
             Real loc[3];
 
@@ -176,9 +187,12 @@ Castro::locWgtSum (const std::string& name,
                 ds = fab(i,j,k) * loc[2];
             }
 
-            Gpu::Atomic::Add(sum_d, ds);
+            return {ds};
         });
     }
+
+    ReduceTuple hv = reduce_data.value();
+    Real sum = amrex::get<0>(hv);
 
     if (!local)
         ParallelDescriptor::ReduceRealSum(sum);
@@ -206,10 +220,12 @@ Castro::volProductSum (const std::string& name1,
         MultiFab::Multiply(*mf2, mask, 0, 0, 1, 0);
     }
 
-    Real sum = 0.0;
+    ReduceOps<ReduceOpSum> reduce_op;
+    ReduceData<Real> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:sum)
+#pragma omp parallel
 #endif    
     for (MFIter mfi(*mf1, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -219,13 +235,15 @@ Castro::volProductSum (const std::string& name1,
     
         const Box& box = mfi.tilebox();
 
-        Real* sum_d = AMREX_MFITER_REDUCE_SUM(&sum);
-
-        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(box, i, j, k,
+        reduce_op.eval(box, reduce_data,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
         {
-            Gpu::Atomic::Add(sum_d, fab1(i,j,k) * fab2(i,j,k) * vol(i,j,k));
+            return {fab1(i,j,k) * fab2(i,j,k) * vol(i,j,k)};
         });
     }
+
+    ReduceTuple hv = reduce_data.value();
+    Real sum = amrex::get<0>(hv);
 
     if (!local)
         ParallelDescriptor::ReduceRealSum(sum);
@@ -251,13 +269,15 @@ Castro::locSquaredSum (const std::string& name,
         MultiFab::Multiply(*mf, mask, 0, 0, 1, 0);
     }
 
-    Real sum = 0.0;
+    ReduceOps<ReduceOpSum> reduce_op;
+    ReduceData<Real> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
 
     auto dx     = geom.CellSizeArray();
     auto problo = geom.ProbLoArray();
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:sum)
+#pragma omp parallel
 #endif    
     for (MFIter mfi(*mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -265,9 +285,8 @@ Castro::locSquaredSum (const std::string& name,
     
         const Box& box = mfi.tilebox();
 
-        Real* sum_d = AMREX_MFITER_REDUCE_SUM(&sum);
-
-        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(box, i, j, k,
+        reduce_op.eval(box, reduce_data,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
         {
             Real loc[3];
 
@@ -300,9 +319,12 @@ Castro::locSquaredSum (const std::string& name,
                 ds = fab(i,j,k) * (loc[0] * loc[0] + loc[1] * loc[1] + loc[2] * loc[2]);
             }
 
-            Gpu::Atomic::Add(sum_d, ds);
+            return {ds};
         });
     }
+
+    ReduceTuple hv = reduce_data.value();
+    Real sum = amrex::get<0>(hv);
 
     if (!local)
         ParallelDescriptor::ReduceRealSum(sum);

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -242,29 +242,29 @@ Castro::check_for_cfl_violation(const Real dt)
 
     BL_PROFILE("Castro::check_for_cfl_violation()");
 
-    Real courno = -1.0e+200;
-
     auto dx = geom.CellSizeArray();
 
     MultiFab& S_new = get_new_data(State_Type);
 
     int ltime_integration_method = time_integration_method;
 
+    ReduceOps<ReduceOpMax> reduce_op;
+    ReduceData<Real> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+
 #ifdef _OPENMP
-#pragma omp parallel reduction(max:courno)
+#pragma omp parallel
 #endif
     for (MFIter mfi(S_new, hydro_tile_size); mfi.isValid(); ++mfi) {
 
         const Box& bx = mfi.tilebox();
 
-        Real* courno_d = AMREX_MFITER_REDUCE_MAX(&courno);
-
         auto qaux_arr = qaux.array(mfi);
         auto q_arr = q.array(mfi);
 
-        AMREX_PARALLEL_FOR_3D(bx, i, j, k,
+        reduce_op.eval(bx, reduce_data,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
         {
-
             // Compute running max of Courant number over grids
 
             Real dtdx = dt / dx[0];
@@ -287,15 +287,7 @@ Castro::check_for_cfl_violation(const Real dt)
 
                 // CTU integration constraint
 
-                Real courmx = *courno_d;
-                Real courmy = *courno_d;
-                Real courmz = *courno_d;
-
-                courmx = amrex::max(courmx, courx);
-                courmy = amrex::max(courmy, coury);
-                courmz = amrex::max(courmz, courz);
-
-                Gpu::Atomic::Max(courno_d, amrex::max(courmx, courmy, courmz));
+                return {amrex::max(courx, coury, courz)};
 
 #ifndef AMREX_USE_CUDA
                 if (verbose == 1) {
@@ -357,13 +349,16 @@ Castro::check_for_cfl_violation(const Real dt)
                 }
 #endif
 
-                Gpu::Atomic::Max(courno_d, courtmp);
+                return {courtmp};
 
             }
 
         });
 
     }
+
+    ReduceTuple hv = reduce_data.value();
+    Real courno = amrex::get<0>(hv);
 
     ParallelDescriptor::ReduceRealMax(courno);
 


### PR DESCRIPTION

## PR summary

The original approach to reductions in the CUDA Fortran code was to use AMREX_MFITER_REDUCE_SUM, combined with a call to reduce_add, reduce_min, etc. When we switched to C++ with amrex::ParallelFor, we kept the same approach but called the equivalent C++ call from AMReX instead of reduce_add et al. I recently discovered that there were some edge cases where this is broken, and switched entirely to using atomics in commit b881808bbd1f518c60123b8b195c0d18b8bfff36. While the safety issue was fixed, performance of reductions dropped enough that it is now a relevant factor. 

So we are now switching (hopefully for good) to the AMReX reducer implementation that uses ReduceOps, ReduceData, and ReduceTuple. Some examples can be seen in amrex/Tutorials/GPU/ParallelReduce. In this approach we define a tuple of data to reduce over, along with associated reduction operations for each member in the tuple, and then our lambda function returns the data to reduce instead of being a void. The lambda function is evaluated by the reduce operation, and then we get the data at the end with amrex::get(). This operation is thread-safe, so in CUDA we don't need any special handling (that is done by AMReX) and for OpenMP we don't need to do a reduction (it is done atomically behind the scenes in AMReX; this is less efficient but probably doesn't matter for us).

Going forward, all new conversions to C++ that involve reductions should use this approach.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
