### PR TITLE
Add fluxes consistently between simplified SDC and CTU

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 20.07
+
+   * A bug where refluxing between AMR levels resulted in incorrect results
+     when a retry occurred in the previous timestep has been fixed. (#1018)
+
 # 20.06
 
    * The parameter castro.density_reset_method has been removed. A density

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -538,6 +538,8 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
         // will include Strang-split reactions; for simplified SDC, we defer the
         // burn until after the advance.
 
+        int num_sub_iters = 1;
+
         // Save the number of SDC iterations in case we are about to modify it.
 
         int sdc_iters_old = sdc_iters;
@@ -552,15 +554,17 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
                 sdc_iters += 1;
                 amrex::Print() << "Adding an SDC iteration due to the retry." << std::endl << std::endl;
             }
+
+            num_sub_iters = sdc_iters;
         }
 
         advance_status status;
 
-        for (int n = 0; n < sdc_iters; ++n) {
+        for (int n = 0; n < num_sub_iters; ++n) {
 
             if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
                 sdc_iteration = n;
-                amrex::Print() << "Beginning SDC iteration " << n + 1 << " of " << sdc_iters << "." << std::endl << std::endl;
+                amrex::Print() << "Beginning SDC iteration " << n + 1 << " of " << num_sub_iters << "." << std::endl << std::endl;
             }
 
             // We do the hydro advance here, and record whether we completed it.
@@ -617,7 +621,7 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
             }
 
             if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
-                amrex::Print() << "Ending SDC iteration " << n + 1 << " of " << sdc_iters << "." << std::endl << std::endl;
+                amrex::Print() << "Ending SDC iteration " << n + 1 << " of " << num_sub_iters << "." << std::endl << std::endl;
             }
 
         }

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1287,10 +1287,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
       nstep_fsp = std::max(nstep_fsp, priv_nstep_fsp);
 #endif
 
-#if AMREX_SPACEDIM <= 2
-      Array4<Real> pradial_fab = pradial.array();
-#endif
-
 
       for (int idir = 0; idir < AMREX_SPACEDIM; ++idir) {
 
@@ -1311,109 +1307,92 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 #endif
 
         if (idir == 0) {
-            // get the scaled radial pressure -- we need to treat this specially
-#if AMREX_SPACEDIM == 1
-            if (!Geom().IsCartesian()) {
-                amrex::ParallelFor(nbx,
-                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
-                {
-                    pradial_fab(i,j,k) = qex_arr(i,j,k,GDPRES) * dt;
-                });
-            }
+#if AMREX_SPACEDIM <= 2
+            Array4<Real> pradial_fab = pradial.array();
 #endif
 
-#if AMREX_SPACEDIM == 2
+            // get the scaled radial pressure -- we need to treat this specially
+#if AMREX_SPACEDIM <= 2
+
+#if AMREX_SPACEDIM == 1
+            if (!Geom().IsCartesian()) {
+#elif AMREX_SPACEDIM == 2
             if (!mom_flux_has_p(0, 0, coord)) {
+#endif
                 amrex::ParallelFor(nbx,
                 [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
                 {
                     pradial_fab(i,j,k) = qex_arr(i,j,k,GDPRES) * dt;
                 });
             }
+
 #endif
         }
 
-        // Store the fluxes from this advance.
+        // Store the fluxes from this advance. For simplified SDC integration we
+        // only need to do this on the last iteration.
 
-        // For normal integration we want to add the fluxes from this advance
-        // since we may be subcycling the timestep. But for simplified SDC integration
-        // we want to copy the fluxes since we expect that there will not be
-        // subcycling and we only want the last iteration's fluxes.
+        bool add_fluxes = true;
 
-        Array4<Real> const flux_fab = (flux[idir]).array();
-        Array4<Real> fluxes_fab = (*fluxes[idir]).array(mfi);
-        const int numcomp = NUM_STATE;
+        if (time_integration_method == SimplifiedSpectralDeferredCorrections &&
+            sdc_iteration == sdc_iters - 1) {
+            add_fluxes = false;
+        }
 
-        if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
+        if (add_fluxes) {
 
-            AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(idir), numcomp, i, j, k, n,
-            {
-                fluxes_fab(i,j,k,n) = flux_fab(i,j,k,n);
-            });
-
-        } else {
+            Array4<Real> const flux_fab = (flux[idir]).array();
+            Array4<Real> fluxes_fab = (*fluxes[idir]).array(mfi);
+            const int numcomp = NUM_STATE;
 
             AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(idir), numcomp, i, j, k, n,
             {
                 fluxes_fab(i,j,k,n) += flux_fab(i,j,k,n);
             });
 
-        }
-
 #ifdef RADIATION
-        Array4<Real> const rad_flux_fab = (rad_flux[idir]).array();
-        Array4<Real> rad_fluxes_fab = (*rad_fluxes[idir]).array(mfi);
-        const int radcomp = Radiation::nGroups;
-
-        if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
-
-            AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(idir), radcomp, i, j, k, n,
-            {
-                rad_fluxes_fab(i,j,k,n) = rad_flux_fab(i,j,k,n);
-            });
-
-        } else {
+            Array4<Real> const rad_flux_fab = (rad_flux[idir]).array();
+            Array4<Real> rad_fluxes_fab = (*rad_fluxes[idir]).array(mfi);
+            const int radcomp = Radiation::nGroups;
 
             AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(idir), radcomp, i, j, k, n,
             {
                 rad_fluxes_fab(i,j,k,n) += rad_flux_fab(i,j,k,n);
             });
 
