### PR TITLE
fix a copy for SDC -- wrong number of ghost cells were assumed

### DIFF
--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -147,7 +147,7 @@ Castro::do_advance_sdc (Real time,
 
         // store the result in sources_for_hydro -- this is what will
         // be used in the final conservative update
-        MultiFab::Copy(sources_for_hydro, old_source, 0, 0, NSRC, sources_for_hydro.nGrow());
+        MultiFab::Copy(sources_for_hydro, old_source, 0, 0, NSRC, old_source.nGrow());
 
       } else {
         sources_for_hydro.setVal(0.0, 0);


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

In general, Source_Type has less ghost cells that sources_for_hydro

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
