### PR TITLE
Fix lambda capture of dx in MGutils

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # 20.07
 
+   * A CUDA illegal memory access error in Poisson gravity and diffusion
+     has been fixed (#1039).
+
    * The parameter castro.track_grid_losses has been removed. (#1035)
 
    * The parameter castro.print_fortran_warnings, which no longer had any

--- a/Source/diffusion/Diffusion.cpp
+++ b/Source/diffusion/Diffusion.cpp
@@ -79,8 +79,9 @@ Diffusion::applyop (int level, MultiFab& Temperature,
 void
 Diffusion::weight_cc(int level, MultiFab& cc)
 {
-    const Real* dx = parent->Geom(level).CellSize();
+    auto dx = parent->Geom(level).CellSizeArray();
     const int coord_type = parent->Geom(level).Coord();
+
 #ifdef _OPENMP
 #pragma omp parallel      
 #endif
@@ -95,8 +96,9 @@ Diffusion::weight_cc(int level, MultiFab& cc)
 void
 Diffusion::unweight_cc(int level, MultiFab& cc)
 {
-    const Real* dx = parent->Geom(level).CellSize();
+    auto dx = parent->Geom(level).CellSizeArray();
     const int coord_type = parent->Geom(level).Coord();
+
 #ifdef _OPENMP
 #pragma omp parallel      
 #endif

--- a/Source/driver/MGutils.H
+++ b/Source/driver/MGutils.H
@@ -14,26 +14,26 @@ apply_metric(const Box& bx,
 #if AMREX_SPACEDIM >= 2
              Array4<Real> const ecy, const Box& ybx,
 #endif
-             const Real* dx,
+             GpuArray<Real, AMREX_SPACEDIM> dx,
              const int coord_type);
 
 void
 do_weight_cc(const Box& bx,
              Array4<Real> const cc,
-             const Real* dx,
+             GpuArray<Real, AMREX_SPACEDIM> dx,
              const int coord_type);
 
 void
 do_unweight_cc(const Box& bx,
                Array4<Real> const cc,
-               const Real* dx,
+               GpuArray<Real, AMREX_SPACEDIM> dx,
                const int coord_type);
 
 void
 do_unweight_edges(const Box& bx,
                   Array4<Real> const ec,
                   const int idir,
-                  const Real* dx,
+                  GpuArray<Real, AMREX_SPACEDIM> dx,
                   const int coord_type);
 
 #endif

--- a/Source/driver/MGutils.cpp
+++ b/Source/driver/MGutils.cpp
@@ -10,105 +10,92 @@ apply_metric(const Box& bx,
 #if AMREX_SPACEDIM >= 2
              Array4<Real> const ecy, const Box& ybx,
 #endif
-             const Real* dx,
+             GpuArray<Real, AMREX_SPACEDIM> dx,
              const int coord_type)
 {
+    // r-z
+    if (coord_type == 1) {
 
-  // r-z
-  if (coord_type == 1) {
+        amrex::ParallelFor(bx,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        {
 
-    AMREX_PARALLEL_FOR_3D(bx, i, j, k,
-    {
+            IntVect idx(D_DECL(i, j, k));
 
-     IntVect idx(D_DECL(i, j, k));
+            // at centers
+            if (rbx.contains(idx)) {
+                Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
+                rhs(i,j,k) *= r;
+            }
 
-     // at centers
-     if (rbx.contains(idx)) {
-       Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
-       rhs(i,j,k) *= r;
-     }
-
-     // On x-edges
-     if (xbx.contains(idx)) {
-       Real r = static_cast<Real>(i) * dx[0];
-       ecx(i,j,k) *= r;
-     }
+            // On x-edges
+            if (xbx.contains(idx)) {
+                Real r = static_cast<Real>(i) * dx[0];
+                ecx(i,j,k) *= r;
+            }
 
 #if AMREX_SPACEDIM >= 2
-     // On y-edges
-     if (ybx.contains(idx)) {
-       Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
-       ecy(i,j,k) *= r;
-     }
+            // On y-edges
+            if (ybx.contains(idx)) {
+                Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
+                ecy(i,j,k) *= r;
+            }
 #endif
 
-    });
+        });
 
-#ifndef AMREX_USE_CUDA
-  } else {
-
-    amrex::Print() << "Bogus coord_type in apply_metric " << coord_type << std::endl;
-
-    amrex::Error("Error:: MGutils.cpp :: ca_apply_metric");
-#endif
-
-  }
+    } else {
+        amrex::Print() << "Bogus coord_type in apply_metric " << coord_type << std::endl;
+        amrex::Error("Error:: MGutils.cpp :: ca_apply_metric");
+    }
 }
 
 
 void
 do_weight_cc(const Box& bx,
              Array4<Real> const cc,
-             const Real* dx,
+             GpuArray<Real, AMREX_SPACEDIM> dx,
              const int coord_type)
 {
+    // r-z
+    if (coord_type == 1) {
 
-  // r-z
-  if (coord_type == 1) {
+        // At centers
+        amrex::ParallelFor(bx,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        {
+            Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
+            cc(i,j,k) *= r;
+        });
 
-    // At centers
-    AMREX_PARALLEL_FOR_3D(bx, i, j, k,
-    {
-
-      Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
-      cc(i,j,k) *= r;
-    });
-
-#ifndef AMREX_USE_CUDA
-  } else {
-
-    amrex::Print() << "Bogus coord_type in weight_cc " << coord_type << std::endl;
-    amrex::Error("Error:: MGutils.cpp :: ca_weight_cc");
-#endif
-  }
+    } else {
+      amrex::Print() << "Bogus coord_type in weight_cc " << coord_type << std::endl;
+      amrex::Error("Error:: MGutils.cpp :: ca_weight_cc");
+    }
 }
 
 
 void
 do_unweight_cc(const Box& bx,
                Array4<Real> const cc,
-               const Real* dx,
+               GpuArray<Real, AMREX_SPACEDIM> dx,
                const int coord_type)
 {
+    // r-z
+    if (coord_type == 1) {
 
-  // r-z
-  if (coord_type == 1) {
+        // At centers
+        amrex::ParallelFor(bx,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        {
+            Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
+            cc(i,j,k) /= r;
+        });
 
-    // At centers
-    AMREX_PARALLEL_FOR_3D(bx, i, j, k,
-    {
-
-      Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
-      cc(i,j,k) /= r;
-    });
-
-#ifndef AMREX_USE_CUDA
-  } else {
-
-    amrex::Print() << "Bogus coord_type in unweight_cc " << coord_type << std::endl;
-    amrex::Error("Error:: MGutils.cpp :: ca_unweight_cc");
-#endif
-  }
+    } else {
+        amrex::Print() << "Bogus coord_type in unweight_cc " << coord_type << std::endl;
+        amrex::Error("Error:: MGutils.cpp :: ca_unweight_cc");
+    }
 }
 
 
@@ -116,41 +103,38 @@ void
 do_unweight_edges(const Box& bx,
                   Array4<Real> const ec,
                   const int idir,
-                  const Real* dx,
+                  GpuArray<Real, AMREX_SPACEDIM> dx,
                   const int coord_type)
 {
+    // r-z
+    if (coord_type == 1) {
 
-  // r-z
-  if (coord_type == 1) {
+        if (idir == 0) {
 
-    if (idir == 0) {
+            // On x-edges
+            amrex::ParallelFor(bx,
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            {
+                if (i != 0) {
+                    Real r = static_cast<Real>(i) * dx[0];
+                    ec(i,j,k) /= r;
+                }
+            });
 
-      // On x-edges
-      AMREX_PARALLEL_FOR_3D(bx, i, j, k,
-      {
+        } else {
 
-        if (i != 0) {
-          Real r = static_cast<Real>(i) * dx[0];
-          ec(i,j,k) /= r;
+            // On y-edges
+            amrex::ParallelFor(bx,
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            {
+                Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
+                ec(i,j,k) /= r;
+            });
         }
-      });
 
     } else {
-
-      // On y-edges
-      AMREX_PARALLEL_FOR_3D(bx, i, j, k,
-      {
-        Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
-        ec(i,j,k) /= r;
-      });
+        amrex::Print() << "Bogus coord_type in unweight_edges " << coord_type << std::endl;
+        amrex::Error("Error:: MGutils.cpp :: ca_unweight_edges");
     }
-
-#ifndef AMREX_USE_CUDA
-  } else {
-
-    amrex::Print() << "Bogus coord_type in unweight_edges " << coord_type << std::endl;
-    amrex::Error("Error:: MGutils.cpp :: ca_unweight_edges");
-#endif
-  }
 }
 

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -2070,9 +2070,10 @@ void
 Gravity::applyMetricTerms(int level, MultiFab& Rhs, const Vector<MultiFab*>& coeffs)
 {
     BL_PROFILE("Gravity::applyMetricTerms()");
-    
-    const Real* dx = parent->Geom(level).CellSize();
+
+    auto dx = parent->Geom(level).CellSizeArray();
     int coord_type = parent->Geom(level).Coord();
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -2099,9 +2100,10 @@ void
 Gravity::unweight_cc(int level, MultiFab& cc)
 {
     BL_PROFILE("Gravity::unweight_cc()");
-    
-    const Real* dx = parent->Geom(level).CellSize();
+
+    auto dx = parent->Geom(level).CellSizeArray();
     const int coord_type = parent->Geom(level).Coord();
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -2117,19 +2119,22 @@ void
 Gravity::unweight_edges(int level, const Vector<MultiFab*>& edges)
 {
     BL_PROFILE("Gravity::unweight_edges()");
-    
-    const Real* dx = parent->Geom(level).CellSize();
+
+    auto dx = parent->Geom(level).CellSizeArray();
     const int coord_type = parent->Geom(level).Coord();
+
+    for (int idir = 0; idir < BL_SPACEDIM; ++idir) {
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    for (int idir=0; idir<BL_SPACEDIM; ++idir) {
         for (MFIter mfi(*edges[idir], TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
             const Box& bx = mfi.tilebox();
 
             do_unweight_edges(bx, (*edges[idir]).array(mfi), idir, dx, coord_type);
         }
+
     }
 }
 #endif


### PR DESCRIPTION

## PR summary

Device lambda capture of dx in the MGutils routines (apply_metric, etc.) requires that we use a GpuArray (geom.CellSizeArray()) rather than a raw pointer. The current code resulted in an illegal memory access error in CUDA when run with 2D Poisson gravity (and there were likely issues in diffusion in 2D as well). This issue was introduced in the port of this code from Fortran to C++ (#854).

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
