### PR TITLE
Restore OpenMP parallel region

### DIFF
--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -66,6 +66,8 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 #ifdef _OPENMP
 #ifdef RADIATION
 #pragma omp parallel reduction(max:nstep_fsp)
+#else
+#pragma omp parallel
 #endif
 #endif
   {


### PR DESCRIPTION

## PR summary

This restores an OpenMP parallel region that was accidentally removed in #1035.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
