### PR TITLE
Add test coverage for custom knapsack weights

### DIFF
--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
@@ -53,6 +53,7 @@ amr.grid_eff = 0.9                                 # What constitutes an efficie
 castro.do_hydro = 1                                # Whether or not to do hydrodynamics
 castro.do_grav = 1                                 # Whether or not to do gravity
 castro.do_react = 1                                # Whether or not to do reactions
+castro.use_custom_knapsack_weights = 1             # Compute a new load balancing just for reactions
 castro.do_sponge = 0                               # Whether or not to apply the sponge
 castro.add_ext_src = 1                             # Whether or not to apply external source terms
 castro.ext_src_implicit = 1


### PR DESCRIPTION

## PR summary

Enable test suite coverage of castro.use_custom_knapsack_weights.

## PR checklist

- [ ] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
