### PR TITLE
Remove obsolete castro.print_fortran_warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # 20.07
 
+   * The parameter castro.print_fortran_warnings, which no longer had any
+     effect, has been removed. (#1036)
+
    * PPM reconstruction has been added to the MHD solver (#1002)
 
    * The Reactions_Type StateData has been reworked so that its first

--- a/Exec/hydro_tests/rotating_torus/inputs_3d
+++ b/Exec/hydro_tests/rotating_torus/inputs_3d
@@ -65,7 +65,6 @@ castro.sum_interval   = 1       # timesteps between computing mass
 castro.v              = 1       # verbosity in Castro.cpp
 amr.v                 = 1       # verbosity in Amr.cpp
 castro.print_energy_diagnostics = 1
-castro.print_fortran_warnings = 1
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed

--- a/Exec/hydro_tests/rotating_torus/inputs_3d.test
+++ b/Exec/hydro_tests/rotating_torus/inputs_3d.test
@@ -63,7 +63,6 @@ castro.sum_interval   = 1       # timesteps between computing mass
 castro.v              = 1       # verbosity in Castro.cpp
 amr.v                 = 1       # verbosity in Amr.cpp
 castro.print_energy_diagnostics = 1
-castro.print_fortran_warnings = 1
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed

--- a/Exec/science/convective_flame/exploration/inputs.2d.template
+++ b/Exec/science/convective_flame/exploration/inputs.2d.template
@@ -40,8 +40,6 @@ castro.use_flattening = 1
 
 castro.riemann_solver = 0
 
-castro.print_fortran_warnings = 1
-
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -4.2e7
 

--- a/Exec/science/convective_flame/inputs.2d.test
+++ b/Exec/science/convective_flame/inputs.2d.test
@@ -40,8 +40,6 @@ castro.use_flattening = 1
 
 castro.riemann_solver = 0
 
-castro.print_fortran_warnings = 1
-
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -4.2e7
 

--- a/Exec/science/convective_flame/inputs.2d.testsuite
+++ b/Exec/science/convective_flame/inputs.2d.testsuite
@@ -40,8 +40,6 @@ castro.use_flattening = 1
 
 castro.riemann_solver = 0
 
-castro.print_fortran_warnings = 1
-
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -4.2e7
 

--- a/Exec/science/convective_flame/inputs.2d_good
+++ b/Exec/science/convective_flame/inputs.2d_good
@@ -40,8 +40,6 @@ castro.use_flattening = 1
 
 castro.riemann_solver = 0
 
-castro.print_fortran_warnings = 1
-
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -4.2e7
 

--- a/Exec/science/convective_flame/inputs.3d.test
+++ b/Exec/science/convective_flame/inputs.3d.test
@@ -36,8 +36,6 @@ castro.do_sponge = 1
 
 castro.ppm_type = 1
 
-castro.print_fortran_warnings = 1
-
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -4.2e7
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -542,9 +542,6 @@ dump_old                     bool          false
 # last spatial dimension is vertical
 domain_is_plane_parallel     bool          false
 
-# display warnings in Fortran90 routines
-print_fortran_warnings       int           (0, 1)
-
 # display information about updates to the state (how much mass, momentum, energy added)
 print_update_diagnostics     int           (0, 1)
 


### PR DESCRIPTION

## PR summary

This parameter no longer had any effect, since the Fortran routines that used it have all been converted to C++.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
