### PR TITLE
Don't limit later timesteps because of retries

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -471,17 +471,10 @@ public:
 /// don't do a retry unless the criteria are violated. This is
 /// used only for the CTU advance.
 ///
-/// @param time     the current simulation time
-/// @param dt       the timestep to advance (e.g., go from time to
-///                    time + dt)
-/// @param amr_iteration    where we are in the current AMR subcycle.  Each
-///                    level will take a number of steps to reach the
-///                    final time of the coarser level below it.  This
-///                    counter starts at 1
-/// @param amr_ncycle   the number of subcycles at this level
+/// @param dt_subcycle     the current subcycled timestep
 /// @param advance_status  was the advance successful?
 ///
-    bool retry_advance_ctu(amrex::Real& time, amrex::Real dt, int amr_iteration, int amr_ncycle, advance_status status);
+    bool retry_advance_ctu(amrex::Real &dt_subcycle, advance_status status);
 
 ///
 /// Subcyles until we've reached the target time, ``time`` + ``dt``.
@@ -1452,7 +1445,6 @@ protected:
 ///
     int sub_iteration;
     int sub_ncycle;
-    amrex::Real dt_subcycle;
     amrex::Real dt_advance;
 
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -748,9 +748,6 @@ Castro::initMFs()
 
     post_step_regrid = 0;
 
-    lastDtRetryLimited = false;
-    lastDtFromRetry = 1.e200;
-
     lastDt = 1.e200;
 
 }
@@ -1559,23 +1556,6 @@ Castro::computeNewDt (int                   finest_level,
 
           }
        }
-    }
-
-    //
-    // If we limited the last step by a retry,
-    // apply that here if the retry-recommended
-    // timestep is smaller than what we calculated.
-    //
-    for (int i = 0; i <= finest_level; ++i) {
-        if (getLevel(i).lastDtRetryLimited == 1) {
-            if (getLevel(i).lastDtFromRetry < dt_min[i]) {
-                if (verbose && ParallelDescriptor::IOProcessor()) {
-                    std::cout << " ... limiting dt at level " << i << " to: "
-                              << getLevel(i).lastDtFromRetry << " = retry-limited timestep\n";
-                }
-                dt_min[i] = getLevel(i).lastDtFromRetry;
-            }
-        }
     }
 
     //

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -220,7 +220,6 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
 
     sub_iteration = 0;
     sub_ncycle = 0;
-    dt_subcycle = 1.e200;
     dt_advance = dt;
 
     keep_prev_state = false;


### PR DESCRIPTION

## PR summary

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite
- [ ] all functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated
- [ ] if appropriate, this change is described in the docs
