### PR TITLE
store UEINT flux, initialize UTEMP and USHK flux to 0

### DIFF
--- a/Source/mhd/Castro_mhd.cpp
+++ b/Source/mhd/Castro_mhd.cpp
@@ -275,6 +275,11 @@ Castro::just_the_mhd(Real time, Real dt)
             flux0_arr(i,j,k,UMY) = flxx_arr(i,j,k,UMY);
             flux0_arr(i,j,k,UMZ) = flxx_arr(i,j,k,UMZ);
             flux0_arr(i,j,k,UEDEN) = flxx_arr(i,j,k,UEDEN);
+            flux0_arr(i,j,k,UEINT) = flxx_arr(i,j,k,UEINT);
+            flux0_arr(i,j,k,UTEMP) = 0.0;
+#ifdef SHOCK_VAR
+            flux0_arr(i,j,k,USHK) = 0.0;
+#endif
             for (int n = 0; n < NumSpec; n++) {
               flux0_arr(i,j,k,UFS+n) = flxx_arr(i,j,k,UFS+n);
             }
@@ -289,6 +294,11 @@ Castro::just_the_mhd(Real time, Real dt)
             flux1_arr(i,j,k,UMY) = flxy_arr(i,j,k,UMY);
             flux1_arr(i,j,k,UMZ) = flxy_arr(i,j,k,UMZ);
             flux1_arr(i,j,k,UEDEN) = flxy_arr(i,j,k,UEDEN);
+            flux1_arr(i,j,k,UEINT) = flxy_arr(i,j,k,UEINT);
+            flux1_arr(i,j,k,UTEMP) = 0.0;
+#ifdef SHOCK_VAR
+            flux1_arr(i,j,k,USHK) = 0.0;
+#endif
             for (int n = 0; n < NumSpec; n++) {
               flux1_arr(i,j,k,UFS+n) = flxy_arr(i,j,k,UFS+n);
             }
@@ -303,6 +313,11 @@ Castro::just_the_mhd(Real time, Real dt)
             flux2_arr(i,j,k,UMY) = flxz_arr(i,j,k,UMY);
             flux2_arr(i,j,k,UMZ) = flxz_arr(i,j,k,UMZ);
             flux2_arr(i,j,k,UEDEN) = flxz_arr(i,j,k,UEDEN);
+            flux2_arr(i,j,k,UEINT) = flxz_arr(i,j,k,UEINT);
+            flux2_arr(i,j,k,UTEMP) = 0.0;
+#ifdef SHOCK_VAR
+            flux2_arr(i,j,k,USHK) = 0.0;
+#endif
             for (int n = 0; n < NumSpec; n++) {
               flux2_arr(i,j,k,UFS+n) = flxz_arr(i,j,k,UFS+n);
             }


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This fixes a floating point exception in the flux storage loops in Castro_mhd.cpp

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
