### PR TITLE
Throw error if CFL is too large for density flux limiter

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -372,6 +372,10 @@ Castro::read_params ()
       }
 
 
+    if (limit_fluxes_on_small_dens && cfl > 0.5_rt) {
+        amrex::Error("limit_fluxes_on_small_dens requires CFL <= 0.5");
+    }
+
 
     // Make sure not to call refluxing if we're not actually doing any hydro.
     if (do_hydro == 0) do_reflux = 0;


### PR DESCRIPTION

## PR summary

The paper we derive the flux limiter from observes that the first order Lax-Friedrichs flux only guarantees positivity if CFL <= 0.5, so this should be a requirement.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
