### PR TITLE
shift the MHD interface states so left and right are indexed the same

### DIFF
--- a/Source/mhd/Castro_mhd.cpp
+++ b/Source/mhd/Castro_mhd.cpp
@@ -50,8 +50,8 @@ Castro::just_the_mhd(Real time, Real dt)
 
       FArrayBox flatn;
 
-      FArrayBox qm;
-      FArrayBox qp;
+      FArrayBox qleft;
+      FArrayBox qright;
 
       FArrayBox flxx;
       FArrayBox flxy;
@@ -159,8 +159,8 @@ Castro::just_the_mhd(Real time, Real dt)
 
 
           // Interpolate Cell centered values to faces
-          qp.resize(bx_gc, NQ * AMREX_SPACEDIM);
-          qm.resize(bx_gc, NQ * AMREX_SPACEDIM);
+          qleft.resize(bx_gc, NQ * AMREX_SPACEDIM);
+          qright.resize(bx_gc, NQ * AMREX_SPACEDIM);
 
           const Box& nbx = amrex::surroundingNodes(bx, 0);
           const Box& nby = amrex::surroundingNodes(bx, 1);
@@ -175,8 +175,8 @@ Castro::just_the_mhd(Real time, Real dt)
               BL_TO_FORTRAN_ANYD(Bx),
               BL_TO_FORTRAN_ANYD(By),
               BL_TO_FORTRAN_ANYD(Bz),
-              BL_TO_FORTRAN_ANYD(qp),
-              BL_TO_FORTRAN_ANYD(qm),
+              BL_TO_FORTRAN_ANYD(qleft),
+              BL_TO_FORTRAN_ANYD(qright),
               BL_TO_FORTRAN_ANYD(srcQ),
               dx_f, dt);
 
@@ -189,8 +189,8 @@ Castro::just_the_mhd(Real time, Real dt)
               BL_TO_FORTRAN_ANYD(Bx),
               BL_TO_FORTRAN_ANYD(By),
               BL_TO_FORTRAN_ANYD(Bz),
-              BL_TO_FORTRAN_ANYD(qp),
-              BL_TO_FORTRAN_ANYD(qm),
+              BL_TO_FORTRAN_ANYD(qleft),
+              BL_TO_FORTRAN_ANYD(qright),
               BL_TO_FORTRAN_ANYD(srcQ),
               dx_f, dt);
 
@@ -203,8 +203,8 @@ Castro::just_the_mhd(Real time, Real dt)
               BL_TO_FORTRAN_ANYD(Bx),
               BL_TO_FORTRAN_ANYD(By),
               BL_TO_FORTRAN_ANYD(Bz),
-              BL_TO_FORTRAN_ANYD(qp),
-              BL_TO_FORTRAN_ANYD(qm),
+              BL_TO_FORTRAN_ANYD(qleft),
+              BL_TO_FORTRAN_ANYD(qright),
               BL_TO_FORTRAN_ANYD(srcQ),
               dx_f, dt);
 
