### PR TITLE
Add a return if timestep validity check fails

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -305,6 +305,7 @@ Castro::do_advance_ctu(Real time,
     if (castro::change_max * new_dt < dt) {
         status.success = false;
         status.reason = "timestep validity check failed";
+        return status;
     }
 
     finalize_do_advance(time, dt, amr_iteration, amr_ncycle);


### PR DESCRIPTION

## PR summary

This adds an immediate return if the timestep validity check fails, which makes it consistent with the other advance failures.

## PR motivation

I don't think this will change anything, the only thing that gets skipped is the finalize. But it seems safer.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
