### PR TITLE
Optionally scale the ODE tolerances with SDC iteration for simplified SDC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+   * When using simplified SDC, we now pass the current SDC iteration number
+     and the total number of SDC iterations to the ODE integrator. The user may
+     now scale ODE solver tolerances with the SDC iteration number using the
+     extern parameter `sdc_burn_tol_factor`. Defaults to no scaling. (#903)
+
    * The reaction weights metric implemented in version 20.05 (#863) has been
      added to the simplified SDC reactions driver. (#930)
 

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -568,7 +568,7 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
 
                     // Do the ODE integration to capture the reaction source terms.
 
-                    bool burn_success = react_state(subcycle_time, dt_subcycle);
+                    bool burn_success = react_state(subcycle_time, dt_subcycle, num_sub_iters);
 
                     if (!burn_success) {
                         status.success = false;

--- a/Source/reactions/Castro_react.H
+++ b/Source/reactions/Castro_react.H
@@ -17,7 +17,7 @@
 /// @param time     current time
 /// @param dt       timestep
 ///
-    bool react_state(amrex::Real time, amrex::Real dt);
+    bool react_state(amrex::Real time, amrex::Real dt, const int num_sdc_iters);
 
 ///
 /// Are there any zones in ``State`` that can burn?

--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -267,7 +267,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt)
 // Simplified SDC version
 
 bool
-Castro::react_state(Real time, Real dt)
+Castro::react_state(Real time, Real dt, const int num_sdc_iters)
 {
     BL_PROFILE("Castro::react_state()");
 
@@ -325,7 +325,7 @@ Castro::react_state(Real time, Real dt)
                                       BL_TO_FORTRAN_ANYD(a),
                                       BL_TO_FORTRAN_ANYD(r),
                                       BL_TO_FORTRAN_ANYD(m),
-                                      time, dt, sdc_iteration,
+                                      time, dt, sdc_iteration, num_sdc_iters,
                                       AMREX_MFITER_REDUCE_SUM(&burn_failed));
 
     }

--- a/Source/reactions/Castro_react_F.H
+++ b/Source/reactions/Castro_react_F.H
@@ -16,7 +16,8 @@ extern "C"
      const amrex::Real* asrc, const int* as_lo, const int* as_hi,
      amrex::Real* reactions, const int* r_lo, const int* r_hi,
      const int* mask, const int* m_lo, const int* m_hi,
-     const amrex::Real time, const amrex::Real dt_react, const int sdc_iter,
+     const amrex::Real time, const amrex::Real dt_react,
+     const int sdc_iter, const int num_sdc_iters,
      amrex::Real* burn_failure);
 
   void ca_react_state

--- a/Source/reactions/React_nd.F90
+++ b/Source/reactions/React_nd.F90
@@ -238,7 +238,7 @@ contains
                                            asrc,as_lo,as_hi, &
                                            reactions,r_lo,r_hi, &
                                            mask,m_lo,m_hi, &
-                                           time,dt_react,sdc_iter, &
+                                           time,dt_react,sdc_iter, num_sdc_iters, &
                                            failed) bind(C, name="ca_react_state_simplified_sdc")
 
     use network           , only : nspec, naux
@@ -270,7 +270,7 @@ contains
     real(rt), intent(inout) :: reactions(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec+3)
     integer , intent(in   ) :: mask(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3))
     real(rt), intent(in   ), value :: time, dt_react
-    integer , intent(in   ), value :: sdc_iter
+    integer , intent(in   ), value :: sdc_iter, num_sdc_iters
     real(rt) , intent(inout) :: failed
 
     integer  :: i, j, k, n
@@ -296,6 +296,9 @@ contains
              do_burn = .true.
              burn_state_in % success = .true.
              burn_state_out % success = .true.
+
+             burn_state_in % sdc_iter = sdc_iter
+             burn_state_in % num_sdc_iters = num_sdc_iters
 
              ! Don't burn on zones that we are intentionally masking out.
 


### PR DESCRIPTION
For simplified SDC, this now initializes the current SDC iteration number and the total number of SDC iterations in the `sdc_t` derived type passed to the ODE integrator.

This allows the user to scale ODE solver tolerances with the SDC iteration number as described in Microphysics PR 309 here: https://github.com/starkiller-astro/Microphysics/pull/309

# PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