@@ -242,8 +242,8 @@ Castro::just_the_mhd(Real time, Real dt)
 
           corner_transport(lo, hi,
                            BL_TO_FORTRAN_ANYD(q),
-                           BL_TO_FORTRAN_ANYD(qm),
-                           BL_TO_FORTRAN_ANYD(qp),
+                           BL_TO_FORTRAN_ANYD(qleft),
+                           BL_TO_FORTRAN_ANYD(qright),
                            BL_TO_FORTRAN_ANYD(flxx),
                            BL_TO_FORTRAN_ANYD(flxy),
                            BL_TO_FORTRAN_ANYD(flxz),

--- a/Source/mhd/Castro_mhd.cpp
+++ b/Source/mhd/Castro_mhd.cpp
@@ -212,9 +212,9 @@ Castro::just_the_mhd(Real time, Real dt)
           // Corner Couple and find the correct fluxes + electric fields
 
           // need to revisit these box sizes
-          const Box& nbxf = amrex::grow(nbx, IntVect(1, 1, 1));
-          const Box& nbyf = amrex::grow(nby, IntVect(1, 1, 1));
-          const Box& nbzf = amrex::grow(nbz, IntVect(1, 1, 1));
+          const Box& nbxf = amrex::grow(nbx, IntVect(0, 1, 1));
+          const Box& nbyf = amrex::grow(nby, IntVect(1, 0, 1));
+          const Box& nbzf = amrex::grow(nbz, IntVect(1, 1, 0));
 
           const Box& nbxe = amrex::grow(nbx, IntVect(2, 3, 3));
           const Box& nbye = amrex::grow(nby, IntVect(3, 2, 3));

--- a/Source/mhd/Castro_mhd.cpp
+++ b/Source/mhd/Castro_mhd.cpp
@@ -212,15 +212,19 @@ Castro::just_the_mhd(Real time, Real dt)
           // Corner Couple and find the correct fluxes + electric fields
 
           // need to revisit these box sizes
-          const Box& nbxf = amrex::grow(nbx, IntVect(2, 3, 3));
-          const Box& nbyf = amrex::grow(nby, IntVect(3, 2, 3));
-          const Box& nbzf = amrex::grow(nbz, IntVect(3, 3, 2));
+          const Box& nbxf = amrex::grow(nbx, IntVect(1, 1, 1));
+          const Box& nbyf = amrex::grow(nby, IntVect(1, 1, 1));
+          const Box& nbzf = amrex::grow(nbz, IntVect(1, 1, 1));
+
+          const Box& nbxe = amrex::grow(nbx, IntVect(2, 3, 3));
+          const Box& nbye = amrex::grow(nby, IntVect(3, 2, 3));
+          const Box& nbze = amrex::grow(nbz, IntVect(3, 3, 2));
 
           flxx.resize(nbxf, NUM_STATE+3);
           auto flxx_arr = flxx.array();
           auto elix_flxx = flxx.elixir();
 
-          Extmp.resize(nbxf);
+          Extmp.resize(nbxe);
           auto Ex_arr = Extmp.array();
           auto elix_Ex = Extmp.elixir();
 
@@ -228,7 +232,7 @@ Castro::just_the_mhd(Real time, Real dt)
           auto flxy_arr = flxy.array();
           auto elix_flxy = flxy.elixir();
 
-          Eytmp.resize(nbyf);
+          Eytmp.resize(nbye);
           auto Ey_arr = Eytmp.array();
           auto elix_Ey = Eytmp.elixir();
 
@@ -236,7 +240,7 @@ Castro::just_the_mhd(Real time, Real dt)
           auto flxz_arr = flxz.array();
           auto elix_flxz = flxz.elixir();
 
-          Eztmp.resize(nbzf);
+          Eztmp.resize(nbze);
           auto Ez_arr = Eztmp.array();
           auto elix_Ez = Eztmp.elixir();
 

--- a/Source/mhd/Castro_mhd_F.H
+++ b/Source/mhd/Castro_mhd_F.H
@@ -31,8 +31,8 @@ extern "C"
   void corner_transport
     (const int lo[], const int hi[],
      const BL_FORT_FAB_ARG_3D(q),
-     const BL_FORT_FAB_ARG_3D(qm),
-     const BL_FORT_FAB_ARG_3D(qp),
+     const BL_FORT_FAB_ARG_3D(qleft),
+     const BL_FORT_FAB_ARG_3D(qright),
      BL_FORT_FAB_ARG_3D(flxx),
      BL_FORT_FAB_ARG_3D(flxy),
      BL_FORT_FAB_ARG_3D(flxz),

--- a/Source/mhd/ct_upwind.f90
+++ b/Source/mhd/ct_upwind.f90
@@ -546,7 +546,7 @@ contains
     ! than we'd need for hydro alone due to the electric update
 
     ![lo(1), lo(2)-1, lo(3)-1][hi(1)+1, hi(2)+1, hi(3)+1]
-    work_lo = (/ lo(1)-1, lo(2)-1, lo(3)-1 /)
+    work_lo = (/ lo(1), lo(2)-1, lo(3)-1 /)
     work_hi = (/ hi(1)+1, hi(2)+1, hi(3)+1 /)
     call hlld(work_lo, work_hi, &
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &

--- a/Source/mhd/ct_upwind.f90
+++ b/Source/mhd/ct_upwind.f90
@@ -211,11 +211,11 @@ contains
 
     ! affected by Y Flux
     ![lo(1)-2, lo(2)-2, lo(3)-2] [hi(1)+2, hi(2)+2, hi(2)+2]
-    work_lo = (/ lo(1)-2 , lo(2)-2, lo(3)-2 /)
+    work_lo = (/ lo(1)-1 , lo(2)-2, lo(3)-2 /)
     work_hi = (/ hi(1)+2 , hi(2)+2, hi(3)+2 /)
 
-    ut_lo = work_lo
-    ut_hi = work_hi
+    ut_lo = [lo(1)-2, lo(2)-2, lo(3)-2]
+    ut_hi = [hi(1)+2, hi(2)+2, hi(3)+2]
 
     call bl_allocate(utmp_left, ut_lo, ut_hi, NVAR+3)
     call bl_allocate(utmp_right, ut_lo, ut_hi, NVAR+3)
@@ -257,9 +257,12 @@ contains
 
     call bl_allocate(flx_xy, fxy_lo, fxy_hi, NVAR+3)
 
+    print *, "calling hlld"
     call hlld(fxy_lo, fxy_hi, &
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &
               flx_xy, fxy_lo, fxy_hi, 1) !F^{x|y}
+
+    print *, "done"
 
     ! affected by Z Flux
     call corner_couple(work_lo, work_hi, &
@@ -298,9 +301,11 @@ contains
 
     !Y direction
 
+    print *, "here"
+
     ! affected by X Flux
     ![lo(1)-2, lo(2)-2, lo(3)-2] [hi(1)+2, hi(2)+2, hi(3)+2]
-    work_lo = (/ lo(1)-2, lo(2)-2, lo(3)-2 /)
+    work_lo = (/ lo(1)-2, lo(2)-1, lo(3)-2 /)
     work_hi = (/ hi(1)+2, hi(2)+2, hi(3)+2 /)
 
     call corner_couple(work_lo, work_hi, &
@@ -338,6 +343,7 @@ contains
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &
               flx_yx, fyx_lo, fyx_hi, 2) !F^{y|x}
 
+    print *, "z direction"
 
     ! affected by Z Flux
     call corner_couple(work_lo, work_hi, &
@@ -364,6 +370,8 @@ contains
     call ConsToPrim(work_lo, work_hi, &
                     qtmp_right, ut_lo, ut_hi, utmp_right, ut_lo, ut_hi)
 
+    print *, "here2"
+
     fyz_lo = (/ lo(1)-2, lo(2)-1, lo(3)-2 /)
     fyz_hi = (/ hi(1)+2, hi(2)+2, hi(3)+2 /)
 
@@ -377,7 +385,7 @@ contains
 
     ! affected by X Flux
     ![lo(1)-2, lo(2)-2, lo(3)-2] [hi(1)+2, hi(2)+2, hi(3)+2]
-    work_lo = (/ lo(1)-2, lo(2)-2, lo(3)-2 /)
+    work_lo = (/ lo(1)-2, lo(2)-2, lo(3)-1 /)
     work_hi = (/ hi(1)+2, hi(2)+2, hi(3)+2/)
     call corner_couple(work_lo, work_hi, &
                        utmp_right, ut_lo, ut_hi, &
@@ -403,6 +411,7 @@ contains
     call ConsToPrim(work_lo, work_hi, &
                     qtmp_right, ut_lo, ut_hi, utmp_right, ut_lo, ut_hi)
 
+    print *, "fxz"
 
     ![lo(1)-2,lo(2)-2,lo(3)-1][h1(1)+2, h1(2)+2, h1(3)+2]
     fzx_lo = (/ lo(1)-2, lo(2)-2, lo(3)-1 /)
@@ -453,29 +462,32 @@ contains
     ! Use Averaged 2D fluxes to interpolate temporary Edge Centered Electric Fields, reuse "flx1D"
     ! eq. 42 and 43
 
-    do k = lo(3)-2, hi(3)+2
-       do j = lo(2)-2, hi(2)+2
+    do k = lo(3)-1, hi(3)+2
+       do j = lo(2)-1, hi(2)+2
           do i = lo(1)-1, hi(1)+2
              flxx1D(i,j,k,:) = 0.5d0*(flx_xy(i,j,k,:) + flx_xz(i,j,k,:))
           end do
        end do
     end do
 
-    do k = lo(3)-2, hi(3)+2
+    do k = lo(3)-1, hi(3)+2
        do j = lo(2)-1, hi(2)+2
-          do i = lo(1)-2, hi(1)+2
+          do i = lo(1)-1, hi(1)+2
              flxy1D(i,j,k,:) = 0.5d0*(flx_yx(i,j,k,:) + flx_yz(i,j,k,:))
           end do
        end do
     end do
 
     do k = lo(3)-1, hi(3)+2
-       do j = lo(2)-2, hi(2)+2
-          do i = lo(1)-2, hi(1)+2
+       do j = lo(2)-1, hi(2)+2
+          do i = lo(1)-1, hi(1)+2
              flxz1D(i,j,k,:) = 0.5d0*(flx_zx(i,j,k,:) + flx_zy(i,j,k,:))
           end do
        end do
     end do
+
+
+    print *, "after flux averaging"
 
     ! eq. 41
     ![lo(1)-1, lo(2)-1, lo(3)-1][hi(1)+1, hi(2)+2, hi(3)+2]
@@ -508,6 +520,8 @@ contains
     ! MM CTU Step 7, 8, and 9
     ! Half Step conservative vars eq.44, eq.45, eq.46
     ! Here we reuse utmp_left/right to denote the half-time conservative state
+
+    print *, "x half step"
 
     !for x direction
     ![lo(1)-1,lo(2)-1, lo(3)-1][hi(1)+1, hi(2)+1, hi(3)+1]
@@ -546,12 +560,14 @@ contains
     ! than we'd need for hydro alone due to the electric update
 
     ![lo(1), lo(2)-1, lo(3)-1][hi(1)+1, hi(2)+1, hi(3)+1]
-    work_lo = (/ lo(1), lo(2)-1, lo(3)-1 /)
+    work_lo = (/ lo(1)-1, lo(2)-1, lo(3)-1 /)
     work_hi = (/ hi(1)+1, hi(2)+1, hi(3)+1 /)
     call hlld(work_lo, work_hi, &
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &
               flxx, flxx_lo, flxx_hi, 1)
 
+
+    print *, "y half step"
 
     !for y direction
 
@@ -585,11 +601,13 @@ contains
                     qtmp_left, ut_lo, ut_hi, utmp_left, ut_lo, ut_hi)
 
     ![lo(1)-1, lo(2), lo(3)-1][hi(1)+1,hi(2)+1, hi(3)+1]
-    work_lo = (/ lo(1)-1, lo(2), lo(3)-1 /)
+    work_lo = (/ lo(1)-1, lo(2)-1, lo(3)-1 /)
     work_hi = (/ hi(1)+1, hi(2)+1, hi(3)+1 /)
     call hlld(work_lo, work_hi, &
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &
               flxy, flxy_lo, flxy_hi, 2)
+
+    print *, "z half step"
 
     !for z direction
 
@@ -623,7 +641,7 @@ contains
                     qtmp_left, ut_lo, ut_hi, utmp_left, ut_lo, ut_hi)
 
     ![lo(1)-1,lo(2)-1,lo(3)][hi(1)+1, hi(2)+1, hi(3)+1]
-    work_lo = (/ lo(1)-1, lo(2)-1, lo(3) /)
+    work_lo = (/ lo(1)-1, lo(2)-1, lo(3)-1 /)
     work_hi = (/ hi(1)+1, hi(2)+1, hi(3)+1 /)
     call hlld(work_lo, work_hi, &
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &

--- a/Source/mhd/ct_upwind.f90
+++ b/Source/mhd/ct_upwind.f90
@@ -462,25 +462,25 @@ contains
     ! Use Averaged 2D fluxes to interpolate temporary Edge Centered Electric Fields, reuse "flx1D"
     ! eq. 42 and 43
 
-    do k = lo(3)-1, hi(3)+2
-       do j = lo(2)-1, hi(2)+2
+    do k = lo(3)-2, hi(3)+2
+       do j = lo(2)-2, hi(2)+2
           do i = lo(1)-1, hi(1)+2
              flxx1D(i,j,k,:) = 0.5d0*(flx_xy(i,j,k,:) + flx_xz(i,j,k,:))
           end do
        end do
     end do
 
-    do k = lo(3)-1, hi(3)+2
+    do k = lo(3)-2, hi(3)+2
        do j = lo(2)-1, hi(2)+2
-          do i = lo(1)-1, hi(1)+2
+          do i = lo(1)-2, hi(1)+2
              flxy1D(i,j,k,:) = 0.5d0*(flx_yx(i,j,k,:) + flx_yz(i,j,k,:))
           end do
        end do
     end do
 
     do k = lo(3)-1, hi(3)+2
-       do j = lo(2)-1, hi(2)+2
-          do i = lo(1)-1, hi(1)+2
+       do j = lo(2)-2, hi(2)+2
+          do i = lo(1)-2, hi(1)+2
              flxz1D(i,j,k,:) = 0.5d0*(flx_zx(i,j,k,:) + flx_zy(i,j,k,:))
           end do
        end do

--- a/Source/mhd/ct_upwind.f90
+++ b/Source/mhd/ct_upwind.f90
@@ -24,8 +24,8 @@ contains
 
   subroutine corner_transport(lo, hi, &
                               q, q_lo, q_hi, &
-                              qright, qr_lo, qr_hi, &
                               qleft, ql_lo, ql_hi, &
+                              qright, qr_lo, qr_hi, &
                               flxx, flxx_lo , flxx_hi, &
                               flxy, flxy_lo , flxy_hi, &
                               flxz, flxz_lo , flxz_hi, &

--- a/Source/mhd/ct_upwind.f90
+++ b/Source/mhd/ct_upwind.f90
@@ -257,12 +257,10 @@ contains
 
     call bl_allocate(flx_xy, fxy_lo, fxy_hi, NVAR+3)
 
-    print *, "calling hlld"
     call hlld(fxy_lo, fxy_hi, &
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &
               flx_xy, fxy_lo, fxy_hi, 1) !F^{x|y}
 
-    print *, "done"
 
     ! affected by Z Flux
     call corner_couple(work_lo, work_hi, &
@@ -300,8 +298,6 @@ contains
 
 
     !Y direction
-
-    print *, "here"
 
     ! affected by X Flux
     ![lo(1)-2, lo(2)-2, lo(3)-2] [hi(1)+2, hi(2)+2, hi(3)+2]
@@ -343,8 +339,6 @@ contains
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &
               flx_yx, fyx_lo, fyx_hi, 2) !F^{y|x}
 
-    print *, "z direction"
-
     ! affected by Z Flux
     call corner_couple(work_lo, work_hi, &
                        utmp_right, ut_lo, ut_hi, &
@@ -369,8 +363,6 @@ contains
 
     call ConsToPrim(work_lo, work_hi, &
                     qtmp_right, ut_lo, ut_hi, utmp_right, ut_lo, ut_hi)
-
-    print *, "here2"
 
     fyz_lo = (/ lo(1)-2, lo(2)-1, lo(3)-2 /)
     fyz_hi = (/ hi(1)+2, hi(2)+2, hi(3)+2 /)
@@ -410,8 +402,6 @@ contains
 
     call ConsToPrim(work_lo, work_hi, &
                     qtmp_right, ut_lo, ut_hi, utmp_right, ut_lo, ut_hi)
-
-    print *, "fxz"
 
     ![lo(1)-2,lo(2)-2,lo(3)-1][h1(1)+2, h1(2)+2, h1(3)+2]
     fzx_lo = (/ lo(1)-2, lo(2)-2, lo(3)-1 /)
@@ -487,8 +477,6 @@ contains
     end do
 
 
-    print *, "after flux averaging"
-
     ! eq. 41
     ![lo(1)-1, lo(2)-1, lo(3)-1][hi(1)+1, hi(2)+2, hi(3)+2]
     work_lo = (/ lo(1)-1, lo(2)-1, lo(3)-1 /)
@@ -520,8 +508,6 @@ contains
     ! MM CTU Step 7, 8, and 9
     ! Half Step conservative vars eq.44, eq.45, eq.46
     ! Here we reuse utmp_left/right to denote the half-time conservative state
-
-    print *, "x half step"
 
     !for x direction
     ![lo(1)-1,lo(2)-1, lo(3)-1][hi(1)+1, hi(2)+1, hi(3)+1]
@@ -567,8 +553,6 @@ contains
               flxx, flxx_lo, flxx_hi, 1)
 
 
-    print *, "y half step"
-
     !for y direction
 
     ![lo(1)-1,lo(2)-1, lo(3)-1][hi(1)+1, hi(2)+1, hi(3)+1]
@@ -601,13 +585,11 @@ contains
                     qtmp_left, ut_lo, ut_hi, utmp_left, ut_lo, ut_hi)
 
     ![lo(1)-1, lo(2), lo(3)-1][hi(1)+1,hi(2)+1, hi(3)+1]
-    work_lo = (/ lo(1)-1, lo(2)-1, lo(3)-1 /)
+    work_lo = (/ lo(1)-1, lo(2), lo(3)-1 /)
     work_hi = (/ hi(1)+1, hi(2)+1, hi(3)+1 /)
     call hlld(work_lo, work_hi, &
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &
               flxy, flxy_lo, flxy_hi, 2)
-
-    print *, "z half step"
 
     !for z direction
 
@@ -641,7 +623,7 @@ contains
                     qtmp_left, ut_lo, ut_hi, utmp_left, ut_lo, ut_hi)
 
     ![lo(1)-1,lo(2)-1,lo(3)][hi(1)+1, hi(2)+1, hi(3)+1]
-    work_lo = (/ lo(1)-1, lo(2)-1, lo(3)-1 /)
+    work_lo = (/ lo(1)-1, lo(2)-1, lo(3) /)
     work_hi = (/ hi(1)+1, hi(2)+1, hi(3)+1 /)
     call hlld(work_lo, work_hi, &
               qtmp_left, ut_lo, ut_hi, qtmp_right, ut_lo, ut_hi, &

--- a/Source/mhd/hlld.f90
+++ b/Source/mhd/hlld.f90
@@ -106,14 +106,10 @@ contains
        do j = work_lo(2), work_hi(2)
           do i = work_lo(1), work_hi(1)
 
-             if (dir .eq. 1) then
-                qL(:) = qleft(i-1,j,k,:)
-             else if (dir .eq. 2) then
-                qL(:) = qleft(i,j-1,k,:)
-             else if (dir .eq. 3) then
-                qL(:) = qleft(i,j,k-1,:)
-             end if
+             ! this is a loop over interfaces, so, e.g., for dir = 1 (x), we are seeing
+             ! q_{i-1/2,j,k,L} and q_{i-1/2,j,k,R}
 
+             qL(:) = qleft(i,j,k,:)
              qR(:) = qright(i,j,k,:)
 
              !flx(i,j,k,:) = 0.d0

--- a/Source/mhd/mhd_plm_3d.f90
+++ b/Source/mhd/mhd_plm_3d.f90
@@ -349,7 +349,7 @@ contains
              qright(i,j,k,QREINT,idir) = eos_state % e * eos_state % rho
 
              ! add source terms
-             if (dir == 1) then
+             if (idir == 1) then
                 qleft(i+1,j,k,QRHO,idir) = max(small_dens, qleft(i+1,j,k,QRHO,idir) + 0.5d0*dt*srcQ(i,j,k,QRHO))
                 qleft(i+1,j,k,QU,idir) = qleft(i+1,j,k,QU,idir) + 0.5d0*dt*srcQ(i,j,k,QU)
                 qleft(i+1,j,k,QV,idir) = qleft(i+1,j,k,QV,idir) + 0.5d0*dt*srcQ(i,j,k,QV)
@@ -357,7 +357,7 @@ contains
                 qleft(i+1,j,k,QPRES,idir) = qleft(i+1,j,k,QPRES,idir) + 0.5d0*dt*srcQ(i,j,k,QPRES)
                 qleft(i+1,j,k,QREINT,idir) = qleft(i+1,j,k,QREINT,idir) + 0.5d0*dt*srcQ(i,j,k,QREINT)
 
-             else if (dir == 2) then
+             else if (idir == 2) then
                 qleft(i,j+1,k,QRHO,idir) = max(small_dens, qleft(i,j+1,k,QRHO,idir) + 0.5d0*dt*srcQ(i,j,k,QRHO))
                 qleft(i,j+1,k,QU,idir) = qleft(i,j+1,k,QU,idir) + 0.5d0*dt*srcQ(i,j,k,QU)
                 qleft(i,j+1,k,QV,idir) = qleft(i,j+1,k,QV,idir) + 0.5d0*dt*srcQ(i,j,k,QV)

--- a/Source/mhd/mhd_plm_3d.f90
+++ b/Source/mhd/mhd_plm_3d.f90
@@ -223,26 +223,39 @@ contains
 
              ! left state at i+1/2
 
-             qleft(i,j,k,QRHO,idir) = max(small_dens, s(i,j,k,QRHO) + 0.5d0*summ_p(IEIGN_RHO) + 0.5d0*dt*smhd(IEIGN_RHO))
-             qleft(i,j,k,QU,idir) = s(i,j,k,QU) + 0.5d0*summ_p(IEIGN_U) + 0.5d0*dt*smhd(IEIGN_U)
-             qleft(i,j,k,QV,idir) = s(i,j,k,QV) + 0.5d0*summ_p(IEIGN_V) + 0.5d0*dt*smhd(IEIGN_V)
-             qleft(i,j,k,QW,idir) = s(i,j,k,QW) + 0.5d0*summ_p(IEIGN_W) + 0.5d0*dt*smhd(IEIGN_W)
-             qleft(i,j,k,QPRES,idir) = max(small_pres, s(i,j,k,QPRES) + 0.5d0*summ_p(IEIGN_P) + 0.5d0*dt*smhd(IEIGN_P))
 
              if (idir == 1) then
-                qleft(i,j,k,QMAGX,idir) = bx(i+1,j,k) !! Bx stuff
-                qleft(i,j,k,QMAGY,idir) = s(i,j,k,QMAGY) + 0.5d0*summ_p(IEIGN_BT) + 0.5d0*dt*smhd(IEIGN_BT)
-                qleft(i,j,k,QMAGZ,idir) = s(i,j,k,QMAGZ) + 0.5d0*summ_p(IEIGN_BTT) + 0.5d0*dt*smhd(IEIGN_BTT)
+                qleft(i+1,j,k,QRHO,idir) = max(small_dens, s(i,j,k,QRHO) + 0.5d0*summ_p(IEIGN_RHO) + 0.5d0*dt*smhd(IEIGN_RHO))
+                qleft(i+1,j,k,QU,idir) = s(i,j,k,QU) + 0.5d0*summ_p(IEIGN_U) + 0.5d0*dt*smhd(IEIGN_U)
+                qleft(i+1,j,k,QV,idir) = s(i,j,k,QV) + 0.5d0*summ_p(IEIGN_V) + 0.5d0*dt*smhd(IEIGN_V)
+                qleft(i+1,j,k,QW,idir) = s(i,j,k,QW) + 0.5d0*summ_p(IEIGN_W) + 0.5d0*dt*smhd(IEIGN_W)
+                qleft(i+1,j,k,QPRES,idir) = max(small_pres, s(i,j,k,QPRES) + 0.5d0*summ_p(IEIGN_P) + 0.5d0*dt*smhd(IEIGN_P))
+
+                qleft(i+1,j,k,QMAGX,idir) = bx(i+1,j,k) !! Bx stuff
+                qleft(i+1,j,k,QMAGY,idir) = s(i,j,k,QMAGY) + 0.5d0*summ_p(IEIGN_BT) + 0.5d0*dt*smhd(IEIGN_BT)
+                qleft(i+1,j,k,QMAGZ,idir) = s(i,j,k,QMAGZ) + 0.5d0*summ_p(IEIGN_BTT) + 0.5d0*dt*smhd(IEIGN_BTT)
 
              else if (idir == 2) then
-                qleft(i,j,k,QMAGX,idir) = s(i,j,k,QMAGX) + 0.5d0*summ_p(IEIGN_BT) + 0.5d0*dt*smhd(IEIGN_BT)
-                qleft(i,j,k,QMAGY,idir) = by(i,j+1,k) !! By stuff
-                qleft(i,j,k,QMAGZ,idir) = s(i,j,k,QMAGZ) + 0.5d0*summ_p(IEIGN_BTT) + 0.5d0*dt*smhd(IEIGN_BTT)
+                qleft(i,j+1,k,QRHO,idir) = max(small_dens, s(i,j,k,QRHO) + 0.5d0*summ_p(IEIGN_RHO) + 0.5d0*dt*smhd(IEIGN_RHO))
+                qleft(i,j+1,k,QU,idir) = s(i,j,k,QU) + 0.5d0*summ_p(IEIGN_U) + 0.5d0*dt*smhd(IEIGN_U)
+                qleft(i,j+1,k,QV,idir) = s(i,j,k,QV) + 0.5d0*summ_p(IEIGN_V) + 0.5d0*dt*smhd(IEIGN_V)
+                qleft(i,j+1,k,QW,idir) = s(i,j,k,QW) + 0.5d0*summ_p(IEIGN_W) + 0.5d0*dt*smhd(IEIGN_W)
+                qleft(i,j+1,k,QPRES,idir) = max(small_pres, s(i,j,k,QPRES) + 0.5d0*summ_p(IEIGN_P) + 0.5d0*dt*smhd(IEIGN_P))
+
+                qleft(i,j+1,k,QMAGX,idir) = s(i,j,k,QMAGX) + 0.5d0*summ_p(IEIGN_BT) + 0.5d0*dt*smhd(IEIGN_BT)
+                qleft(i,j+1,k,QMAGY,idir) = by(i,j+1,k) !! By stuff
+                qleft(i,j+1,k,QMAGZ,idir) = s(i,j,k,QMAGZ) + 0.5d0*summ_p(IEIGN_BTT) + 0.5d0*dt*smhd(IEIGN_BTT)
 
              else
-                qleft(i,j,k,QMAGX,idir) = s(i,j,k,QMAGX) + 0.5d0*summ_p(IEIGN_BT) + 0.5d0*dt*smhd(IEIGN_BT)
-                qleft(i,j,k,QMAGY,idir) = s(i,j,k,QMAGY) + 0.5d0*summ_p(IEIGN_BTT) + 0.5d0*dt*smhd(IEIGN_BTT)
-                qleft(i,j,k,QMAGZ,idir) = bz(i,j,k+1) !! Bz stuff
+                qleft(i,j,k+1,QRHO,idir) = max(small_dens, s(i,j,k,QRHO) + 0.5d0*summ_p(IEIGN_RHO) + 0.5d0*dt*smhd(IEIGN_RHO))
+                qleft(i,j,k+1,QU,idir) = s(i,j,k,QU) + 0.5d0*summ_p(IEIGN_U) + 0.5d0*dt*smhd(IEIGN_U)
+                qleft(i,j,k+1,QV,idir) = s(i,j,k,QV) + 0.5d0*summ_p(IEIGN_V) + 0.5d0*dt*smhd(IEIGN_V)
+                qleft(i,j,k+1,QW,idir) = s(i,j,k,QW) + 0.5d0*summ_p(IEIGN_W) + 0.5d0*dt*smhd(IEIGN_W)
+                qleft(i,j,k+1,QPRES,idir) = max(small_pres, s(i,j,k,QPRES) + 0.5d0*summ_p(IEIGN_P) + 0.5d0*dt*smhd(IEIGN_P))
+
+                qleft(i,j,k+1,QMAGX,idir) = s(i,j,k,QMAGX) + 0.5d0*summ_p(IEIGN_BT) + 0.5d0*dt*smhd(IEIGN_BT)
+                qleft(i,j,k+1,QMAGY,idir) = s(i,j,k,QMAGY) + 0.5d0*summ_p(IEIGN_BTT) + 0.5d0*dt*smhd(IEIGN_BTT)
+                qleft(i,j,k+1,QMAGZ,idir) = bz(i,j,k+1) !! Bz stuff
              end if
 
              ! right state at i-1/2
@@ -288,18 +301,45 @@ contains
 
                call slope(dW, dL, dR, flatn(i,j,k))
 
-               qleft(i,j,k,ii,idir) = s(i,j,k,ii) + 0.5d0*(1.0d0 - dtdx*un) * dW
+               if (idir == 1) then
+                  qleft(i+1,j,k,ii,idir) = s(i,j,k,ii) + 0.5d0*(1.0d0 - dtdx*un) * dW
+               else if (idir == 2) then
+                  qleft(i,j+1,k,ii,idir) = s(i,j,k,ii) + 0.5d0*(1.0d0 - dtdx*un) * dW
+               else
+                  qleft(i,j,k+1,ii,idir) = s(i,j,k,ii) + 0.5d0*(1.0d0 - dtdx*un) * dW
+               endif
                qright(i,j,k,ii,idir) = s(i,j,k,ii) - 0.5d0*(1.0d0 + dtdx*un) * dW
              enddo
 
              ! rho e
-             eos_state % rho = qleft(i,j,k,QRHO,idir)
-             eos_state % p   = qleft(i,j,k,QPRES,idir)
-             eos_state % T   = s(i,j,k,QTEMP) !some initial guess?
-             eos_state % xn  = qleft(i,j,k,QFS:QFS+nspec-1,idir)
+             if (idir == 1) then
+                eos_state % rho = qleft(i+1,j,k,QRHO,idir)
+                eos_state % p   = qleft(i+1,j,k,QPRES,idir)
+                eos_state % T   = s(i,j,k,QTEMP) !some initial guess?
+                eos_state % xn  = qleft(i+1,j,k,QFS:QFS+nspec-1,idir)
 
-             call eos(eos_input_rp, eos_state)
-             qleft(i,j,k,QREINT,idir) = eos_state % e * eos_state % rho
+                call eos(eos_input_rp, eos_state)
+                qleft(i+1,j,k,QREINT,idir) = eos_state % e * eos_state % rho
+
+             else if (idir == 2) then
+                eos_state % rho = qleft(i,j+1,k,QRHO,idir)
+                eos_state % p   = qleft(i,j+1,k,QPRES,idir)
+                eos_state % T   = s(i,j,k,QTEMP) !some initial guess?
+                eos_state % xn  = qleft(i,j+1,k,QFS:QFS+nspec-1,idir)
+
+                call eos(eos_input_rp, eos_state)
+                qleft(i,j+1,k,QREINT,idir) = eos_state % e * eos_state % rho
+
+             else
+                eos_state % rho = qleft(i,j,k+1,QRHO,idir)
+                eos_state % p   = qleft(i,j,k+1,QPRES,idir)
+                eos_state % T   = s(i,j,k,QTEMP) !some initial guess?
+                eos_state % xn  = qleft(i,j,k+1,QFS:QFS+nspec-1,idir)
+
+                call eos(eos_input_rp, eos_state)
+                qleft(i,j,k+1,QREINT,idir) = eos_state % e * eos_state % rho
+
+             end if
 
              eos_state % rho = qright(i,j,k,QRHO,idir)
              eos_state % p   = qright(i,j,k,QPRES,idir)
@@ -309,12 +349,30 @@ contains
              qright(i,j,k,QREINT,idir) = eos_state % e * eos_state % rho
 
              ! add source terms
-             qleft(i,j,k,QRHO,idir) = max(small_dens, qleft(i,j,k,QRHO,idir) + 0.5d0*dt*srcQ(i,j,k,QRHO))
-             qleft(i,j,k,QU,idir) = qleft(i,j,k,QU,idir) + 0.5d0*dt*srcQ(i,j,k,QU)
-             qleft(i,j,k,QV,idir) = qleft(i,j,k,QV,idir) + 0.5d0*dt*srcQ(i,j,k,QV)
-             qleft(i,j,k,QW,idir) = qleft(i,j,k,QW,idir) + 0.5d0*dt*srcQ(i,j,k,QW)
-             qleft(i,j,k,QPRES,idir) = qleft(i,j,k,QPRES,idir) + 0.5d0*dt*srcQ(i,j,k,QPRES)
-             qleft(i,j,k,QREINT,idir) = qleft(i,j,k,QREINT,idir) + 0.5d0*dt*srcQ(i,j,k,QREINT)
+             if (dir == 1) then
+                qleft(i+1,j,k,QRHO,idir) = max(small_dens, qleft(i+1,j,k,QRHO,idir) + 0.5d0*dt*srcQ(i,j,k,QRHO))
+                qleft(i+1,j,k,QU,idir) = qleft(i+1,j,k,QU,idir) + 0.5d0*dt*srcQ(i,j,k,QU)
+                qleft(i+1,j,k,QV,idir) = qleft(i+1,j,k,QV,idir) + 0.5d0*dt*srcQ(i,j,k,QV)
+                qleft(i+1,j,k,QW,idir) = qleft(i+1,j,k,QW,idir) + 0.5d0*dt*srcQ(i,j,k,QW)
+                qleft(i+1,j,k,QPRES,idir) = qleft(i+1,j,k,QPRES,idir) + 0.5d0*dt*srcQ(i,j,k,QPRES)
+                qleft(i+1,j,k,QREINT,idir) = qleft(i+1,j,k,QREINT,idir) + 0.5d0*dt*srcQ(i,j,k,QREINT)
+
+             else if (dir == 2) then
+                qleft(i,j+1,k,QRHO,idir) = max(small_dens, qleft(i,j+1,k,QRHO,idir) + 0.5d0*dt*srcQ(i,j,k,QRHO))
+                qleft(i,j+1,k,QU,idir) = qleft(i,j+1,k,QU,idir) + 0.5d0*dt*srcQ(i,j,k,QU)
+                qleft(i,j+1,k,QV,idir) = qleft(i,j+1,k,QV,idir) + 0.5d0*dt*srcQ(i,j,k,QV)
+                qleft(i,j+1,k,QW,idir) = qleft(i,j+1,k,QW,idir) + 0.5d0*dt*srcQ(i,j,k,QW)
+                qleft(i,j+1,k,QPRES,idir) = qleft(i,j+1,k,QPRES,idir) + 0.5d0*dt*srcQ(i,j,k,QPRES)
+                qleft(i,j+1,k,QREINT,idir) = qleft(i,j+1,k,QREINT,idir) + 0.5d0*dt*srcQ(i,j,k,QREINT)
+
+             else
+                qleft(i,j,k+1,QRHO,idir) = max(small_dens, qleft(i,j,k+1,QRHO,idir) + 0.5d0*dt*srcQ(i,j,k,QRHO))
+                qleft(i,j,k+1,QU,idir) = qleft(i,j,k+1,QU,idir) + 0.5d0*dt*srcQ(i,j,k,QU)
+                qleft(i,j,k+1,QV,idir) = qleft(i,j,k+1,QV,idir) + 0.5d0*dt*srcQ(i,j,k,QV)
+                qleft(i,j,k+1,QW,idir) = qleft(i,j,k+1,QW,idir) + 0.5d0*dt*srcQ(i,j,k,QW)
+                qleft(i,j,k+1,QPRES,idir) = qleft(i,j,k+1,QPRES,idir) + 0.5d0*dt*srcQ(i,j,k,QPRES)
+                qleft(i,j,k+1,QREINT,idir) = qleft(i,j,k+1,QREINT,idir) + 0.5d0*dt*srcQ(i,j,k,QREINT)
+             end if
 
              qright(i,j,k,QRHO,idir) = max(small_dens, qright(i,j,k,QRHO,idir) + 0.5d0*dt*srcQ(i,j,k,QRHO))
              qright(i,j,k,QU,idir) = qright(i,j,k,QU,idir) + 0.5d0*dt*srcQ(i,j,k,QU)


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

Previously for the MHD solver, we were storing q_{i+1/2,L} as qleft(i,j,k) and q_{i-1/2,R} as qright(i,j,k).  This shifts the indexing so (i,j,k) for an interface state always means {i-1/2,j,k}.  This makes the convention consistent with the other hydro solvers.

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
