### PR TITLE
port check_for_mhd_cfl_violation to C++

### DIFF
--- a/Source/mhd/Castro_mhd.H
+++ b/Source/mhd/Castro_mhd.H
@@ -1,12 +1,6 @@
     void just_the_mhd(amrex::Real time, amrex::Real dt);
 
     void
-    mhd_speeds(const amrex::Box& bx,
-               amrex::Array4<amrex::Real const> const& Bx,
-               amrex::Array4<amrex::Real const> const& By,
-               amrex::Array4<amrex::Real const> const& Bz,
-               amrex::Array4<amrex::Real const> const& q_arr,
-               amrex::Array4<amrex::Real const> const& qaux_arr,
-               amrex::Array4<amrex::Real> const& cx,
-               amrex::Array4<amrex::Real> const& cy,
-               amrex::Array4<amrex::Real> const& cz);
+    check_for_mhd_cfl_violation(const amrex::Box& bx, const amrex::Real dt,
+                                amrex::Array4<amrex::Real const> const& q_arr,
+                                amrex::Array4<amrex::Real const> const& qaux_arr);

--- a/Source/mhd/Castro_mhd.cpp
+++ b/Source/mhd/Castro_mhd.cpp
@@ -16,8 +16,6 @@ Castro::just_the_mhd(Real time, Real dt)
       const auto dx = geom.CellSizeArray();
       const Real* dx_f = geom.CellSize();
 
-      Real courno = -1.0e+200;
-
       const int*  domain_lo = geom.Domain().loVect();
       const int*  domain_hi = geom.Domain().hiVect();
 
@@ -40,7 +38,7 @@ Castro::just_the_mhd(Real time, Real dt)
 
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:mass:courno)
+#pragma omp parallel
 #endif
     {
 
@@ -136,12 +134,7 @@ Castro::just_the_mhd(Real time, Real dt)
 
           src_to_prim(bx_gc, q_arr, src_arr, src_q_arr);
 
-          check_for_mhd_cfl_violation(lo, hi,
-                                      BL_TO_FORTRAN_ANYD(q),
-                                      BL_TO_FORTRAN_ANYD(cs[0]),
-                                      BL_TO_FORTRAN_ANYD(cs[1]),
-                                      BL_TO_FORTRAN_ANYD(cs[2]),
-                                      courno, dx_f, dt);
+          check_for_mhd_cfl_violation(bx, dt, q_arr, qaux_arr);
 
           flatn.resize(bx_gc, 1);
           auto flatn_arr = flatn.array();

--- a/Source/mhd/Castro_mhd.cpp
+++ b/Source/mhd/Castro_mhd.cpp
@@ -45,7 +45,6 @@ Castro::just_the_mhd(Real time, Real dt)
     {
 
       FArrayBox flux[AMREX_SPACEDIM], E[AMREX_SPACEDIM];
-      FArrayBox cs[AMREX_SPACEDIM];
 
       FArrayBox bcc;
       FArrayBox q;
@@ -119,10 +118,6 @@ Castro::just_the_mhd(Real time, Real dt)
 
           srcQ.resize(bx_gc, NQSRC);
 
-          for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-            cs[idir].resize(bx_gc, 1);
-          }
-
           const int* lo_gc = bx_gc.loVect();
           const int* hi_gc = bx_gc.hiVect();
 
@@ -132,15 +127,6 @@ Castro::just_the_mhd(Real time, Real dt)
                   bcc_arr,
                   Bx_arr, By_arr, Bz_arr,
                   q_arr, qaux_arr);
-
-          auto cx_arr = (cs[0]).array();
-          auto cy_arr = (cs[1]).array();
-          auto cz_arr = (cs[2]).array();
-
-          mhd_speeds(bx_gc,
-                     Bx_arr, By_arr, Bz_arr,
-                     q_arr, qaux_arr,
-                     cx_arr, cy_arr, cz_arr);
 
           const int* lo1 = obx.loVect();
           const int* hi1 = obx.hiVect();

