### PR TITLE
Move simplified SDC burn into CTU advance

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -272,9 +272,49 @@ Castro::do_advance_ctu(Real time,
       expand_state(S_new, cur_time, S_new.nGrow());
     }
 
-    // Do the second half of the reactions.
+    // Do the second half of the reactions for Strang, or the full burn for simplified SDC.
 
 #ifdef REACTIONS
+
+#ifdef SIMPLIFIED_SDC
+
+    if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
+
+        if (do_react) {
+
+            // Do the ODE integration to capture the reaction source terms.
+
+            bool burn_success = react_state(time, dt);
+
+            // Skip the rest of the advance if the burn was unsuccessful.
+
+            if (!burn_success) {
+                status.success = false;
+                status.reason = "burn unsuccessful";
+                return status;
+            }
+
+            MultiFab& S_new = get_new_data(State_Type);
+
+            clean_state(S_new, time + dt, S_new.nGrow());
+
+            // Compute the reactive source term for use in the next iteration.
+
+            MultiFab& SDC_react_new = get_new_data(Simplified_SDC_React_Type);
+            get_react_source_prim(SDC_react_new, time, dt);
+
+            // Check for NaN's.
+
+#ifndef AMREX_USE_CUDA
+            check_for_nan(S_new);
+#endif
+
+        }
+
+    }
+
+#else // SIMPLIFIED_SDC
+
     if (time_integration_method != SimplifiedSpectralDeferredCorrections) {
 
         burn_success = react_state(S_new, R_new, cur_time - 0.5 * dt, 0.5 * dt);
@@ -289,7 +329,10 @@ Castro::do_advance_ctu(Real time,
         }
 
     }
-#endif
+
+#endif // SIMPLIFIED_SDC
+
+#endif // REACTIONS
 
     // Check if this timestep violated our stability criteria. Our idea is,
     // if the timestep created a velocity v and sound speed at the new time
@@ -568,44 +611,8 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
             }
 
             // We do the hydro advance here, and record whether we completed it.
-            // If we are doing simplified SDC, there is no point in doing the burn
-            // or the subsequent SDC iterations if the advance was incomplete.
 
             status = do_advance_ctu(subcycle_time, dt_subcycle, amr_iteration, amr_ncycle);
-
-#ifdef SIMPLIFIED_SDC
-#ifdef REACTIONS
-            if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
-                if (do_react && status.success) {
-
-                    // Do the ODE integration to capture the reaction source terms.
-
-                    bool burn_success = react_state(subcycle_time, dt_subcycle);
-
-                    if (!burn_success) {
-                        status.success = false;
-                        status.reason = "burn unsuccessful";
-                    }
-
-                    MultiFab& S_new = get_new_data(State_Type);
-
-                    clean_state(S_new, subcycle_time + dt_subcycle, S_new.nGrow());
-
-                    // Compute the reactive source term for use in the next iteration.
-
-                    MultiFab& SDC_react_new = get_new_data(Simplified_SDC_React_Type);
-                    get_react_source_prim(SDC_react_new, subcycle_time, dt_subcycle);
-
-                    // Check for NaN's.
-
-#ifndef AMREX_USE_CUDA
-                    check_for_nan(S_new);
-#endif
-
-                }
-            }
-#endif
-#endif
 
             if (in_retry) {
                 in_retry = false;


### PR DESCRIPTION
## PR summary

Since the simplified SDC burn was happening right after do_advance_ctu, this change simplifies the logic so it happens just inside instead.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
