### PR TITLE
Save new Reactions_Type data after a simplified SDC burn

### DIFF
--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -365,13 +365,6 @@ Castro::react_state(Real time, Real dt)
 
     }
 
-    // For the ca_check_timestep routine, we need to have both the old
-    // and new burn defined, so we simply do a copy here
-    MultiFab& R_old = get_old_data(Reactions_Type);
-    MultiFab& R_new = get_new_data(Reactions_Type);
-    MultiFab::Copy(R_new, R_old, 0, 0, R_new.nComp(), R_new.nGrow());
-
-
     if (burn_success)
         return true;
     else


### PR DESCRIPTION
@jmsexton03 has reported that for Simplified SDC in the flame problem, `enuc` in the plotfiles is identically zero. This is not the case for Strang and the reason appears to be a bug.

This PR will ensure new `Reactions_Type` data is saved after the burn properly so enuc will be saved into the plotfiles correctly, corresponding to the value at the last SDC iteration. It should not change the estimated timestep because we aren't currently using `Reactions_Type` to do so.

To elaborate:

Currently in Simplified SDC, `Castro::react_state()` sets the new `Reactions_Type` data (`R_new`) in `ca_react_state_simplified_sdc`.

There we update Unew using the results of the burn, however, right before returning from `react_state()` we overwrite the burn results in `R_new` with the old values in `Reactions_Type` in `R_old` in the `MultiFab::Copy()`.

This was done in 3460254fc9 because at that time the burning timestep estimator required the `Reactions_Type` data to be defined. (Although even then it seemingly makes more sense to save `R_new` back into `R_old` after the burn instead of vice versa?).

As of 37e048ccface1579c09632c49182f2dbcf3b0ea1 the timestep checking logic no longer requires the `Reactions_Type` data in the deprecated `ca_check_timestep`. We are just calling the `actual_rhs` to get an instantaneous value for `d(Enuc)/dt`. Although in `Castro::estTimeStep()` we are passing `R_new` into `ca_estdt_burning`, it remains unused there.