--- a/Source/mhd/electric.f90
+++ b/Source/mhd/electric.f90
@@ -208,13 +208,17 @@ subroutine electric_edge_y(work_lo, work_hi, &
            ! Compute Ey(i-1/2, j, k-1/2)
 
            ! dEy/dz i-1/2, j, k-3/4
+
+           ! first compute dEy/dz_{i-1,j,k-3/4}
            call electric(q(i-1,j,k-1,:), Ecen, 2)
            a = 2.d0 * (-flxz(i-1,j,k,UMAGX) - Ecen)
 
+           ! now compute dEy/dz_{i,j,k-3/4}
            call electric(q(i,j,k-1,:), Ecen, 2)
            b = 2.d0 * (-flxz(i,j,k,UMAGX) - Ecen)
 
            ! upwind in the x direction to get dEy/dz i-1/2, j, k-3/4
+           ! using u_{i-1/2,j,k-1}
            if (flxx(i,j,k-1,URHO) .gt. 0.d0) then
               d1 = a
            else if (flxx(i,j,k-1,URHO) .lt. 0.d0) then
@@ -224,13 +228,17 @@ subroutine electric_edge_y(work_lo, work_hi, &
            endif
 
            ! dEy/dz i-1/2, j, k-1/4
+
+           ! first compute dEy/dz_{i-1,j,k-1/4}
            call electric(q(i-1,j,k,:), Ecen, 2)
            a = 2.d0 * (Ecen + flxz(i-1,j,k,UMAGX))
 
+           ! now compute dEy/dz_{i,j,k-1/4}
            call electric(q(i,j,k,:), Ecen, 2)
            b = 2.d0 * (Ecen + flxz(i,j,k,UMAGX))
 
            ! upwind in the x direction to get dEy/dz i-1/2, j, k-1/4
+           ! using u_{i-1/2.j,k}
            if (flxx(i,j,k,URHO) .gt. 0.d0) then
               d2 = a
            else if (flxx(i,j,k,URHO) .lt. 0.d0) then
@@ -244,14 +252,18 @@ subroutine electric_edge_y(work_lo, work_hi, &
            dd1 = 0.125d0*(d1-d2)
 
 
-           ! dEy/dx i -3/4, j, k - 1/2
+           ! dEy/dx i-3/4, j, k-1/2
+
+           ! first compute dEy/dz_{i-3/4,j,k-1}
            call electric(q(i-1,j,k-1,:), Ecen, 2)
            a = 2.d0*(flxx(i,j,k-1,UMAGZ) - Ecen)
 
-           call electric(q(i-1,j, k, :), Ecen, 2)
+           ! next compute dEy/dz_{i-3/4,j,k}
+           call electric(q(i-1,j,k, :), Ecen, 2)
            b = 2.d0*(flxx(i,j,k,UMAGZ) - Ecen)
 
-           ! upwind in the z direction to get dEy/dx i-3/4, j, k -1/2
+           ! upwind in the z direction to get dEy/dx i-3/4, j, k-1/2
+           ! using w_{i-1,j,k-1/2}
            if (flxz(i-1,j,k,URHO) .gt. 0.d0) then
               d1 = a
            else if (flxz(i-1,j,k,URHO) .lt. 0.d0) then
@@ -261,13 +273,17 @@ subroutine electric_edge_y(work_lo, work_hi, &
            endif
 
            ! dEy/dx i-1/4, j, k-1/2
+
+           ! first compute dEy/dx_{i-1/4,j,k-1}
            call electric(q(i,j,k-1,:), Ecen, 2)
            a = 2.d0*(Ecen - flxx(i,j,k-1,UMAGZ))
 
+           ! next compute dEy/dx_{i-1/4,j,k}
            call electric(q(i,j,k,:), Ecen, 2)
            b = 2.d0*(Ecen - flxx(i,j,k,UMAGZ))
 
-           ! upwind in the z direction for i-1/2,j,k-1/2
+           ! upwind in the z direction for i-1/4, j, k-1/2
+           ! using w_{i,j,k-1/2}
            if (flxz(i,j,k,URHO) .gt. 0.d0) then
               d2 = a
            else if (flxz(i,j,k,URHO) .lt. 0.d0) then

--- a/Source/mhd/mhd_util.cpp
+++ b/Source/mhd/mhd_util.cpp
@@ -9,6 +9,7 @@ using namespace amrex;
 
 void
 Castro::check_for_mhd_cfl_violation(const Box& bx,
+                                    const Real dt,
                                     Array4<Real const> const& q_arr,
                                     Array4<Real const> const& qaux_arr) {
 

--- a/Source/mhd/mhd_util.cpp
+++ b/Source/mhd/mhd_util.cpp
@@ -8,18 +8,22 @@
 using namespace amrex;
 
 void
-Castro::mhd_speeds(const Box& bx,
-                   Array4<Real const> const& Bx,
-                   Array4<Real const> const& By,
-                   Array4<Real const> const& Bz,
-                   Array4<Real const> const& q_arr,
-                   Array4<Real const> const& qaux_arr,
-                   Array4<Real> const& cx,
-                   Array4<Real> const& cy,
-                   Array4<Real> const& cz) {
+Castro::check_for_mhd_cfl_violation(const Box& bx,
+                                    Array4<Real const> const& q_arr,
+                                    Array4<Real const> const& qaux_arr) {
 
-  amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  auto dx = geom.CellSizeArray();
+
+  Real dtdx = dt / dx[0];
+  Real dtdy = dt / dx[1];
+  Real dtdz = dt / dx[2];
+
+  ReduceOps<ReduceOpMax> reduce_op;
+  ReduceData<Real> reduce_data(reduce_op);
+  using ReduceTuple = typename decltype(reduce_data)::Type;
+
+  reduce_op.eval(bx, reduce_data,
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
   {
 
     //sound speed for ideal mhd
@@ -30,20 +34,76 @@ Castro::mhd_speeds(const Box& bx,
                q_arr(i,j,k,QMAGY) * q_arr(i,j,k,QMAGY) +
                q_arr(i,j,k,QMAGZ) * q_arr(i,j,k,QMAGZ)) * rho_inv;
 
-    Real ctmp = 0.0;
-
+    Real cx = 0.0;
     Real cad = q_arr(i,j,k,QMAGX) * q_arr(i,j,k,QMAGX) * rho_inv;
-    eos_soundspeed_mhd(ctmp, as2, ca, cad);
-    cx(i,j,k) = ctmp;
+    eos_soundspeed_mhd(cx, as2, ca, cad);
 
+    Real cy = 0.0;
     cad = q_arr(i,j,k,QMAGY) * q_arr(i,j,k,QMAGY) * rho_inv;
-    eos_soundspeed_mhd(ctmp, as2, ca, cad);
-    cy(i,j,k) = ctmp;
+    eos_soundspeed_mhd(cy, as2, ca, cad);
 
+    Real cz = 0.0;
     cad = q_arr(i,j,k,QMAGZ) * q_arr(i,j,k,QMAGZ) * rho_inv;
-    eos_soundspeed_mhd(ctmp, as2, ca, cad);
-    cz(i,j,k) = ctmp;
+    eos_soundspeed_mhd(cz, as2, ca, cad);
+
+    Real courx = (cx + std::abs(q_arr(i,j,k,QU))) * dtdx;
+    Real coury = (cy + std::abs(q_arr(i,j,k,QV))) * dtdy;
+    Real courz = (cz + std::abs(q_arr(i,j,k,QW))) * dtdz;
+
+#ifndef AMREX_USE_CUDA
+    if (verbose == 1) {
+
+      if (courx > 1.0_rt) {
+        std::cout << std::endl;
+        std::cout << "Warning:: CFL violation in check_for_mhd_cfl_violation" << std::endl;
+        std::cout << ">>> ... (u+c) * dt / dx > 1 " << courx << std::endl;
+        std::cout << ">>> ... at cell i = " << i << " j = " << j << " k = " << k << std::endl;
+        std::cout << ">>> ... u = " << q_arr(i,j,k,QU) << " c = " << cx << std::endl;
+        std::cout << ">>> ... B = " << q_arr(i,j,k,QMAGX) << " " << q_arr(i,j,k,QMAGY) << " " << q_arr(i,j,k,QMAGZ) << std::endl;
+        std::cout << ">>> ... density = " << q_arr(i,j,k,QRHO) << std::endl;
+        std::cout << ">>> ... internal e = " << q_arr(i,j,k,QREINT) << std::endl;
+        std::cout << ">>> ... pressure = " << q_arr(i,j,k,QPRES) << std::endl;
+      }
+
+      if (coury > 1.0_rt) {
+        std::cout << std::endl;
+        std::cout << "Warning:: CFL violation in check_for_mhd_cfl_violation" << std::endl;
+        std::cout << ">>> ... (v+c) * dt / dx > 1 " << coury << std::endl;
+        std::cout << ">>> ... at cell i = " << i << " j = " << j << " k = " << k << std::endl;
+        std::cout << ">>> ... v = " << q_arr(i,j,k,QV) << " c = " << cy << std::endl;
+        std::cout << ">>> ... B = " << q_arr(i,j,k,QMAGX) << " " << q_arr(i,j,k,QMAGY) << " " << q_arr(i,j,k,QMAGZ) << std::endl;
+        std::cout << ">>> ... density = " << q_arr(i,j,k,QRHO) << std::endl;
+        std::cout << ">>> ... internal e = " << q_arr(i,j,k,QREINT) << std::endl;
+        std::cout << ">>> ... pressure = " << q_arr(i,j,k,QPRES) << std::endl;
+      }
+
+      if (courz > 1.0_rt) {
+        std::cout << std::endl;
+        std::cout << "Warning:: CFL violation in check_for_mhd_cfl_violation" << std::endl;
+        std::cout << ">>> ... (w+c) * dt / dx > 1 " << courz << std::endl;
+        std::cout << ">>> ... at cell i = " << i << " j = " << j << " k = " << k << std::endl;
+        std::cout << ">>> ... w = " << q_arr(i,j,k,QW) << " c = " << cz << std::endl;
+        std::cout << ">>> ... B = " << q_arr(i,j,k,QMAGX) << " " << q_arr(i,j,k,QMAGY) << " " << q_arr(i,j,k,QMAGZ) << std::endl;
+        std::cout << ">>> ... density = " << q_arr(i,j,k,QRHO) << std::endl;
+        std::cout << ">>> ... internal e = " << q_arr(i,j,k,QREINT) << std::endl;
+        std::cout << ">>> ... pressure = " << q_arr(i,j,k,QPRES) << std::endl;
+
+      }
+
+    }
+#endif
+
+    return {amrex::max(courx, coury, courz)};
 
   });
+
+  ReduceTuple hv = reduce_data.value();
+  Real courno = amrex::get<0>(hv);
+
+  if (courno > 1.0) {
+    amrex::Print() << "WARNING -- EFFECTIVE CFL AT LEVEL " << level << " IS " << courno << std::endl << std::endl;
+
+    cfl_violation = 1;
+  }
 
 }


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This gets rid of the cs[AMREX_SPACEDIM] FABs for the sound speeds and instead computes them on the fly in check_for_mhd_cfl_violation as needed.  

It also adds some comments to electric_edge_y as I took a pass reading through and checking it.

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
