### PR TITLE
Disable agglomeration and consolidation in diffusion MLMG

### DIFF
--- a/Source/diffusion/Diffusion.cpp
+++ b/Source/diffusion/Diffusion.cpp
@@ -154,9 +154,14 @@ Diffusion::applyop_mlmg (int level, MultiFab& Temperature,
     const Geometry& geom = parent->Geom(level);
     const BoxArray& ba = Temperature.boxArray();
     const DistributionMapping& dm = Temperature.DistributionMap();
-    
-    MLABecLaplacian mlabec({geom}, {ba}, {dm},
-                           LPInfo().setMetricTerm(true).setMaxCoarseningLevel(0));
+
+    LPInfo info;
+    info.setMetricTerm(true);
+    info.setMaxCoarseningLevel(0);
+    info.setAgglomeration(0);
+    info.setConsolidation(0);
+
+    MLABecLaplacian mlabec({geom}, {ba}, {dm}, info);
     mlabec.setMaxOrder(diffusion::mlmg_maxorder);
 
     mlabec.setDomainBC(mlmg_lobc, mlmg_hibc);


### PR DESCRIPTION

## PR summary

The MLMG operator used in diffusion now has agglomeration and consolidation disabled. These were not relevant since we're just calling apply_op, not doing V-cycles, and it turns out that one of the functions (`makeSubCommunicator()`) does not scale well to O(10k) ranks on Summit.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