-        }
 #endif
-
-        Array4<Real> mass_fluxes_fab = (*mass_fluxes[idir]).array(mfi);
-
-        AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(idir), 1, i, j, k, n,
-        {
-            mass_fluxes_fab(i,j,k,0) = flux_fab(i,j,k,URHO);
-        });
-
-      } // idir loop
 
 #if AMREX_SPACEDIM <= 2
-      if (!Geom().IsCartesian()) {
+            Array4<Real> pradial_fab = pradial.array();
+            Array4<Real> P_radial_fab = P_radial.array(mfi);
 
-          Array4<Real> P_radial_fab = P_radial.array(mfi);
-
-          if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
-
-              AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(0), 1, i, j, k, n,
-              {
-                  P_radial_fab(i,j,k,0) = pradial_fab(i,j,k,0);
-              });
-
-          } else {
-
-              AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(0), 1, i, j, k, n,
-              {
-                  P_radial_fab(i,j,k,0) += pradial_fab(i,j,k,0);
-              });
-
-          }
-
-      }
+#if AMREX_SPACEDIM == 1
+            if (idir == 0 && !Geom().IsCartesian()) {
+#elif AMREX_SPACEDIM == 2
+            if (idir == 0 && !mom_flux_has_p(0, 0, coord)) {
 #endif
+                AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(0), 1, i, j, k, n,
+                {
+                    P_radial_fab(i,j,k,0) += pradial_fab(i,j,k,0);
+                });
+
+            }
+#endif
+
+        } // add_fluxes
+
+         Array4<Real> mass_fluxes_fab = (*mass_fluxes[idir]).array(mfi);
+
+         AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(idir), 1, i, j, k, n,
+         {
+             // This is a copy, not an add, since we need mass_fluxes to be
+             // only this subcycle's data when we evaluate the gravitational
+             // forces.
+
+             mass_fluxes_fab(i,j,k,0) = flux_fab(i,j,k,URHO);
+         });
+
+      } // idir loop
 
       if (track_grid_losses == 1) {
 

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1381,16 +1381,17 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
         } // add_fluxes
 
-         Array4<Real> mass_fluxes_fab = (*mass_fluxes[idir]).array(mfi);
+        Array4<Real> const flux_fab = (flux[idir]).array();
+        Array4<Real> mass_fluxes_fab = (*mass_fluxes[idir]).array(mfi);
 
-         AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(idir), 1, i, j, k, n,
-         {
-             // This is a copy, not an add, since we need mass_fluxes to be
-             // only this subcycle's data when we evaluate the gravitational
-             // forces.
+        AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(idir), 1, i, j, k, n,
+        {
+            // This is a copy, not an add, since we need mass_fluxes to be
+            // only this subcycle's data when we evaluate the gravitational
+            // forces.
 
-             mass_fluxes_fab(i,j,k,0) = flux_fab(i,j,k,URHO);
-         });
+            mass_fluxes_fab(i,j,k,0) = flux_fab(i,j,k,URHO);
+        });
 
       } // idir loop
 

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1363,20 +1363,21 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 #endif
 
 #if AMREX_SPACEDIM <= 2
-            Array4<Real> pradial_fab = pradial.array();
-            Array4<Real> P_radial_fab = P_radial.array(mfi);
 
 #if AMREX_SPACEDIM == 1
             if (idir == 0 && !Geom().IsCartesian()) {
 #elif AMREX_SPACEDIM == 2
             if (idir == 0 && !mom_flux_has_p(0, 0, coord)) {
 #endif
+                Array4<Real> pradial_fab = pradial.array();
+                Array4<Real> P_radial_fab = P_radial.array(mfi);
+
                 AMREX_HOST_DEVICE_FOR_4D(mfi.nodaltilebox(0), 1, i, j, k, n,
                 {
                     P_radial_fab(i,j,k,0) += pradial_fab(i,j,k,0);
                 });
-
             }
+
 #endif
 
         } // add_fluxes

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1335,7 +1335,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
         bool add_fluxes = true;
 
         if (time_integration_method == SimplifiedSpectralDeferredCorrections &&
-            sdc_iteration == sdc_iters - 1) {
+            sdc_iteration != sdc_iters - 1) {
             add_fluxes = false;
         }
 


### PR DESCRIPTION

## PR summary

At the end of the CTU hydro loop, we store the local Fab data from the fluxes and pressure into fluxes, mass_fluxes, and P_radial. This is done as an add because in general we subcycle the CTU advance, and we want the fluxes at the end of the timestep to be the sum of the fluxes from all subcycles. Then this data is reused later in the reflux.

Previously, for simplified SDC, we were copying the data instead of adding it, because we didn't want to add for each simplified SDC iteration, and when retry subcycling was added, it didn't work for simplified SDC. However we can now retry with simplified SDC, so we make it consistent with the CTU advance by adding fluxes as well, but only on the last SDC iteration.

In order to do this we modify Castro_advance_ctu.cpp slightly so that `sdc_iters` is directly modified on a retry (so that we can read its current value in the hydro advance).

We also correct the fact that P_radial was being stored inconsistently; we stored it always for non-Cartesian geometries, which was different from the logic we used for calculating the local pradial_fab update.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
