### PR TITLE
Set dt_cutoff as fraction of current simulation time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # 20.05
 
+   * The meaning of dt_cutoff has changed: it is now the fraction of the
+     current simulation time which dt may be no smaller than, instead of
+     being an absolute measure. We now have set a non-zero default
+     (1.e-12) as well. (#865)
+
    * Backwards compatibility in restarting from a checkpoint is no longer
      supported. Checkpoints from older versions of the code (as determined
      by the checkpoint version in the CastroHeader file in the checkpoint

--- a/Exec/gravity_tests/DustCollapse/inputs_1d
+++ b/Exec/gravity_tests/DustCollapse/inputs_1d
@@ -43,7 +43,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_2d_halfstar
+++ b/Exec/gravity_tests/DustCollapse/inputs_2d_halfstar
@@ -44,7 +44,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_2d_monopole_regtest
+++ b/Exec/gravity_tests/DustCollapse/inputs_2d_monopole_regtest
@@ -36,7 +36,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_2d_octant
+++ b/Exec/gravity_tests/DustCollapse/inputs_2d_octant
@@ -50,7 +50,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_2d_poisson_regtest
+++ b/Exec/gravity_tests/DustCollapse/inputs_2d_poisson_regtest
@@ -38,7 +38,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_3d_fullstar
+++ b/Exec/gravity_tests/DustCollapse/inputs_3d_fullstar
@@ -42,7 +42,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_3d_monopole_regtest
+++ b/Exec/gravity_tests/DustCollapse/inputs_3d_monopole_regtest
@@ -36,7 +36,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_3d_monopole_regtest_restart
+++ b/Exec/gravity_tests/DustCollapse/inputs_3d_monopole_regtest_restart
@@ -36,7 +36,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_3d_octant
+++ b/Exec/gravity_tests/DustCollapse/inputs_3d_octant
@@ -42,7 +42,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_3d_poisson_regtest
+++ b/Exec/gravity_tests/DustCollapse/inputs_3d_poisson_regtest
@@ -39,7 +39,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.03    # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_3d_poisson_regtest_restart
+++ b/Exec/gravity_tests/DustCollapse/inputs_3d_poisson_regtest_restart
@@ -38,7 +38,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/DustCollapse/inputs_pointmass
+++ b/Exec/gravity_tests/DustCollapse/inputs_pointmass
@@ -36,7 +36,6 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5
 castro.init_shrink    = 0.01
 castro.change_max     = 1.0
-castro.dt_cutoff      = 1.e-10
 castro.limit_fluxes_on_small_dens = 1
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/StarGrav/inputs_1d
+++ b/Exec/gravity_tests/StarGrav/inputs_1d
@@ -35,7 +35,6 @@ castro.do_sponge = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/gravity_tests/StarGrav/inputs_2d
+++ b/Exec/gravity_tests/StarGrav/inputs_2d
@@ -40,7 +40,6 @@ castro.riemann_solver = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/gravity_tests/StarGrav/inputs_2d.test
+++ b/Exec/gravity_tests/StarGrav/inputs_2d.test
@@ -40,7 +40,6 @@ castro.riemann_solver = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/gravity_tests/StarGrav/inputs_3d
+++ b/Exec/gravity_tests/StarGrav/inputs_3d
@@ -35,7 +35,6 @@ castro.do_sponge = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/gravity_tests/code_comp/inputs_2d.sdc4
+++ b/Exec/gravity_tests/code_comp/inputs_2d.sdc4
@@ -43,7 +43,6 @@ castro.sdc_solve_for_rhoe = 1
 gravity.gravity_type = PrescribedGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/gravity_tests/code_comp/inputs_3d
+++ b/Exec/gravity_tests/code_comp/inputs_3d
@@ -36,7 +36,6 @@ castro.ppm_type = 1
 
 gravity.gravity_type = PrescribedGrav
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/gravity_tests/code_comp/inputs_3d.sdc4
+++ b/Exec/gravity_tests/code_comp/inputs_3d.sdc4
@@ -41,7 +41,6 @@ castro.sdc_solve_for_rhoe = 1
 
 gravity.gravity_type = PrescribedGrav
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/gravity_tests/evrard_collapse/inputs
+++ b/Exec/gravity_tests/evrard_collapse/inputs
@@ -32,7 +32,6 @@ gravity.max_multipole_order = 2    # Multipole expansion includes terms up to r*
 gravity.rel_tol = 1.e-10           # Relative tolerance for multigrid solver
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/gravity_tests/evrard_collapse/inputs.test
+++ b/Exec/gravity_tests/evrard_collapse/inputs.test
@@ -30,7 +30,6 @@ gravity.gravity_type = PoissonGrav # Full self-gravity with the Poisson equation
 gravity.max_multipole_order = 2    # Multipole expansion includes terms up to r**(-max_multipole_order)
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/gravity_tests/hse_convergence/inputs.ppm.128
+++ b/Exec/gravity_tests/hse_convergence/inputs.ppm.128
@@ -42,7 +42,6 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.fixed_dt = 7.5e-5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence/inputs.ppm.256
+++ b/Exec/gravity_tests/hse_convergence/inputs.ppm.256
@@ -42,7 +42,6 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.fixed_dt = 3.75e-5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence/inputs.ppm.512
+++ b/Exec/gravity_tests/hse_convergence/inputs.ppm.512
@@ -42,7 +42,6 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.fixed_dt = 1.875e-5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence/inputs.ppm.64
+++ b/Exec/gravity_tests/hse_convergence/inputs.ppm.64
@@ -42,7 +42,6 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.fixed_dt = 1.5e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence/inputs_1d.well_balance
+++ b/Exec/gravity_tests/hse_convergence/inputs_1d.well_balance
@@ -51,7 +51,6 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.fixed_dt = 0.375e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence_general/inputs_1d.128.hse_test
+++ b/Exec/gravity_tests/hse_convergence_general/inputs_1d.128.hse_test
@@ -46,7 +46,6 @@ castro.diffuse_temp = 0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.use_retry      = 1
 castro.max_subcycles = 16
 castro.fixed_dt = 3.75e-8

--- a/Exec/gravity_tests/hse_convergence_general/inputs_1d.256.hse_test
+++ b/Exec/gravity_tests/hse_convergence_general/inputs_1d.256.hse_test
@@ -46,7 +46,6 @@ castro.diffuse_temp = 0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.use_retry      = 1
 castro.max_subcycles = 16
 castro.fixed_dt = 1.875e-8

--- a/Exec/gravity_tests/hse_convergence_general/inputs_1d.512.hse_test
+++ b/Exec/gravity_tests/hse_convergence_general/inputs_1d.512.hse_test
@@ -46,7 +46,6 @@ castro.diffuse_temp = 0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.use_retry      = 1
 castro.max_subcycles = 16
 castro.fixed_dt = 9.375e-9

--- a/Exec/gravity_tests/hydrostatic_adjust/inputs
+++ b/Exec/gravity_tests/hydrostatic_adjust/inputs
@@ -33,7 +33,6 @@ castro.small_temp    = 5.e6
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/gravity_tests/hydrostatic_adjust/inputs-subchandra
+++ b/Exec/gravity_tests/hydrostatic_adjust/inputs-subchandra
@@ -34,7 +34,6 @@ castro.small_temp    = 5.e6
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/HCBubble/inputs-sod-x
+++ b/Exec/hydro_tests/HCBubble/inputs-sod-x
@@ -26,7 +26,6 @@ castro.ppm_type = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/HCBubble/inputs.L0
+++ b/Exec/hydro_tests/HCBubble/inputs.L0
@@ -26,7 +26,6 @@ castro.ppm_type = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/KH/inputs.2d
+++ b/Exec/hydro_tests/KH/inputs.2d
@@ -33,7 +33,6 @@ castro.small_dens = 1.e-4
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/KH/inputs.2d.p3
+++ b/Exec/hydro_tests/KH/inputs.2d.p3
@@ -33,7 +33,6 @@ castro.small_dens = 1.e-4
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/KH/inputs.3d
+++ b/Exec/hydro_tests/KH/inputs.3d
@@ -32,7 +32,6 @@ castro.small_temp = 1.e-4
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Noh/inputs_3d
+++ b/Exec/hydro_tests/Noh/inputs_3d
@@ -26,7 +26,6 @@ castro.small_dens = 1.0e-6
 castro.small_temp = 1.0e-6
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/RT/inputs.dungeon
+++ b/Exec/hydro_tests/RT/inputs.dungeon
@@ -36,7 +36,6 @@ gravity.const_grav   = -1.0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.3     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 0       # timesteps between computing mass

--- a/Exec/hydro_tests/RT/inputs_2d
+++ b/Exec/hydro_tests/RT/inputs_2d
@@ -32,7 +32,6 @@ gravity.const_grav   = -1.0
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.3     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/RT/inputs_2d.particles
+++ b/Exec/hydro_tests/RT/inputs_2d.particles
@@ -32,7 +32,6 @@ gravity.const_grav   = -1.0
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.3     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/RT/inputs_3d
+++ b/Exec/hydro_tests/RT/inputs_3d
@@ -32,7 +32,6 @@ gravity.const_grav   = -1.0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.3     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sedov/inputs.1d.cyl
+++ b/Exec/hydro_tests/Sedov/inputs.1d.cyl
@@ -22,7 +22,6 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/Sedov/inputs.1d.sph
+++ b/Exec/hydro_tests/Sedov/inputs.1d.sph
@@ -23,7 +23,6 @@ castro.do_react = 0
 castro.ppm_type = 2
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/Sedov/inputs.2d.cyl_in_cartcoords
+++ b/Exec/hydro_tests/Sedov/inputs.2d.cyl_in_cartcoords
@@ -22,7 +22,6 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/Sedov/inputs.2d.cyl_in_cartcoords.testsuite
+++ b/Exec/hydro_tests/Sedov/inputs.2d.cyl_in_cartcoords.testsuite
@@ -22,7 +22,6 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/Sedov/inputs.2d.sph_in_cylcoords
+++ b/Exec/hydro_tests/Sedov/inputs.2d.sph_in_cylcoords
@@ -33,7 +33,6 @@ castro.use_flattening = 1
 castro.riemann_solver = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/Sedov/inputs.2d.sph_in_cylcoords.testsuite
+++ b/Exec/hydro_tests/Sedov/inputs.2d.sph_in_cylcoords.testsuite
@@ -33,7 +33,6 @@ castro.use_flattening = 1
 castro.riemann_solver = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/Sedov/inputs.3d.sph
+++ b/Exec/hydro_tests/Sedov/inputs.3d.sph
@@ -23,7 +23,6 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/Sedov/inputs.3d.sph.testsuite
+++ b/Exec/hydro_tests/Sedov/inputs.3d.sph.testsuite
@@ -23,7 +23,6 @@ castro.do_react = 0
 castro.ppm_type = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/Sedov/inputs.mini-Castro
+++ b/Exec/hydro_tests/Sedov/inputs.mini-Castro
@@ -24,7 +24,6 @@ castro.ppm_type = 1
 castro.time_integration_method = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/hydro_tests/Sedov/inputs.mini-Castro.gpu_test
+++ b/Exec/hydro_tests/Sedov/inputs.mini-Castro.gpu_test
@@ -25,7 +25,6 @@ castro.ppm_type = 1
 castro.time_integration_method = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/hydro_tests/Sedov/scaling/sc20/inputs
+++ b/Exec/hydro_tests/Sedov/scaling/sc20/inputs
@@ -22,7 +22,6 @@ castro.do_hydro = 1
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20
 castro.cfl            = 0.5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/hydro_tests/Sod/Figure1/inputs-sod-1d
+++ b/Exec/hydro_tests/Sod/Figure1/inputs-sod-1d
@@ -26,7 +26,6 @@ castro.do_react = 0
 castro.ppm_type = 2
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod/Figure2/inputs-test2-1d
+++ b/Exec/hydro_tests/Sod/Figure2/inputs-test2-1d
@@ -37,7 +37,6 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod/Figure3/inputs-test3-1d
+++ b/Exec/hydro_tests/Sod/Figure3/inputs-test3-1d
@@ -23,7 +23,6 @@ castro.do_react = 0
 castro.ppm_type = 2
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod/inputs-double-rarefaction
+++ b/Exec/hydro_tests/Sod/inputs-double-rarefaction
@@ -28,7 +28,6 @@ castro.small_dens = 1.e-13
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-slowshock-x
+++ b/Exec/hydro_tests/Sod/inputs-slowshock-x
@@ -31,7 +31,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-sod-rt1
+++ b/Exec/hydro_tests/Sod/inputs-sod-rt1
@@ -26,7 +26,6 @@ castro.ppm_type = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-sod-rt2
+++ b/Exec/hydro_tests/Sod/inputs-sod-rt2
@@ -26,7 +26,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-sod-rt3
+++ b/Exec/hydro_tests/Sod/inputs-sod-rt3
@@ -26,7 +26,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-sod-x
+++ b/Exec/hydro_tests/Sod/inputs-sod-x
@@ -26,7 +26,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-sod-y
+++ b/Exec/hydro_tests/Sod/inputs-sod-y
@@ -26,7 +26,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-sod-z
+++ b/Exec/hydro_tests/Sod/inputs-sod-z
@@ -26,7 +26,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod/inputs-test1-helm
@@ -27,7 +27,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-test2-1d
+++ b/Exec/hydro_tests/Sod/inputs-test2-1d
@@ -37,7 +37,7 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod/inputs-test2-helm
@@ -27,7 +27,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-test2-x
+++ b/Exec/hydro_tests/Sod/inputs-test2-x
@@ -23,7 +23,7 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod/inputs-test2-y
+++ b/Exec/hydro_tests/Sod/inputs-test2-y
@@ -24,7 +24,7 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod/inputs-test2-z
+++ b/Exec/hydro_tests/Sod/inputs-test2-z
@@ -23,7 +23,7 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod/inputs-test3-helm
@@ -27,7 +27,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod/inputs-test3-x
+++ b/Exec/hydro_tests/Sod/inputs-test3-x
@@ -23,7 +23,7 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod/inputs-test3-y
+++ b/Exec/hydro_tests/Sod/inputs-test3-y
@@ -23,7 +23,7 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod/inputs-test3-z
+++ b/Exec/hydro_tests/Sod/inputs-test3-z
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 0
 castro.ppm_type = 1
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep

--- a/Exec/hydro_tests/Sod_stellar/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/inputs-test1-helm
@@ -32,7 +32,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/inputs-test1-helm-y
+++ b/Exec/hydro_tests/Sod_stellar/inputs-test1-helm-y
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/inputs-test1-helm-z
+++ b/Exec/hydro_tests/Sod_stellar/inputs-test1-helm-z
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/inputs-test2-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/inputs-test3-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/inputs-test4-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/CW-ev/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/CW-ev/inputs-test1-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/CW-ev/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/CW-ev/inputs-test2-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/CW-ev/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/CW-ev/inputs-test3-helm
@@ -32,7 +32,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/CW-ev/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/CW-ev/inputs-test4-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/CW/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/CW/inputs-test1-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/CW/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/CW/inputs-test2-helm
@@ -32,7 +32,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/CW/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/CW/inputs-test3-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/CW/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/CW/inputs-test4-helm
@@ -32,7 +32,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev-CGF/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev-CGF/inputs-test1-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev-CGF/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev-CGF/inputs-test2-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev-CGF/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev-CGF/inputs-test3-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev-CGF/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev-CGF/inputs-test4-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 0s
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev-dt/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev-dt/inputs-test1-helm
@@ -32,7 +32,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev-dt/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev-dt/inputs-test2-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev-dt/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev-dt/inputs-test3-helm
@@ -32,7 +32,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev-dt/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev-dt/inputs-test4-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev/inputs-test1-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev/inputs-test2-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev/inputs-test3-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ev/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ev/inputs-test4-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-I-ev/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-I-ev/inputs-test1-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-I-ev/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-I-ev/inputs-test2-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-I-ev/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-I-ev/inputs-test3-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-I-ev/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-I-ev/inputs-test4-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-II-ev/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-II-ev/inputs-test1-helm
@@ -32,7 +32,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-II-ev/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-II-ev/inputs-test2-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-II-ev/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-II-ev/inputs-test3-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-II-ev/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-II-ev/inputs-test4-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-III-ev/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-III-ev/inputs-test1-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-III-ev/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-III-ev/inputs-test2-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-III-ev/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-III-ev/inputs-test3-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-III-ev/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC-ppmT-III-ev/inputs-test4-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC/inputs-test1-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC/inputs-test1-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC/inputs-test2-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC/inputs-test2-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC/inputs-test3-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC/inputs-test3-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Sod_stellar/runs/MC/inputs-test4-helm
+++ b/Exec/hydro_tests/Sod_stellar/runs/MC/inputs-test4-helm
@@ -33,7 +33,7 @@ castro.riemann_solver = 1
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/Vortices_LWAcoustics/inputs.2d
+++ b/Exec/hydro_tests/Vortices_LWAcoustics/inputs.2d
@@ -34,7 +34,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/acoustic_pulse/inputs.128.sdc2.testsuite
+++ b/Exec/hydro_tests/acoustic_pulse/inputs.128.sdc2.testsuite
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse/inputs.128.sdc4.testsuite
+++ b/Exec/hydro_tests/acoustic_pulse/inputs.128.sdc4.testsuite
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse/inputs.2d.128
+++ b/Exec/hydro_tests/acoustic_pulse/inputs.2d.128
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse/inputs.2d.256
+++ b/Exec/hydro_tests/acoustic_pulse/inputs.2d.256
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse/inputs.2d.512
+++ b/Exec/hydro_tests/acoustic_pulse/inputs.2d.512
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse/inputs.2d.64
+++ b/Exec/hydro_tests/acoustic_pulse/inputs.2d.64
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse/inputs.2d.64.sdc_ml
+++ b/Exec/hydro_tests/acoustic_pulse/inputs.2d.64.sdc_ml
@@ -25,7 +25,7 @@ castro.time_integration_method = 2
 castro.sdc_order = 2
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse_general/inputs.128
+++ b/Exec/hydro_tests/acoustic_pulse_general/inputs.128
@@ -22,7 +22,6 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse_general/inputs.128.sdc4.testsuite
+++ b/Exec/hydro_tests/acoustic_pulse_general/inputs.128.sdc4.testsuite
@@ -28,7 +28,6 @@ castro.limit_fourth_order = 1
 castro.use_reconstructed_gamma1 = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse_general/inputs.256
+++ b/Exec/hydro_tests/acoustic_pulse_general/inputs.256
@@ -22,7 +22,6 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse_general/inputs.512
+++ b/Exec/hydro_tests/acoustic_pulse_general/inputs.512
@@ -22,7 +22,6 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/acoustic_pulse_general/inputs.64
+++ b/Exec/hydro_tests/acoustic_pulse_general/inputs.64
@@ -22,7 +22,6 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/double_bubble/inputs_2d
+++ b/Exec/hydro_tests/double_bubble/inputs_2d
@@ -41,7 +41,7 @@ gravity.const_grav   = -1.e9
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/double_bubble/inputs_2d.single
+++ b/Exec/hydro_tests/double_bubble/inputs_2d.single
@@ -41,7 +41,7 @@ gravity.const_grav   = -1.e9
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/double_bubble/inputs_2d.single.equal
+++ b/Exec/hydro_tests/double_bubble/inputs_2d.single.equal
@@ -41,7 +41,7 @@ gravity.const_grav   = -1.e9
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/double_bubble/inputs_2d.test
+++ b/Exec/hydro_tests/double_bubble/inputs_2d.test
@@ -41,7 +41,7 @@ gravity.const_grav   = -1.e9
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/double_mach_reflection/inputs.2d
+++ b/Exec/hydro_tests/double_mach_reflection/inputs.2d
@@ -28,7 +28,7 @@ castro.ppm_type = 1
 castro.riemann_solver = 2
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/double_mach_reflection/inputs.2d.test
+++ b/Exec/hydro_tests/double_mach_reflection/inputs.2d.test
@@ -28,7 +28,7 @@ castro.ppm_type = 1
 castro.riemann_solver = 2
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/gamma_law_bubble/inputs_2d.test
+++ b/Exec/hydro_tests/gamma_law_bubble/inputs_2d.test
@@ -41,7 +41,7 @@ gravity.const_grav   = -1.e9
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/gamma_law_bubble/inputs_2d_MAESTRO.big
+++ b/Exec/hydro_tests/gamma_law_bubble/inputs_2d_MAESTRO.big
@@ -51,7 +51,7 @@ gravity.const_grav   = -1.e9
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/gresho_vortex/inputs.2d
+++ b/Exec/hydro_tests/gresho_vortex/inputs.2d
@@ -31,7 +31,7 @@ castro.riemann_solver = 1
 
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/heating_verification/inputs
+++ b/Exec/hydro_tests/heating_verification/inputs
@@ -26,7 +26,7 @@ castro.ppm_type = 1
 castro.hybrid_riemann = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/oddeven/inputs.2d
+++ b/Exec/hydro_tests/oddeven/inputs.2d
@@ -24,7 +24,7 @@ castro.ppm_type = 0
 castro.hybrid_riemann = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/oddeven/inputs.3d
+++ b/Exec/hydro_tests/oddeven/inputs.3d
@@ -25,7 +25,7 @@ castro.hybrid_riemann = 0
 castro.riemann_solver = 2
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/rotating_torus/inputs_3d
+++ b/Exec/hydro_tests/rotating_torus/inputs_3d
@@ -58,7 +58,7 @@ castro.rotational_period = 1.0
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/rotating_torus/inputs_3d.test
+++ b/Exec/hydro_tests/rotating_torus/inputs_3d.test
@@ -56,7 +56,7 @@ castro.rotational_period = 1.0
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 1.e-10  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/symmetry/inputs.1d
+++ b/Exec/hydro_tests/symmetry/inputs.1d
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/symmetry/inputs.2d
+++ b/Exec/hydro_tests/symmetry/inputs.2d
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/symmetry/inputs.3d
+++ b/Exec/hydro_tests/symmetry/inputs.3d
@@ -23,7 +23,7 @@ castro.do_react = 0
 castro.ppm_type = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/hydro_tests/test_convect/inputs_2d
+++ b/Exec/hydro_tests/test_convect/inputs_2d
@@ -42,7 +42,7 @@ gravity.const_grav   = -1.5e10
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/hydro_tests/toy_convect/inputs_2d
+++ b/Exec/hydro_tests/toy_convect/inputs_2d
@@ -35,7 +35,7 @@ gravity.const_grav   = -1.04263053e9
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M2
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M2
@@ -65,7 +65,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M2.mg
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M2.mg
@@ -65,7 +65,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M2.test
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M2.test
@@ -64,7 +64,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M2.test.multid
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M2.test.multid
@@ -64,7 +64,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M5
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M5
@@ -65,7 +65,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg
@@ -66,7 +66,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg.test
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg.test
@@ -65,7 +65,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg.test.multid
+++ b/Exec/radiation_tests/Rad2Tshock/inputs.M5.mg.test.multid
@@ -65,7 +65,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/Rad2Tshock/inputs_y.M5
+++ b/Exec/radiation_tests/Rad2Tshock/inputs_y.M5
@@ -65,7 +65,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/Rad2Tshock/inputs_z.M5
+++ b/Exec/radiation_tests/Rad2Tshock/inputs_z.M5
@@ -65,7 +65,7 @@ castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1 
 #castro.initial_dt     = 0.01
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadBreakout/inputs.1d
+++ b/Exec/radiation_tests/RadBreakout/inputs.1d
@@ -77,7 +77,7 @@ castro.add_ext_src=0            #  Add external source terms
 castro.cfl            = 0.6      # cfl number for hyperbolic system
 castro.init_shrink    = 0.01     # scale back initial timestep
 castro.change_max     = 1.05 
-castro.dt_cutoff      = 1.e-4  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/radiation_tests/RadBreakout/inputs.1d.test
+++ b/Exec/radiation_tests/RadBreakout/inputs.1d.test
@@ -75,7 +75,7 @@ castro.add_ext_src=0            #  Add external source terms
 castro.cfl            = 0.6      # cfl number for hyperbolic system
 castro.init_shrink    = 0.01     # scale back initial timestep
 castro.change_max     = 1.05 
-castro.dt_cutoff      = 1.e-4  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/radiation_tests/RadFront/inputs1d
+++ b/Exec/radiation_tests/RadFront/inputs1d
@@ -64,7 +64,7 @@ castro.small_dens =1.0e-10
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.0e-9 
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt       = 1.3e-12
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadFront/inputs2d
+++ b/Exec/radiation_tests/RadFront/inputs2d
@@ -68,7 +68,7 @@ castro.grav_source_type = 4
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05 #1.0e-9 
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt       = 1.3e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadShestakovBolstad/inputs.common
+++ b/Exec/radiation_tests/RadShestakovBolstad/inputs.common
@@ -60,7 +60,7 @@ castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0
 #castro.initial_dt     = 1.e-12
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt  =  4.5339149910673475e-08   # 1/256
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadSlope/inputs
+++ b/Exec/radiation_tests/RadSlope/inputs
@@ -66,7 +66,7 @@ castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.2 
 #castro.initial_dt     = 5.0e-15
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt       = 1.0e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadSourceTest/inputs-cooling
+++ b/Exec/radiation_tests/RadSourceTest/inputs-cooling
@@ -61,7 +61,7 @@ castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.025
 castro.initial_dt     = 1.e-16
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-11
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadSourceTest/inputs-heating
+++ b/Exec/radiation_tests/RadSourceTest/inputs-heating
@@ -64,7 +64,7 @@ castro.cfl            = 5000.0     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.025
 castro.initial_dt     = 1.e-16
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-11
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadSourceTest/inputs-heating-mg
+++ b/Exec/radiation_tests/RadSourceTest/inputs-heating-mg
@@ -64,7 +64,7 @@ castro.cfl            = 5000.0     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.025
 castro.initial_dt     = 1.e-16
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt       = 1.e-11
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadSphere/inputs
+++ b/Exec/radiation_tests/RadSphere/inputs
@@ -59,7 +59,7 @@ castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.05
 castro.initial_dt     = 1.e-18
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt       = 1.e-15
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadSuOlson/inputs
+++ b/Exec/radiation_tests/RadSuOlson/inputs
@@ -68,7 +68,7 @@ castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.2 
 #castro.initial_dt     = 5.0e-15
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt       = 1.0e-13
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadSuOlsonMG/inputs.common
+++ b/Exec/radiation_tests/RadSuOlsonMG/inputs.common
@@ -64,7 +64,7 @@ castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.2 
 castro.initial_dt     = 5.0e-15
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt       = 3.3356409519815201e-12     # 1e-1 tau
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadThermalWave/inputs.1d
+++ b/Exec/radiation_tests/RadThermalWave/inputs.1d
@@ -40,7 +40,7 @@ amr.probin_file     = probin.1d
 castro.lo_bc       =  3 
 castro.hi_bc       =  2 
 
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.initial_dt     = 1.e-15

--- a/Exec/radiation_tests/RadThermalWave/inputs.1d.test
+++ b/Exec/radiation_tests/RadThermalWave/inputs.1d.test
@@ -39,7 +39,7 @@ amr.probin_file     = probin.1d
 castro.lo_bc       =  3 
 castro.hi_bc       =  2 
 
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.initial_dt     = 1.e-15

--- a/Exec/radiation_tests/RadThermalWave/inputs.2d
+++ b/Exec/radiation_tests/RadThermalWave/inputs.2d
@@ -40,7 +40,7 @@ amr.probin_file     = probin.2d
 castro.lo_bc       =  3    2  
 castro.hi_bc       =  2    2
 
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.initial_dt     = 1.e-15

--- a/Exec/radiation_tests/RadThermalWave/inputs.2d.test
+++ b/Exec/radiation_tests/RadThermalWave/inputs.2d.test
@@ -40,7 +40,7 @@ amr.probin_file     = probin.2d
 castro.lo_bc       =  3    2  
 castro.hi_bc       =  2    2
 
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.initial_dt     = 1.e-15

--- a/Exec/radiation_tests/RadThermalWave/inputs.3d
+++ b/Exec/radiation_tests/RadThermalWave/inputs.3d
@@ -40,7 +40,7 @@ amr.probin_file     = probin.3d
 castro.lo_bc       =  2    2    2
 castro.hi_bc       =  2    2    2
 
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.initial_dt     = 1.e-15

--- a/Exec/radiation_tests/RadThermalWave/inputs.3d.test
+++ b/Exec/radiation_tests/RadThermalWave/inputs.3d.test
@@ -40,7 +40,7 @@ amr.probin_file     = probin.3d
 castro.lo_bc       =  2    2    2
 castro.hi_bc       =  2    2    2
 
-castro.dt_cutoff      = 1.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.initial_dt     = 1.e-15

--- a/Exec/reacting_tests/bubble_convergence/inputs_1d.well_balance
+++ b/Exec/reacting_tests/bubble_convergence/inputs_1d.well_balance
@@ -51,7 +51,7 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt = 0.375e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.128
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.128
@@ -48,7 +48,7 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt = 0.75e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.256
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.256
@@ -48,7 +48,7 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt = 0.375e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.512
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.512
@@ -48,7 +48,7 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt = 0.1875e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.64
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.64
@@ -48,7 +48,7 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt = 1.5e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.well_balance
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.well_balance
@@ -51,7 +51,7 @@ gravity.const_grav   = -1.e10
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.fixed_dt = 0.375e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/reacting_tests/nse_test/inputs
+++ b/Exec/reacting_tests/nse_test/inputs
@@ -37,7 +37,7 @@ castro.small_temp     = 1.e7
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/reacting_tests/reacting_bubble/inputs_2d
+++ b/Exec/reacting_tests/reacting_bubble/inputs_2d
@@ -43,7 +43,7 @@ gravity.const_grav   = -1.5e10
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/reacting_tests/reacting_bubble/inputs_2d_noentropy
+++ b/Exec/reacting_tests/reacting_bubble/inputs_2d_noentropy
@@ -48,7 +48,7 @@ gravity.const_grav   = -1.5e10
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/reacting_tests/reacting_bubble/inputs_2d_test
+++ b/Exec/reacting_tests/reacting_bubble/inputs_2d_test
@@ -43,7 +43,7 @@ gravity.const_grav   = -1.5e10
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/reacting_tests/reacting_bubble/inputs_2d_zoom
+++ b/Exec/reacting_tests/reacting_bubble/inputs_2d_zoom
@@ -47,7 +47,7 @@ gravity.const_grav   = -1.5e10
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/reacting_tests/reacting_bubble/inputs_3d_test
+++ b/Exec/reacting_tests/reacting_bubble/inputs_3d_test
@@ -45,7 +45,7 @@ gravity.const_grav   = -1.5e10
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/reacting_tests/reacting_convergence/inputs.128
+++ b/Exec/reacting_tests/reacting_convergence/inputs.128
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/reacting_tests/reacting_convergence/inputs.128.testsuite
+++ b/Exec/reacting_tests/reacting_convergence/inputs.128.testsuite
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/reacting_tests/reacting_convergence/inputs.256
+++ b/Exec/reacting_tests/reacting_convergence/inputs.256
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/reacting_tests/reacting_convergence/inputs.512
+++ b/Exec/reacting_tests/reacting_convergence/inputs.512
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/reacting_tests/reacting_convergence/inputs.64
+++ b/Exec/reacting_tests/reacting_convergence/inputs.64
@@ -22,7 +22,7 @@ castro.do_hydro = 1
 castro.do_react = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/reacting_tests/reacting_convergence/inputs.64.testsuite.simplified_sdc
+++ b/Exec/reacting_tests/reacting_convergence/inputs.64.testsuite.simplified_sdc
@@ -24,7 +24,7 @@ castro.do_react = 1
 castro.time_integration_method = 3
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/reacting_tests/toy_flame/exploration/inputs.1d.testsuite.temp
+++ b/Exec/reacting_tests/toy_flame/exploration/inputs.1d.testsuite.temp
@@ -31,7 +31,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/reacting_tests/toy_flame/inputs.1d
+++ b/Exec/reacting_tests/toy_flame/inputs.1d
@@ -31,7 +31,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/reacting_tests/toy_flame/inputs.1d.testsuite
+++ b/Exec/reacting_tests/toy_flame/inputs.1d.testsuite
@@ -31,7 +31,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/Detonation/inputs-collision
+++ b/Exec/science/Detonation/inputs-collision
@@ -26,7 +26,7 @@ castro.do_react = 1
 castro.cfl            = 0.5
 castro.init_shrink    = 0.1
 castro.change_max     = 1.05
-castro.dt_cutoff      = 1.e-20
+
 
 castro.small_temp     = 1.e5
 

--- a/Exec/science/Detonation/inputs-collision.testsuite
+++ b/Exec/science/Detonation/inputs-collision.testsuite
@@ -26,7 +26,7 @@ castro.do_react = 1
 castro.cfl            = 0.5
 castro.init_shrink    = 0.1
 castro.change_max     = 1.25
-castro.dt_cutoff      = 1.e-20
+
 
 castro.small_temp     = 1.e5
 

--- a/Exec/science/Detonation/inputs-det-x
+++ b/Exec/science/Detonation/inputs-det-x
@@ -37,7 +37,7 @@ castro.small_temp     = 1.e7
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/Detonation/inputs-det-x.regrid
+++ b/Exec/science/Detonation/inputs-det-x.regrid
@@ -38,7 +38,7 @@ castro.use_post_step_regrid = 1
 castro.cfl            = 0.25    # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/Detonation/inputs-det-x.sdc
+++ b/Exec/science/Detonation/inputs-det-x.sdc
@@ -42,7 +42,7 @@ castro.riemann_solver = 0
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/Detonation/inputs-det-x.sdc.test
+++ b/Exec/science/Detonation/inputs-det-x.sdc.test
@@ -46,7 +46,7 @@ castro.riemann_solver = 0
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.dtnuc_e        = 0.25
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/Detonation/inputs-det-x.sdc2
+++ b/Exec/science/Detonation/inputs-det-x.sdc2
@@ -47,7 +47,7 @@ castro.riemann_solver = 0
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.dtnuc_e = 0.25
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/Detonation/inputs-det-x.simplified_sdc
+++ b/Exec/science/Detonation/inputs-det-x.simplified_sdc
@@ -38,7 +38,7 @@ castro.riemann_solver = 0
 castro.cfl            = 0.75     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/Detonation/inputs-det-x.subch
+++ b/Exec/science/Detonation/inputs-det-x.subch
@@ -37,7 +37,7 @@ castro.riemann_solver = 0
 castro.cfl            = 0.2     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.dtnuc_e = 0.1
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/Detonation/inputs-det-x.test
+++ b/Exec/science/Detonation/inputs-det-x.test
@@ -26,7 +26,7 @@ castro.ppm_type = 1
 castro.cfl            = 0.25     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/Detonation/nse_runs/inputs.big.template.sdc
+++ b/Exec/science/Detonation/nse_runs/inputs.big.template.sdc
@@ -39,7 +39,7 @@ castro.sdc_iters = @@SDC_ITERS@@
 castro.cfl            = @@CFL@@     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/Detonation/nse_runs/inputs.big.template.strang
+++ b/Exec/science/Detonation/nse_runs/inputs.big.template.strang
@@ -39,7 +39,7 @@ castro.time_integration_method = @@method@@
 castro.cfl            = @@CFL@@     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.dtnuc_e        = @@DTNUC_E@@
 castro.use_retry = 1
 castro.max_subcycles = 32

--- a/Exec/science/Detonation/nse_runs/inputs.template.sdc
+++ b/Exec/science/Detonation/nse_runs/inputs.template.sdc
@@ -39,7 +39,7 @@ castro.sdc_iters = @@SDC_ITERS@@
 castro.cfl            = @@CFL@@     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.plot_per_is_exact = 1
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/Detonation/nse_runs/inputs.template.strang
+++ b/Exec/science/Detonation/nse_runs/inputs.template.strang
@@ -38,7 +38,7 @@ castro.time_integration_method = @@method@@
 castro.cfl            = @@CFL@@     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.plot_per_is_exact = 1
 castro.dtnuc_e        = @@DTNUC_E@@
 castro.use_retry      = 1

--- a/Exec/science/Detonation/sdc_tests/inputs.1d.sdc
+++ b/Exec/science/Detonation/sdc_tests/inputs.1d.sdc
@@ -44,7 +44,7 @@ castro.riemann_solver = 0
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.dtnuc_e        = 0.25
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/bwp-rad/inputs_2d
+++ b/Exec/science/bwp-rad/inputs_2d
@@ -52,7 +52,7 @@ gravity.drdxfac = 2
 
 castro.grav_source_type = 4
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/science/bwp-rad/inputs_2d.test
+++ b/Exec/science/bwp-rad/inputs_2d.test
@@ -52,7 +52,7 @@ gravity.drdxfac = 2
 
 castro.grav_source_type = 4
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/science/bwp-rad/inputs_3d
+++ b/Exec/science/bwp-rad/inputs_3d
@@ -34,7 +34,7 @@ castro.do_radiation = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep by this factor
 castro.change_max     = 1.05    # factor by which dt is allowed to change each timestep

--- a/Exec/science/convective_flame/exploration/inputs.2d.template
+++ b/Exec/science/convective_flame/exploration/inputs.2d.template
@@ -53,7 +53,7 @@ castro.rotation_include_centrifugal = 0
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.use_retry      = 1       # retry subcycled times if we detect a CFL violation
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/convective_flame/inputs.2d.test
+++ b/Exec/science/convective_flame/inputs.2d.test
@@ -53,7 +53,7 @@ castro.rotation_include_centarifugal = 0
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.use_retry      = 1       # retry subcycled times if we detect a CFL violation
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/convective_flame/inputs.2d.testsuite
+++ b/Exec/science/convective_flame/inputs.2d.testsuite
@@ -53,7 +53,7 @@ castro.rotation_include_centrifugal = 0
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/convective_flame/inputs.2d_good
+++ b/Exec/science/convective_flame/inputs.2d_good
@@ -53,7 +53,7 @@ castro.rotation_include_centrifugal = 0
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.use_retry      = 1       # retry subcycled times if we detect a CFL violation
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/convective_flame/inputs.3d.test
+++ b/Exec/science/convective_flame/inputs.3d.test
@@ -48,7 +48,7 @@ castro.rotational_period = 0.01
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/flame/flame_wave_tests/aprox13/inputs.1d.flame_wave.boost
+++ b/Exec/science/flame/flame_wave_tests/aprox13/inputs.1d.flame_wave.boost
@@ -35,7 +35,7 @@ castro.diffuse_cond_scale_fac = 10.0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/flame/flame_wave_tests/triple_alpha_plus_cago/inputs.1d.flame_wave.boost
+++ b/Exec/science/flame/flame_wave_tests/triple_alpha_plus_cago/inputs.1d.flame_wave.boost
@@ -36,7 +36,7 @@ castro.diffuse_cond_scale_fac = 10.0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/flame/inputs.1d
+++ b/Exec/science/flame/inputs.1d
@@ -35,7 +35,7 @@ castro.diffuse_cutoff_density = 1.e-2
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/flame/inputs.1d.aprox13
+++ b/Exec/science/flame/inputs.1d.aprox13
@@ -35,7 +35,7 @@ castro.diffuse_cutoff_density = 1.e-2
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/flame/inputs.1d.aprox13.boost
+++ b/Exec/science/flame/inputs.1d.aprox13.boost
@@ -36,7 +36,7 @@ castro.diffuse_cond_scale_fac = 10.0
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/flame/inputs.1d.sdc
+++ b/Exec/science/flame/inputs.1d.sdc
@@ -49,7 +49,7 @@ castro.diffuse_cutoff_density = 1.e-2
 castro.cfl            = 0.75    # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.dtnuc_e        = 0.25
 
 

--- a/Exec/science/flame/inputs.1d.sdc.conv.1024
+++ b/Exec/science/flame/inputs.1d.sdc.conv.1024
@@ -52,7 +52,7 @@ castro.cfl            = 0.75    # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
 castro.fixed_dt = 1.6e-10
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.dtnuc_e        = 0.5
 
 

--- a/Exec/science/flame/inputs.1d.sdc.conv.2048
+++ b/Exec/science/flame/inputs.1d.sdc.conv.2048
@@ -52,7 +52,7 @@ castro.cfl            = 0.75    # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
 castro.fixed_dt = 8.e-11
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.dtnuc_e        = 0.5
 
 

--- a/Exec/science/flame/inputs.1d.sdc.conv.512
+++ b/Exec/science/flame/inputs.1d.sdc.conv.512
@@ -52,7 +52,7 @@ castro.cfl            = 0.75    # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.0     # max time step growth
 castro.fixed_dt = 3.2e-10
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.dtnuc_e        = 0.5
 
 

--- a/Exec/science/flame/inputs.1d.sdc.map
+++ b/Exec/science/flame/inputs.1d.sdc.map
@@ -49,7 +49,7 @@ castro.diffuse_cutoff_density = 1.e-2
 castro.cfl            = 0.75    # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.dtnuc_e        = 0.5
 
 

--- a/Exec/science/flame/inputs.1d.sdc.map.avg
+++ b/Exec/science/flame/inputs.1d.sdc.map.avg
@@ -49,7 +49,7 @@ castro.diffuse_cutoff_density = 1.e-2
 castro.cfl            = 0.75    # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 castro.dtnuc_e        = 0.5
 
 

--- a/Exec/science/flame/inputs.1d.sdc.test
+++ b/Exec/science/flame/inputs.1d.sdc.test
@@ -38,7 +38,7 @@ castro.diffuse_cutoff_density = 1.e-2
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/flame/inputs.1d.sdc.test.3alpha
+++ b/Exec/science/flame/inputs.1d.sdc.test.3alpha
@@ -38,7 +38,7 @@ castro.diffuse_cutoff_density = 1.e-2
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 1.e-15  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/flame_wave/inputs.H_He
+++ b/Exec/science/flame_wave/inputs.H_He
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs.noboost
+++ b/Exec/science/flame_wave/inputs.noboost
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs.noboost.1000Hz
+++ b/Exec/science/flame_wave/inputs.noboost.1000Hz
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs.noboost.3d
+++ b/Exec/science/flame_wave/inputs.noboost.3d
@@ -57,7 +57,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_2d.testsuite
+++ b/Exec/science/flame_wave/inputs_2d.testsuite
@@ -58,7 +58,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/flame_wave/inputs_3d.testsuite
+++ b/Exec/science/flame_wave/inputs_3d.testsuite
@@ -58,7 +58,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/flame_wave/inputs_3d.testsuite.gpu
+++ b/Exec/science/flame_wave/inputs_3d.testsuite.gpu
@@ -58,7 +58,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/flame_wave/inputs_H_He/inputs.H_He.1000Hz
+++ b/Exec/science/flame_wave/inputs_H_He/inputs.H_He.1000Hz
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_H_He/inputs.H_He.2000Hz
+++ b/Exec/science/flame_wave/inputs_H_He/inputs.H_He.2000Hz
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_H_He/inputs.H_He.500Hz
+++ b/Exec/science/flame_wave/inputs_H_He/inputs.H_He.500Hz
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10
+++ b/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10
@@ -58,7 +58,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10.3d
+++ b/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10.3d
@@ -56,7 +56,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10.sdc
+++ b/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10.sdc
@@ -70,7 +70,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.dtnuc_e = 0.1
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10.sdc.small
+++ b/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10.sdc.small
@@ -70,7 +70,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.75     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.dtnuc_e = 0.25
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10_slow
+++ b/Exec/science/flame_wave/inputs_boost/inputs.boost_10_10_slow
@@ -58,7 +58,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_boost/inputs.boost_5_5
+++ b/Exec/science/flame_wave/inputs_boost/inputs.boost_5_5
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_noboost/inputs.noboost.1000Hz
+++ b/Exec/science/flame_wave/inputs_noboost/inputs.noboost.1000Hz
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_noboost/inputs.noboost.2000Hz
+++ b/Exec/science/flame_wave/inputs_noboost/inputs.noboost.2000Hz
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/inputs_noboost/inputs.noboost.500Hz
+++ b/Exec/science/flame_wave/inputs_noboost/inputs.noboost.500Hz
@@ -60,7 +60,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/job_scripts/aprox13/inputs_2d.boost.aprox13
+++ b/Exec/science/flame_wave/job_scripts/aprox13/inputs_2d.boost.aprox13
@@ -56,7 +56,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/job_scripts/aprox13_test/inputs_2d.boost.aprox13
+++ b/Exec/science/flame_wave/job_scripts/aprox13_test/inputs_2d.boost.aprox13
@@ -56,7 +56,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 128
 

--- a/Exec/science/flame_wave/old/inputs.boost_25_4
+++ b/Exec/science/flame_wave/old/inputs.boost_25_4
@@ -59,7 +59,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/old/inputs/inputs_2d
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d
@@ -48,7 +48,7 @@ castro.diffuse_cutoff_density = 1.e4
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/flame_wave/old/inputs/inputs_2d.boost
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d.boost
@@ -51,7 +51,7 @@ castro.diffuse_cond_scale_fac = 10.0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 

--- a/Exec/science/flame_wave/old/inputs/inputs_2d.boost.base
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d.boost.base
@@ -51,7 +51,7 @@ castro.diffuse_cond_scale_fac = 10.0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 

--- a/Exec/science/flame_wave/old/inputs/inputs_2d.boost.g
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d.boost.g
@@ -51,7 +51,7 @@ castro.diffuse_cond_scale_fac = 10.0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 

--- a/Exec/science/flame_wave/old/inputs/inputs_2d.boost.omega10
+++ b/Exec/science/flame_wave/old/inputs/inputs_2d.boost.omega10
@@ -49,7 +49,7 @@ castro.diffuse_cond_scale_fac = 10.0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 

--- a/Exec/science/flame_wave/old/inputs_2d.boost.aprox13.hires
+++ b/Exec/science/flame_wave/old/inputs_2d.boost.aprox13.hires
@@ -56,7 +56,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/old/inputs_2d.boost.hires
+++ b/Exec/science/flame_wave/old/inputs_2d.boost.hires
@@ -54,7 +54,7 @@ castro.react_rho_max = 5.e7
 castro.cfl            = 0.6     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 

--- a/Exec/science/flame_wave/old/inputs_2d.boost.wide
+++ b/Exec/science/flame_wave/old/inputs_2d.boost.wide
@@ -51,7 +51,7 @@ castro.diffuse_cond_scale_fac = 10.0
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 
 

--- a/Exec/science/flame_wave/scaling/inputs.scaling.3d
+++ b/Exec/science/flame_wave/scaling/inputs.scaling.3d
@@ -56,7 +56,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/flame_wave/scaling/inputs.scaling_384.3d
+++ b/Exec/science/flame_wave/scaling/inputs.scaling_384.3d
@@ -57,7 +57,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.hard_cfl_limit = 0
 castro.max_subcycles = 16

--- a/Exec/science/flame_wave/scaling/inputs.scaling_576.3d
+++ b/Exec/science/flame_wave/scaling/inputs.scaling_576.3d
@@ -57,7 +57,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.hard_cfl_limit = 0
 castro.max_subcycles = 16

--- a/Exec/science/flame_wave/science/sc20/inputs.boost_10_10.3d
+++ b/Exec/science/flame_wave/science/sc20/inputs.boost_10_10.3d
@@ -58,7 +58,7 @@ castro.react_T_min = 6.e7
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.use_retry      = 1
 castro.max_subcycles = 16
 

--- a/Exec/science/nova/inputs_2d
+++ b/Exec/science/nova/inputs_2d
@@ -42,7 +42,7 @@ gravity.const_grav   = -8.636e8
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/planet/inputs_1d
+++ b/Exec/science/planet/inputs_1d
@@ -62,7 +62,7 @@ gravity.const_grav   = -1.0e3
 castro.cfl            = 0.01     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01     # scale back initial timestep
 castro.change_max     = 1.001     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt = 1.3e-10
 #castro.initial_dt = 1e-4
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/planet/inputs_2d
+++ b/Exec/science/planet/inputs_2d
@@ -61,7 +61,7 @@ gravity.const_grav   = -1.0e3
 castro.cfl            = 0.01     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01     # scale back initial timestep
 castro.change_max     = 1.01     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/science/planet/inputs_3d
+++ b/Exec/science/planet/inputs_3d
@@ -62,7 +62,7 @@ gravity.const_grav   = -1.0e3
 castro.cfl            = 0.01     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01     # scale back initial timestep
 castro.change_max     = 1.001     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 #castro.fixed_dt = 1.0e-3
 #castro.initial_dt = 1e-4
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/science/rotating_star/inputs_1d
+++ b/Exec/science/rotating_star/inputs_1d
@@ -40,7 +40,7 @@ castro.riemann_solver = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.05     # scale back initial timestep by this factor
 castro.change_max     = 1.025    # factor by which dt is allowed to change each timestep

--- a/Exec/science/rotating_star/inputs_2d
+++ b/Exec/science/rotating_star/inputs_2d
@@ -40,7 +40,7 @@ castro.riemann_solver = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.05     # scale back initial timestep by this factor
 castro.change_max     = 1.025    # factor by which dt is allowed to change each timestep

--- a/Exec/science/rotating_star/inputs_2d.sdc_test
+++ b/Exec/science/rotating_star/inputs_2d.sdc_test
@@ -40,7 +40,7 @@ castro.riemann_solver = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.001     # scale back initial timestep by this factor
 castro.change_max     = 1.1    # factor by which dt is allowed to change each timestep

--- a/Exec/science/rotating_star/inputs_2d.strang_test
+++ b/Exec/science/rotating_star/inputs_2d.strang_test
@@ -40,7 +40,7 @@ castro.riemann_solver = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.001     # scale back initial timestep by this factor
 castro.change_max     = 1.1    # factor by which dt is allowed to change each timestep

--- a/Exec/science/subchandra/inputs_2d
+++ b/Exec/science/subchandra/inputs_2d
@@ -40,7 +40,7 @@ castro.riemann_solver = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.05     # scale back initial timestep by this factor
 castro.change_max     = 1.025    # factor by which dt is allowed to change each timestep

--- a/Exec/science/wdmerger/inputs_2d
+++ b/Exec/science/wdmerger/inputs_2d
@@ -50,7 +50,7 @@ stop_time = 100.0
 castro.use_stopping_criterion = 1
 
 # Level 0 timestep below which we halt
-castro.dt_cutoff = 1.e-8
+
 
 # CFL number for hyperbolic system
 castro.cfl = 0.5

--- a/Exec/science/wdmerger/inputs_3d
+++ b/Exec/science/wdmerger/inputs_3d
@@ -50,7 +50,7 @@ stop_time = 100.0
 castro.use_stopping_criterion = 1
 
 # Level 0 timestep below which we halt
-castro.dt_cutoff = 1.e-8
+
 
 # CFL number for hyperbolic system
 castro.cfl = 0.5

--- a/Exec/science/wdmerger/science/sc20/inputs_collision
+++ b/Exec/science/wdmerger/science/sc20/inputs_collision
@@ -11,7 +11,7 @@ stop_time = 10.0
 
 castro.T_stopping_criterion = 4.e9
 castro.init_shrink = 0.01
-castro.dt_cutoff = 1.e-11
+
 castro.change_max = 1.25
 
 amr.n_cell = 256 256 256

--- a/Exec/science/wdmerger/science/sc20/inputs_merger
+++ b/Exec/science/wdmerger/science/sc20/inputs_merger
@@ -12,7 +12,7 @@ stop_time = 250.0
 castro.T_stopping_criterion = 5.e9
 
 castro.init_shrink = 0.01
-castro.dt_cutoff = 1.e-11
+
 castro.change_max = 1.25
 
 amr.n_cell = 256 256 256

--- a/Exec/science/wdmerger/tests/tde/inputs.test
+++ b/Exec/science/wdmerger/tests/tde/inputs.test
@@ -43,7 +43,7 @@ stop_time = 30.0
 castro.use_stopping_criterion = 1
 
 # Level 0 timestep below which we halt
-castro.dt_cutoff = 1.e-8
+
 
 # CFL number for hyperbolic system
 castro.cfl = 0.15

--- a/Exec/science/wdmerger/tests/wdmerger_2D/inputs_test_wdmerger_2D
+++ b/Exec/science/wdmerger/tests/wdmerger_2D/inputs_test_wdmerger_2D
@@ -16,7 +16,7 @@ geometry.prob_lo =  0.0e0 -5.12e9		   # Lower boundary limits in physical space
 geometry.prob_hi = 5.12e9  5.12e9  		   # Upper boundary limits in physical space
 castro.center =     0.0e0   0.0e0   		   # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
+
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
+++ b/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
@@ -17,7 +17,7 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
+
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
@@ -50,7 +50,7 @@ stop_time = 5.0
 castro.use_stopping_criterion = 1
 
 # Level 0 timestep below which we halt
-castro.dt_cutoff = 1.e-8
+
 
 # CFL number for hyperbolic system
 castro.cfl = 0.5

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
@@ -18,7 +18,7 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
+
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
+++ b/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
@@ -50,7 +50,7 @@ stop_time = 100.0
 castro.use_stopping_criterion = 1
 
 # Level 0 timestep below which we halt
-castro.dt_cutoff = 1.e-8
+
 
 # CFL number for hyperbolic system
 castro.cfl = 0.5

--- a/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
@@ -47,7 +47,7 @@ max_step = 1
 castro.use_stopping_criterion = 1
 
 # Level 0 timestep below which we halt
-castro.dt_cutoff = 1.0e-12
+
 
 # CFL number for hyperbolic system
 castro.cfl = 0.5

--- a/Exec/science/xrb_mixed/inputs_2d
+++ b/Exec/science/xrb_mixed/inputs_2d
@@ -34,7 +34,7 @@ gravity.const_grav   = -2.45e14
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass

--- a/Exec/unit_tests/diffusion_test/inputs.1d
+++ b/Exec/unit_tests/diffusion_test/inputs.1d
@@ -23,7 +23,7 @@ castro.diffuse_temp = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/unit_tests/diffusion_test/inputs.1d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.1d.sph
@@ -23,7 +23,7 @@ castro.diffuse_temp = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/unit_tests/diffusion_test/inputs.2d
+++ b/Exec/unit_tests/diffusion_test/inputs.2d
@@ -23,7 +23,7 @@ castro.diffuse_temp = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph
@@ -23,7 +23,7 @@ castro.diffuse_temp = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/unit_tests/diffusion_test/inputs.3d
+++ b/Exec/unit_tests/diffusion_test/inputs.3d
@@ -23,7 +23,7 @@ castro.diffuse_temp = 1
 castro.do_react = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Exec/unit_tests/particles_test/inputs.2d
+++ b/Exec/unit_tests/particles_test/inputs.2d
@@ -33,7 +33,7 @@ particles.timestamp_temperature = 1
 particles.v                     = 1               # verbosity
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -2319,10 +2319,10 @@ Castro::okToContinue ()
       if (ParallelDescriptor::IOProcessor())
         std::cout << " Signalling a stop of the run due to signalStopJob = true." << std::endl;
     }
-    else if (parent->dtLevel(0) < dt_cutoff) {
+    else if (parent->dtLevel(level) < dt_cutoff * parent->cumTime()) {
       test = 0;
       if (ParallelDescriptor::IOProcessor())
-        std::cout << " Signalling a stop of the run because dt < dt_cutoff." << std::endl;
+        std::cout << " Signalling a stop of the run because dt < dt_cutoff * time." << std::endl;
     }
 
     return test;

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -435,24 +435,9 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
 
     while (subcycle_time < (1.0 - eps) * (time + dt)) {
 
-        // Determine whether we're below the cutoff timestep. Note that
-        // dt_cutoff is set for level 0, so we need to scale this appropriately
-        // depending on our level of refinement.
+        // Save the dt_subcycle before modifying it, we will use it later.
 
-        Real cutoff_dt = dt_cutoff;
-        for (int lev = 0; lev < level; ++lev) {
-            cutoff_dt /= parent->MaxRefRatio(lev);
-        }
-
-        if (dt_subcycle < cutoff_dt) {
-            if (ParallelDescriptor::IOProcessor()) {
-                std::cout << std::endl;
-                std::cout << "  The subcycle mechanism requested subcycled timesteps of maximum length dt = " << dt_subcycle << "," << std::endl
-                          << "  but this timestep is shorter than the user-defined minimum, " << std::endl
-                          << "  castro.dt_cutoff, scaled to the current level (" << cutoff_dt << "). Aborting." << std::endl;
-            }
-            amrex::Abort("Error: subcycled timesteps too short.");
-        }
+        last_dt_subcycle = dt_subcycle;
 
         // Shorten the last timestep so that we don't overshoot
         // the ending time. Relatedly, we also don't want to
@@ -463,16 +448,24 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
         // roundoff issues, under the logic that as long as the
         // tolerance is still small, there is no meaningful harm
         // from the timestep being slightly larger than our recommended
-        // safe dt in the subcycling.       
+        // safe dt in the subcycling.
 
-        const Real eps2 = 1.0e-10;
+        AMREX_ASSERT(dt_cutoff > eps);
 
-        // Save the dt_subcycle before modifying it, we will use it later.
-
-        last_dt_subcycle = dt_subcycle;
-
-        if (subcycle_time + dt_subcycle > (1.0 - eps2) * (time + dt))
+        if (subcycle_time + dt_subcycle > (1.0 - dt_cutoff) * (time + dt))
             dt_subcycle = (time + dt) - subcycle_time;
+
+        // Determine whether we're below the cutoff timestep.
+
+        if (dt_subcycle < dt_cutoff * time) {
+            if (ParallelDescriptor::IOProcessor()) {
+                std::cout << std::endl;
+                std::cout << "  The subcycle mechanism requested subcycled timesteps of maximum length dt = " << dt_subcycle << "," << std::endl
+                          << "  but this timestep is shorter than the user-defined minimum, " << std::endl
+                          << "  castro.dt_cutoff, multiplied by the current time (" << dt_cutoff * time << "). Aborting." << std::endl;
+            }
+            amrex::Abort("Error: subcycled timesteps too short.");
+        }
 
         // Check on whether we are going to take too many subcycles.
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -296,8 +296,9 @@ fixed_dt                     Real         -1.0
 # constraints)
 initial_dt                   Real         -1.0
 
-# the smallest valid timestep---if we go below this, we abort
-dt_cutoff                    Real          0.0
+# the smallest valid timestep, as a fraction of the current simulation time.
+# if we go below this, we abort.
+dt_cutoff                    Real          1.e-12
 
 # the largest valid timestep---limit all timesteps to be no larger than this
 max_dt                       Real          1.e200


### PR DESCRIPTION

## PR summary

The meaning of dt_cutoff has changed: it is now the fraction of the current simulation time which dt may be no smaller than, instead of being an absolute measure. We now have set a non-zero default (1.e-12) as well.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
