### PR TITLE
Write a wrapper for print_update_diagnostics

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3052,31 +3052,11 @@ Castro::enforce_min_density (MultiFab& state_in, int ng)
 
     if (print_update_diagnostics)
     {
-
         // Evaluate what the effective reset source was.
 
         MultiFab::Subtract(reset_source, state_in, 0, 0, state_in.nComp(), 0);
 
-        bool local = true;
-        Vector<Real> reset_update = evaluate_source_change(reset_source, 1.0, local);
-
-#ifdef BL_LAZY
-        Lazy::QueueReduction( [=] () mutable {
-#endif
-            ParallelDescriptor::ReduceRealSum(reset_update.dataPtr(), reset_update.size(), ParallelDescriptor::IOProcessorNumber());
-
-            if (ParallelDescriptor::IOProcessor()) {
-                if (std::abs(reset_update[0]) != 0.0) {
-                    std::cout << std::endl << "  Contributions to the state from negative density resets:" << std::endl;
-
-                    print_source_change(reset_update);
-                }
-            }
-
-#ifdef BL_LAZY
-        });
-#endif
-
+        evaluate_and_print_source_change(reset_source, 1.0, "negative density resets");
     }
 
 }
@@ -3472,25 +3452,7 @@ Castro::reset_internal_energy(
 
         MultiFab::Subtract(reset_source, old_state, 0, 0, old_state.nComp(), 0);
 
-        bool local = true;
-        Vector<Real> reset_update = evaluate_source_change(reset_source, 1.0, local);
-
-#ifdef BL_LAZY
-        Lazy::QueueReduction( [=] () mutable {
-#endif
-            ParallelDescriptor::ReduceRealSum(reset_update.dataPtr(), reset_update.size(), ParallelDescriptor::IOProcessorNumber());
-
-            if (ParallelDescriptor::IOProcessor()) {
-                if (std::abs(reset_update[UEINT]) != 0.0) {
-                    std::cout << std::endl << "  Contributions to the state from negative energy resets:" << std::endl;
-
-                    print_source_change(reset_update);
-                }
-            }
-
-#ifdef BL_LAZY
-        });
-#endif
+        evaluate_and_print_source_change(reset_source, 1.0, "negative energy resets");
     }
 }
 

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -176,6 +176,10 @@ Castro::do_advance_ctu(Real time,
 
       construct_ctu_hydro_source(time, dt);
       apply_source_to_state(S_new, hydro_source, dt, 0);
+
+      if (print_update_diagnostics) {
+          evaluate_and_print_source_change(hydro_source, dt, "hydro source");
+      }
 #else
       just_the_mhd(time, dt);
       apply_source_to_state(S_new, hydro_source, dt, 0);

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1474,27 +1474,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
   if (verbose)
     flush_output();
-
-  if (print_update_diagnostics)
-    {
-
-      bool local = true;
-      Vector<Real> hydro_update = evaluate_source_change(hydro_source, dt, local);
-
-#ifdef BL_LAZY
-      Lazy::QueueReduction( [=] () mutable {
-#endif
-         ParallelDescriptor::ReduceRealSum(hydro_update.dataPtr(), hydro_update.size(), ParallelDescriptor::IOProcessorNumber());
-
-         if (ParallelDescriptor::IOProcessor())
-           std::cout << std::endl << "  Contributions to the state from the hydro source:" << std::endl;
-
-         print_source_change(hydro_update);
-
-#ifdef BL_LAZY
-      });
-#endif
-    }
 #endif
 
   if (verbose && ParallelDescriptor::IOProcessor())

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1469,11 +1469,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
      });
 #endif
   }
-#else
-  // Flush Fortran output
-
-  if (verbose)
-    flush_output();
 #endif
 
   if (verbose && ParallelDescriptor::IOProcessor())

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -761,25 +761,8 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
     flush_output();
 
 
