### PR TITLE
Asyncout

### DIFF
--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -1199,7 +1199,11 @@ Castro::plotFileOutput(const std::string& dir,
 
     const Real io_start_time = ParallelDescriptor::second();
 
-    VisMF::Write(plotMF,TheFullPath,how,true);
+    if (amrex::AsyncOut::UseAsyncOut()) {
+        VisMF::AsyncWrite(std::move(plotMF),TheFullPath);
+    } else {
+        VisMF::Write(plotMF,TheFullPath,how,true);
+    }
 
     const Real io_time = ParallelDescriptor::second() - io_start_time;
 

--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -416,29 +416,11 @@ Castro::checkPoint(const std::string& dir,
                    bool dump_old_default)
 {
 
-  for (int s = 0; s < num_state_type; ++s) {
-      if (dump_old && state[s].hasOldData()) {
-          MultiFab& old_MF = get_old_data(s);
-          amrex::prefetchToHost(old_MF);
-      }
-      MultiFab& new_MF = get_new_data(s);
-      amrex::prefetchToHost(new_MF);
-  }
-
   const Real io_start_time = ParallelDescriptor::second();
 
   AmrLevel::checkPoint(dir, os, how, dump_old);
 
   const Real io_time = ParallelDescriptor::second() - io_start_time;
-
-  for (int s = 0; s < num_state_type; ++s) {
-      if (dump_old && state[s].hasOldData()) {
-          MultiFab& old_MF = get_old_data(s);
-          amrex::prefetchToDevice(old_MF);
-      }
-      MultiFab& new_MF = get_new_data(s);
-      amrex::prefetchToDevice(new_MF);
-  }
 
 #ifdef RADIATION
   if (do_radiation) {
@@ -1208,8 +1190,6 @@ Castro::plotFileOutput(const std::string& dir,
         cnt += Radiation::nplotvar;
     }
 #endif
-
-    amrex::prefetchToHost(plotMF);
 
     //
     // Use the Full pathname when naming the MultiFab.


### PR DESCRIPTION
There are two changes in this PR.  First, some prefetch calls are removed because they are done now in AMReX's I/O functions.  Second, add support for using async out.  It can be turned on with `amrex.async_out=1`.  On up to 64 processes, it should work without any other changes.  For more than 64 processes, one must compile with `MPI_THREAD_MULTIPLE=TRUE` if `amrex.async_out` is on.  I have tested amrex::AsyncOut on summit using `amrex/Tutorials/GPU/CNS` on up to 4096 nodes, the asyncout is order of magnitude faster than the default.

