### PR TITLE
Avoid possible sqrt of negative number in circvel

### DIFF
--- a/Source/driver/Derive.cpp
+++ b/Source/driver/Derive.cpp
@@ -659,7 +659,7 @@ extern "C"
                      dat(i,j,k,2)*y +
                      dat(i,j,k,3)*z) / ( dat(i,j,k,0)*r );
 
-          der(i,j,k,0) = std::sqrt(vtot2 - vr*vr);
+          der(i,j,k,0) = std::sqrt(amrex::max(vtot2 - vr*vr, 0.0_rt));
         }
 
       });


### PR DESCRIPTION

## PR summary

This avoids a possible square root of a negative number caused by roundoff error subtracting two numbers of approximately equal magnitude.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
