### PR TITLE
start working on the sizes of the input states

### DIFF
--- a/Source/mhd/ct_upwind.f90
+++ b/Source/mhd/ct_upwind.f90
@@ -1133,8 +1133,8 @@ contains
 
     integer, intent(in)   :: d, d1, d2, UMAGD, UMAGD1, UMAGD2, sgn
 
-    real(rt), intent(inout) :: ur_out(uro_lo(1):uro_hi(1), uro_lo(2):uro_hi(2), uro_lo(3):uro_hi(3), NVAR+3, 3)
-    real(rt), intent(inout) :: ul_out(ulo_lo(1):ulo_hi(1), ulo_lo(2):ulo_hi(2), ulo_lo(3):ulo_hi(3), NVAR+3, 3)
+    real(rt), intent(inout) :: ur_out(uro_lo(1):uro_hi(1), uro_lo(2):uro_hi(2), uro_lo(3):uro_hi(3), NVAR+3)
+    real(rt), intent(inout) :: ul_out(ulo_lo(1):ulo_hi(1), ulo_lo(2):ulo_hi(2), ulo_lo(3):ulo_hi(3), NVAR+3)
     real(rt), intent(in)    :: ur(ur_lo(1):ur_hi(1), ur_lo(2):ur_hi(2), ur_lo(3):ur_hi(3), NVAR+3)
     real(rt), intent(in)    :: ul(ul_lo(1):ul_hi(1), ul_lo(2):ul_hi(2), ul_lo(3):ul_hi(3), NVAR+3)
 
@@ -1179,38 +1179,38 @@ contains
              !d-Direction
 
              ! right state on the interface (Bd eq.45 in Miniati for -)
