### PR TITLE
Use conservative state in check_for_cfl_violation

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -168,7 +168,7 @@ Castro::do_advance_ctu(Real time,
       cons_to_prim(time);
 
       // Check for CFL violations.
-      check_for_cfl_violation(dt);
+      check_for_cfl_violation(S_old, dt);
 
       // If we detect one, return immediately.
       if (cfl_violation) {

--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -170,7 +170,7 @@ Castro::do_advance_sdc (Real time,
 
       if (do_hydro) {
         // Check for CFL violations.
-        check_for_cfl_violation(dt);
+        check_for_cfl_violation(S_old, dt);
 
         // If we detect one, return immediately.
         if (cfl_violation)

--- a/Source/hydro/Castro_hydro.H
+++ b/Source/hydro/Castro_hydro.H
@@ -27,9 +27,10 @@
 ///
 /// Check to see if the CFL condition has been violated
 ///
+/// @param State MultiFab of conserved variables
 /// @param dt timestep
 ///
-    void check_for_cfl_violation(const amrex::Real dt);
+    void check_for_cfl_violation(const amrex::MultiFab& State, const amrex::Real dt);
 
 ///
 /// this constructs the hydrodynamic source (essentially the flux

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -228,7 +228,7 @@ Castro::cons_to_prim_fourth(const Real time)
 #endif
 
 void
-Castro::check_for_cfl_violation(const Real dt)
+Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
 {
 
     BL_PROFILE("Castro::check_for_cfl_violation()");
@@ -247,10 +247,6 @@ Castro::check_for_cfl_violation(const Real dt)
       dtdz = dt / dx[2];
     }
 
-    MultiFab& S_new = get_new_data(State_Type);
-
-    int ltime_integration_method = time_integration_method;
-
     ReduceOps<ReduceOpMax> reduce_op;
     ReduceData<Real> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -258,23 +254,45 @@ Castro::check_for_cfl_violation(const Real dt)
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    for (MFIter mfi(S_new, hydro_tile_size); mfi.isValid(); ++mfi) {
+    for (MFIter mfi(State, hydro_tile_size); mfi.isValid(); ++mfi) {
 
         const Box& bx = mfi.tilebox();
 
-        auto qaux_arr = qaux.array(mfi);
-        auto q_arr = q.array(mfi);
+        auto U = State.array(mfi);
 
         reduce_op.eval(bx, reduce_data,
         [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
         {
             // Compute running max of Courant number over grids
 
-            Real courx = (qaux_arr(i,j,k,QC) + std::abs(q_arr(i,j,k,QU))) * dtdx;
-            Real coury = (qaux_arr(i,j,k,QC) + std::abs(q_arr(i,j,k,QV))) * dtdy;
-            Real courz = (qaux_arr(i,j,k,QC) + std::abs(q_arr(i,j,k,QW))) * dtdz;
+            Real rho = U(i,j,k,URHO);
+            Real rhoInv = 1.0 / rho;
 
-            if (ltime_integration_method == 0) {
+            Real u = U(i,j,k,UMX) * rhoInv;
+            Real v = U(i,j,k,UMY) * rhoInv;
+            Real w = U(i,j,k,UMZ) * rhoInv;
+
+            eos_t eos_state;
+
+            eos_state.rho = U(i,j,k,URHO);
+            eos_state.T = U(i,j,k,UTEMP);
+            eos_state.e = U(i,j,k,UEINT) * rhoInv;
+            for (int n = 0; n < NumSpec; n++) {
+                eos_state.xn[n] = U(i,j,k,UFS+n) * rhoInv;
+            }
+            for (int n = 0; n < NumAux; n++) {
+                eos_state.aux[n] = U(i,j,k,UFX+n) * rhoInv;
+            }
+
+            eos(eos_input_re, eos_state);
+
+            Real cs = eos_state.cs;
+
+            Real courx = (cs + std::abs(u)) * dtdx;
+            Real coury = (cs + std::abs(v)) * dtdy;
+            Real courz = (cs + std::abs(w)) * dtdz;
+
+            if (castro::time_integration_method == 0) {
 
 #ifndef AMREX_USE_CUDA
                 if (verbose == 1) {
@@ -284,8 +302,8 @@ Castro::check_for_cfl_violation(const Real dt)
                         std::cout << "Warning:: CFL violation in check_for_cfl_violation" << std::endl;
                         std::cout << ">>> ... (u+c) * dt / dx > 1 " << courx << std::endl;
                         std::cout << ">>> ... at cell i = " << i << " j = " << j << " k = " << k << std::endl;
-                        std::cout << ">>> ... u = " << q_arr(i,j,k,QU) << " c = " << qaux_arr(i,j,k,QC) << std::endl;
-                        std::cout << ">>> ... density = " << q_arr(i,j,k,QRHO) << std::endl;
+                        std::cout << ">>> ... u = " << u << " c = " << cs << std::endl;
+                        std::cout << ">>> ... density = " << rho << std::endl;
                     }
 
                     if (coury > 1.0_rt) {
@@ -293,8 +311,8 @@ Castro::check_for_cfl_violation(const Real dt)
                         std::cout << "Warning:: CFL violation in check_for_cfl_violation" << std::endl;
                         std::cout << ">>> ... (v+c) * dt / dx > 1 " << coury << std::endl;
                         std::cout << ">>> ... at cell i = " << i << " j = " << j << " k = " << k << std::endl;
-                        std::cout << ">>> ... v = " << q_arr(i,j,k,QV) << " c = " << qaux_arr(i,j,k,QC) << std::endl;
-                        std::cout << ">>> ... density = " << q_arr(i,j,k,QRHO) << std::endl;
+                        std::cout << ">>> ... v = " << v << " c = " << cs << std::endl;
+                        std::cout << ">>> ... density = " << rho << std::endl;
                     }
 
                     if (courz > 1.0_rt) {
@@ -302,8 +320,8 @@ Castro::check_for_cfl_violation(const Real dt)
                         std::cout << "Warning:: CFL violation in check_for_cfl_violation" << std::endl;
                         std::cout << ">>> ... (w+c) * dt / dx > 1 " << courz << std::endl;
                         std::cout << ">>> ... at cell i = " << i << " j = " << j << " k = " << k << std::endl;
-                        std::cout << ">>> ... w = " << q_arr(i,j,k,QW) << " c = " << qaux_arr(i,j,k,QC) << std::endl;
-                        std::cout << ">>> ... density = " << q_arr(i,j,k,QRHO) << std::endl;
+                        std::cout << ">>> ... w = " << w << " c = " << cs << std::endl;
+                        std::cout << ">>> ... density = " << rho << std::endl;
                     }
 
                 }
@@ -333,9 +351,9 @@ Castro::check_for_cfl_violation(const Real dt)
                         std::cout << std::endl;
                         std::cout << "Warning:: CFL violation in check_for_cfl_violation" << std::endl;
                         std::cout << ">>> ... at cell i = " << i << " j = " << j << " k = " << k << std::endl;
-                        std::cout << ">>> ... u = " << q_arr(i,j,k,QU) << " v = " << q_arr(i,j,k,QV)
-                                  << " w = " << q_arr(i,j,k,QW) << " c = " << qaux_arr(i,j,k,QC) << std::endl;
-                        std::cout << ">>> ... density = " << q_arr(i,j,k,QRHO) << std::endl;
+                        std::cout << ">>> ... u = " << u << " v = " << v
+                                  << " w = " << w << " c = " << cs << std::endl;
+                        std::cout << ">>> ... density = " << rho << std::endl;
                     }
 
                 }


### PR DESCRIPTION

## PR summary

Previously this routine used the primitive state; now it uses the conserved state.

## PR motivation

This helps prepare for #908, by removing the main blocker from putting cons_to_prim inside the hydro update.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
