### PR TITLE
Save integrator stats in the Reactions_Type weights for Simplified SDC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+   * The reaction weights metric implemented in version 20.05 (#863) has been
+     added to the simplified SDC reactions driver. (#930)
+
+   * When using the simplified SDC integration scheme, we now save new-time
+     Reactions_Type data to plotfiles. (#929)
+
 # 20.05
 
    * The parameter use_custom_knapsack_weights and its associated

--- a/Source/reactions/React_nd.F90
+++ b/Source/reactions/React_nd.F90
@@ -400,6 +400,7 @@ contains
                    end do
                    reactions(i,j,k,nspec+1) = (unew(i,j,k,UEINT) * rhonInv - uold(i,j,k,UEINT) * rhooInv) / dt_react
                    reactions(i,j,k,nspec+2) = (unew(i,j,k,UEINT) - uold(i,j,k,UEINT)) / dt_react
+                   reactions(i,j,k,nspec+3) = max(ONE, dble(burn_state_out % n_rhs + 2 * burn_state_out % n_jac))
 
                 end if
 


### PR DESCRIPTION
This PR saves `n_rhs + 2*n_jac` from the integrator into the `Reactions_Type` variable `weights` for simplified SDC as is currently done for Strang.

To see this in the plotfiles requires first merging #929 