-             ur_out(i,j,k,UMAGD,d) = ur(i,j,k,UMAGD) + sgn*0.5d0*dt/dx*((Ed1(i+a1(1),j+a1(2),k+a1(3)) - Ed1(i,j,k)) &
+             ur_out(i,j,k,UMAGD) = ur(i,j,k,UMAGD) + sgn*0.5d0*dt/dx*((Ed1(i+a1(1),j+a1(2),k+a1(3)) - Ed1(i,j,k)) &
                   - (Ed2(i+a2(1),j+a2(2),k+a2(3)) - Ed2(i,j,k)))
              !Bd1 eq.46 in Miniati
-             ur_out(i,j,k,UMAGD1,d) = ur(i,j,k,UMAGD1) + sgn*0.5d0*dt/dx*((Ed(i+b1(1),j+b1(2),k+b1(3)) - Ed(i+b2(1),j+b2(2),k+b2(3))) &
+             ur_out(i,j,k,UMAGD1) = ur(i,j,k,UMAGD1) + sgn*0.5d0*dt/dx*((Ed(i+b1(1),j+b1(2),k+b1(3)) - Ed(i+b2(1),j+b2(2),k+b2(3))) &
                   + (Ed(i+b3(1),j+b3(2),k+b3(3)) - Ed(i,j,k)) &
                   - (Ed2(i+b4(1),j+b4(2),k+b4(3)) - Ed2(i+b2(1),j+b2(2),k+b2(3))) &
                   - (Ed2(i+b5(1),j+b5(2),k+b5(3)) - Ed2(i,j,k)))
              !Bd2 eq. 46 in Miniati
-             ur_out(i,j,k,UMAGD2,d) = ur(i,j,k,UMAGD2) - sgn* 0.5d0*dt/dx*((Ed(i+b1(1),j+b1(2),k+b1(3)) - Ed(i+b3(1),j+b3(2),k+b3(3))) &
+             ur_out(i,j,k,UMAGD2) = ur(i,j,k,UMAGD2) - sgn* 0.5d0*dt/dx*((Ed(i+b1(1),j+b1(2),k+b1(3)) - Ed(i+b3(1),j+b3(2),k+b3(3))) &
                   + (Ed(i+b2(1),j+b2(2),k+b2(3)) - Ed(i,j,k)) &
                   - (Ed1(i+b6(1),j+b6(2),k+b6(3)) - Ed1(i+b3(1),j+b3(2),k+b3(3))) &
                   - (Ed1(i+b5(1),j+b5(2),k+b5(3)) - Ed1(i,j,k)))
 
-             ur_out(i,j,k,UEINT,d) = ur_out(i,j,k,UEINT,d) - 0.5d0*dot_product(ur_out(i,j,k,UMAGX:UMAGZ,d),ur_out(i,j,k,UMAGX:UMAGZ,d))
+             ur_out(i,j,k,UEINT) = ur_out(i,j,k,UEINT) - 0.5d0*dot_product(ur_out(i,j,k,UMAGX:UMAGZ), ur_out(i,j,k,UMAGX:UMAGZ))
 
 
              ! left state on the interface (Bd eq. 45 in Miniati for +)
              ! for the + case, the shifts mentioned above in b6, b5, and b4
              ! also correspond to the 1st, 2nd and 4th, and 3rd term respectevely
-             ul_out(i,j,k,UMAGD,d) = ul(i,j,k,UMAGD) + sgn*0.5d0*dt/dx*((Ed1(i+b6(1),j+b6(2),k+b6(3)) - Ed1(i+b5(1),j+b5(2),k+b5(3))) &
+             ul_out(i,j,k,UMAGD) = ul(i,j,k,UMAGD) + sgn*0.5d0*dt/dx*((Ed1(i+b6(1),j+b6(2),k+b6(3)) - Ed1(i+b5(1),j+b5(2),k+b5(3))) &
                   - (Ed2(i+b4(1),j+b4(2),k+b4(3)) - Ed2(i+b5(1),j+b5(2),k+b5(3))))
              !Bd1 eq. 46 in Miniati
-             ul_out(i,j,k,UMAGD1,d) = ul(i,j,k,UMAGD1) + sgn*0.5d0*dt/dx*((Ed(i+b1(1),j+b1(2),k+b1(3)) - Ed(i+b2(1),j+b2(2),k+b2(3))) &
+             ul_out(i,j,k,UMAGD1) = ul(i,j,k,UMAGD1) + sgn*0.5d0*dt/dx*((Ed(i+b1(1),j+b1(2),k+b1(3)) - Ed(i+b2(1),j+b2(2),k+b2(3))) &
                   + (Ed(i+b3(1),j+b3(2),k+b3(3)) - Ed(i,j,k)) &
                   - (Ed2(i+b4(1),j+b4(2),k+b4(3)) - Ed2(i+b2(1),j+b2(2),k+b2(3))) &
                   - (Ed2(i+b5(1),j+b5(2),k+b5(3)) - Ed2(i,j,k)))
              !Bd2 eq. 46 in Miniati
-             ul_out(i,j,k,UMAGD2,d) = ul(i,j,k,UMAGD2) - sgn*0.5d0*dt/dx*((Ed(i+b1(1),j+b1(2),k+b1(3)) - Ed(i+b3(1),j+b3(2),k+b3(3))) &
+             ul_out(i,j,k,UMAGD2) = ul(i,j,k,UMAGD2) - sgn*0.5d0*dt/dx*((Ed(i+b1(1),j+b1(2),k+b1(3)) - Ed(i+b3(1),j+b3(2),k+b3(3))) &
                   + (Ed(i+b2(1),j+b2(2),k+b2(3)) - Ed(i,j,k)) &
                   - (Ed1(i+b6(1),j+b6(2),k+b6(3)) - Ed1(i+b3(1),j+b3(2),k+b3(3))) &
                   - (Ed1(i+b5(1),j+b5(2),k+b5(3)) - Ed1(i,j,k)))
-             ul_out(i,j,k,UEINT,d) = ul_out(i,j,k,UEINT,d) -0.5d0*dot_product(ul_out(i,j,k,UMAGX:UMAGZ,d),ul_out(i,j,k,UMAGX:UMAGZ,d))
+             ul_out(i,j,k,UEINT) = ul_out(i,j,k,UEINT) -0.5d0*dot_product(ul_out(i,j,k,UMAGX:UMAGZ), ul_out(i,j,k,UMAGX:UMAGZ))
 
           enddo
        enddo

--- a/Source/mhd/ct_upwind.f90
+++ b/Source/mhd/ct_upwind.f90
@@ -781,7 +781,7 @@ contains
     integer, intent(in) :: w_lo(3), w_hi(3)
     integer, intent(in) :: q_lo(3), q_hi(3)
     integer, intent(in) :: u_lo(3), u_hi(3)
-    real(rt), intent(in) :: u(q_lo(1):q_hi(1), q_lo(2):q_hi(2),q_lo(3):q_hi(3),NVAR+3)
+    real(rt), intent(in) :: u(u_lo(1):u_hi(1), u_lo(2):u_hi(2),u_lo(3):u_hi(3),NVAR+3)
     real(rt), intent(out) :: q(q_lo(1):q_hi(1), q_lo(2):q_hi(2), q_lo(3):q_hi(3),NQ)
 
     integer :: i ,j ,k
@@ -793,8 +793,6 @@ contains
        do j = w_lo(2), w_hi(2)
           do i = w_lo(1), w_hi(1)
              q(i,j,k,QRHO)  = u(i,j,k,URHO)
-             print *, "here", i,j,k, q(i,j,k,QRHO)
-             print *, u(i,j,k,UMX)
              q(i,j,k,QU)    = u(i,j,k,UMX)/q(i,j,k,QRHO)
              q(i,j,k,QV)    = u(i,j,k,UMY)/q(i,j,k,QRHO)
              q(i,j,k,QW)    = u(i,j,k,UMZ)/q(i,j,k,QRHO)
@@ -865,10 +863,6 @@ contains
     ! update the state in direction d1 with the flux in direction dir2
 
     d = 0
-
-    print *, "in corner_couple", w_lo, w_hi
-    print *, ur_lo, ur_hi
-    print *, ul_lo, ul_hi
 
     !the first term of the flxd2 substraction is shifted by 1 on the direction d2
     d(d2) = 1

--- a/Source/mhd/hlld.f90
+++ b/Source/mhd/hlld.f90
@@ -27,8 +27,8 @@ subroutine hlld(work_lo, work_hi, &
    integer, intent(in)   :: flx_lo(3), flx_hi(3)
    integer, intent(in)   :: dir
 
-   real(rt), intent(in)  :: qleft(ql_lo(1):ql_hi(1),ql_lo(2):ql_hi(2),ql_lo(3):ql_hi(3),NQ,3)
-   real(rt), intent(in)  :: qright(qr_lo(1):qr_hi(1),qr_lo(2):qr_hi(2),qr_lo(3):qr_hi(3),NQ,3)
+   real(rt), intent(in)  :: qleft(ql_lo(1):ql_hi(1),ql_lo(2):ql_hi(2),ql_lo(3):ql_hi(3),NQ)
+   real(rt), intent(in)  :: qright(qr_lo(1):qr_hi(1),qr_lo(2):qr_hi(2),qr_lo(3):qr_hi(3),NQ)
    real(rt), intent(out) :: flx(flx_lo(1):flx_hi(1),flx_lo(2):flx_hi(2),flx_lo(3):flx_hi(3),NVAR+3)
 
    real(rt)       :: cfL2, cfR, sL, sR, sM, ssL, ssR, pst, caL, canL
@@ -107,14 +107,14 @@ subroutine hlld(work_lo, work_hi, &
 
       
       if (dir .eq. 1) then
-         qL(:) = qleft(i-1,j,k,:,dir)
+         qL(:) = qleft(i-1,j,k,:)
       else if (dir .eq. 2) then
-         qL(:) = qleft(i,j-1,k,:,dir)
+         qL(:) = qleft(i,j-1,k,:)
       else if (dir .eq. 3) then
-         qL(:) = qleft(i,j,k-1,:,dir)
+         qL(:) = qleft(i,j,k-1,:)
       end if
 
-      qR(:) = qright(i,j,k,:,dir)
+      qR(:) = qright(i,j,k,:)
 
       flx(i,j,k,:) = 0.d0  
       FL  = 0.d0; FR = 0.d0; UsL = 0.d0; UsR = 0.d0; FsL = 0.d0; FsR = 0.d0; UssL = 0.d0; UssR = 0.d0; FssL = 0.d0; FssR = 0.d0


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This makes the sizes of the intermediate primitive and conservative state arrays more explicit.  It also greatly reduces the amount of memory needed in the corner transport routines.

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