-  if (print_update_diagnostics)
-    {
-
-      bool local = true;
-      Vector<Real> hydro_update = evaluate_source_change(A_update, dt, local);
-
-#ifdef BL_LAZY
-      Lazy::QueueReduction( [=] () mutable {
-#endif
-          ParallelDescriptor::ReduceRealSum(hydro_update.dataPtr(), hydro_update.size(), ParallelDescriptor::IOProcessorNumber());
-
-          if (ParallelDescriptor::IOProcessor())
-            std::cout << std::endl << "  Contributions to the state from the hydro source:" << std::endl;
-
-          print_source_change(hydro_update);
-
-#ifdef BL_LAZY
-        });
-#endif
+  if (print_update_diagnostics) {
+      evaluate_and_print_source_change(A_update, dt, "hydro source");
     }
 
     if (verbose > 0)

--- a/Source/sources/Castro_sources.H
+++ b/Source/sources/Castro_sources.H
@@ -126,7 +126,7 @@
 ///                 globally over all processes
 ///                 or locally just on this processor?
 ///
-    amrex::Vector<amrex::Real> evaluate_source_change(amrex::MultiFab& update, amrex::Real dt,
+    amrex::Vector<amrex::Real> evaluate_source_change(const amrex::MultiFab& update, amrex::Real dt,
                                                       bool local = false);
 
 
@@ -150,6 +150,16 @@
 ///
     void print_all_source_changes(amrex::Real dt, bool is_new);
 
+
+///
+/// Evaluate the change to the state due to sources and then print it.
+///
+/// @param source       update to the state
+/// @param dt           timestep (will multiply the update)
+/// @param source_name  string to associate with this source
+///
+    void evaluate_and_print_source_change(const amrex::MultiFab& source, amrex::Real dt,
+                                          std::string source_name);
 
 ///
 /// Obtain the sum of all source terms.

--- a/Source/sources/Castro_sources.cpp
+++ b/Source/sources/Castro_sources.cpp
@@ -424,11 +424,11 @@ Castro::apply_sources()
 // Note that the resultant output is volume-weighted.
 
 Vector<Real>
-Castro::evaluate_source_change(MultiFab& source, Real dt, bool local)
+Castro::evaluate_source_change(const MultiFab& source, Real dt, bool local)
 {
 
   BL_PROFILE("Castro::evaluate_source_change()");
-    
+
   Vector<Real> update(source.nComp(), 0.0);
 
   // Create a temporary array which will hold a single component
@@ -465,12 +465,8 @@ Castro::print_source_change(Vector<Real> update)
 
     std::cout << "       mass added: " << update[URHO] << std::endl;
     std::cout << "       xmom added: " << update[UMX] << std::endl;
-#if (BL_SPACEDIM >= 2)
     std::cout << "       ymom added: " << update[UMY] << std::endl;
-#endif
-#if (BL_SPACEDIM == 3)
     std::cout << "       zmom added: " << update[UMZ] << std::endl;
-#endif
     std::cout << "       eint added: " << update[UEINT] << std::endl;
     std::cout << "       ener added: " << update[UEDEN] << std::endl;
 
@@ -481,38 +477,44 @@ Castro::print_source_change(Vector<Real> update)
 
 }
 
+// Calculate the changes to the state due to a source term,
+// and also print the results.
+
+void
+Castro::evaluate_and_print_source_change (const MultiFab& source, Real dt, std::string source_name)
+{
+    bool local = true;
+    Vector<Real> update = evaluate_source_change(source, dt, local);
+
+#ifdef BL_LAZY
+    Lazy::QueueReduction( [=] () mutable {
+#endif
+        ParallelDescriptor::ReduceRealSum(update.dataPtr(), update.size(), ParallelDescriptor::IOProcessorNumber());
+
+        if (ParallelDescriptor::IOProcessor()) {
+            if (std::abs(update[URHO]) != 0.0 || std::abs(update[UEDEN]) != 0.0) {
+                std::cout << std::endl << "  Contributions to the state from " << source_name << ":" << std::endl;
+
+                print_source_change(update);
+            }
+        }
+
+#ifdef BL_LAZY
+    });
+#endif
+}
+
 // For the old-time or new-time sources update, evaluate the change in the state
 // for all source terms, then print the results.
 
 void
 Castro::print_all_source_changes(Real dt, bool is_new)
 {
+    MultiFab& source = is_new ? get_new_data(Source_Type) : get_old_data(Source_Type);
 
-  Vector<Real> summed_updates;
+    std::string source_name = is_new? "new-time sources" : "old-time sources";
 
-  bool local = true;
-
-  MultiFab& source = is_new ? get_new_data(Source_Type) : get_old_data(Source_Type);
-
-  summed_updates = evaluate_source_change(source, dt, local);
-
-#ifdef BL_LAZY
-  Lazy::QueueReduction( [=] () mutable {
-#endif
-
-      ParallelDescriptor::ReduceRealSum(summed_updates.dataPtr(), source.nComp(), ParallelDescriptor::IOProcessorNumber());
-
-      std::string time = is_new ? "new" : "old";
-
-      if (ParallelDescriptor::IOProcessor())
-          std::cout << std::endl << "  Contributions to the state from the " << time << "-time sources:" << std::endl;
-
-      print_source_change(summed_updates);
-
-#ifdef BL_LAZY
-    });
-#endif
-
+    evaluate_and_print_source_change(source, dt, source_name);
 }
 
 // Obtain the sum of all source terms.


### PR DESCRIPTION

## PR summary

Code redundancy is reduced because a few places that were repeating logic for how to sum up and print the contributions to the state are combined into a single wrapper function.

The diagnostics for the CTU hydro source are moved into the CTU advance rather than being called directly in the source constructor.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [x] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
