### PR TITLE
Remove domegadt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # 20.07
 
+   * The functionality that permitted the rotation rate to change as a
+     function of time, castro.rotation_include_domegadt and
+     castro.rotational_dPdt, has been removed. (#1045)
+
    * A CUDA illegal memory access error in Poisson gravity and diffusion
      has been fixed (#1039).
 

--- a/Exec/hydro_tests/rotating_torus/Prob_nd.F90
+++ b/Exec/hydro_tests/rotating_torus/Prob_nd.F90
@@ -23,7 +23,7 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   call probdata_init(name, namlen)
 
 #ifdef ROTATION
-  call get_omega(ZERO, omega)
+  call get_omega(omega)
 #else
   ! Provide a dummy value so that we can compile without rotation.
   omega = [ZERO, ZERO, TWO * M_PI]
@@ -87,7 +87,7 @@ contains
     !$gpu
 
 #ifdef ROTATION
-    call get_omega(ZERO, omega)
+    call get_omega(omega)
 #else
     omega = [ZERO, ZERO, TWO * M_PI]
 #endif

--- a/Exec/science/wdmerger/Prob_nd.F90
+++ b/Exec/science/wdmerger/Prob_nd.F90
@@ -67,7 +67,7 @@
      ! inside the primary or secondary (in which case interpolate from the respective model)
      ! or if we are in an ambient zone.
 
-     call get_omega(time, omega)
+     call get_omega(omega)
 
      !$OMP PARALLEL DO PRIVATE(i, j, k, loc, vel, pos, mom) &
      !$OMP PRIVATE(dist_P, dist_S, zone_state) &

--- a/Exec/science/wdmerger/Problem_F.H
+++ b/Exec/science/wdmerger/Problem_F.H
@@ -67,7 +67,7 @@ extern "C"
 
   void update_center(const amrex::Real* time);
 
-  void get_omega_vec(const amrex::Real* omega, const amrex::Real time);
+  void get_omega_vec(const amrex::Real* omega);
 
   void get_lagrange_points(const amrex::Real mass_1, const amrex::Real mass_2,
 	                   const amrex::Real* com_1, const amrex::Real* com_2);

--- a/Exec/science/wdmerger/inputs_2d
+++ b/Exec/science/wdmerger/inputs_2d
@@ -227,9 +227,6 @@ gravity.do_composite_phi_correction = 0
 # Rotational period of the rotating reference frame
 castro.rotational_period = 100.0
 
-# Time rate of change of the rotational period
-castro.rotational_dPdt = -0.0
-
 ############################################################################################
 # Load balancing
 ############################################################################################

--- a/Exec/science/wdmerger/inputs_3d
+++ b/Exec/science/wdmerger/inputs_3d
@@ -230,9 +230,6 @@ gravity.do_composite_phi_correction = 0
 # Rotational period of the rotating reference frame
 castro.rotational_period = 100.0
 
-# Time rate of change of the rotational period
-castro.rotational_dPdt = -0.0
-
 # Whether to evolve state variables in the inertial or rotating frame
 castro.state_in_rotating_frame = 1
 

--- a/Exec/science/wdmerger/sum_integrated_quantities.cpp
+++ b/Exec/science/wdmerger/sum_integrated_quantities.cpp
@@ -57,7 +57,7 @@ Castro::sum_integrated_quantities ()
 
     Real omega[3] = { 0.0 };
 
-    get_omega_vec(omega, time);
+    get_omega_vec(omega);
 
     // Mass transfer rate
 

--- a/Exec/science/wdmerger/tests/wdmerger_2D/inputs_test_wdmerger_2D
+++ b/Exec/science/wdmerger/tests/wdmerger_2D/inputs_test_wdmerger_2D
@@ -56,7 +56,6 @@ castro.add_ext_src = 1                             # Whether or not to apply ext
 castro.ext_src_implicit = 1
 castro.do_rotation = 1                             # Whether or not to include the rotation source term
 castro.rotational_period = 100.0                   # Rotational period of the rotating reference frame
-castro.rotational_dPdt = -0.0                      # Time rate of change of the rotational period
 castro.implicit_rotation_update = 1                # Implicit rotation coupling
 
 ############################################################################################

--- a/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
+++ b/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
@@ -62,7 +62,6 @@ castro.add_ext_src = 1                             # Whether or not to apply ext
 castro.ext_src_implicit = 1
 castro.do_rotation = 0                             # Whether or not to include the rotation source term
 castro.rotational_period = 100.0                   # Rotational period of the rotating reference frame
-castro.rotational_dPdt = -0.0                      # Time rate of change of the rotational period
 castro.implicit_rotation_update = 1                # Implicit rotation coupling
 
 ############################################################################################

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_test_wdmerger_collision
@@ -58,7 +58,6 @@ castro.add_ext_src = 1                             # Whether or not to apply ext
 castro.ext_src_implicit = 1
 castro.do_rotation = 0                             # Whether or not to include the rotation source term
 castro.rotational_period = 100.0                   # Rotational period of the rotating reference frame
-castro.rotational_dPdt = -0.0                      # Time rate of change of the rotational period
 castro.implicit_rotation_update = 1                # Implicit rotation coupling
 
 ############################################################################################

--- a/Exec/science/wdmerger/tests/wdmerger_mhd/inputs_test_wdmerger_3D
+++ b/Exec/science/wdmerger/tests/wdmerger_mhd/inputs_test_wdmerger_3D
@@ -62,7 +62,6 @@ castro.add_ext_src = 0                             # Whether or not to apply ext
 castro.ext_src_implicit = 1
 castro.do_rotation = 0                             # Whether or not to include the rotation source term
 castro.rotational_period = 100.0                   # Rotational period of the rotating reference frame
-castro.rotational_dPdt = -0.0                      # Time rate of change of the rotational period
 castro.implicit_rotation_update = 1                # Implicit rotation coupling
 
 ############################################################################################

--- a/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
@@ -220,9 +220,6 @@ gravity.no_sync = 0
 # Rotational period of the rotating reference frame
 castro.rotational_period = 100.0
 
-# Time rate of change of the rotational period
-castro.rotational_dPdt = -0.0
-
 # Whether to evolve state variables in the inertial or rotating frame
 castro.state_in_rotating_frame = 1
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -431,18 +431,11 @@ do_rotation                  int          -1                  y
 # the rotation period for the corotating frame
 rotational_period            Real         -1.e200             y        ROTATION        rot_period
 
-# the rotation periods time evolution---this allows the rotation rate to
-# change durning the simulation time
-rotational_dPdt              Real          0.0                y        ROTATION        rot_period_dot
-
 # permits the centrifugal terms in the rotation to be turned on and off
 rotation_include_centrifugal int           1                  y        ROTATION
 
 # permits the Coriolis terms in the rotation to be turned on and off
 rotation_include_coriolis    int           1                  y        ROTATION
-
-# permits the d(omega)/dt terms in the rotation to be turned on and off
-rotation_include_domegadt    int           1                  y        ROTATION
 
 # Which reference frame to measure the state variables with respect to.
 # The standard in the literature when using a rotating reference frame

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -22,7 +22,7 @@ Castro::estdt_cfl(const Real time)
 
 #ifdef ROTATION
   GpuArray<Real, 3> omega;
-  get_omega(time, omega.begin());
+  get_omega(omega.begin());
 #endif
 
   const auto dx = geom.CellSizeArray();

--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -54,7 +54,7 @@ Castro::ctoprim(const Box& bx,
 
 #ifdef ROTATION
   GpuArray<Real, 3> omega;
-  get_omega(time, omega.begin());
+  get_omega(omega.begin());
 #endif
 
   amrex::ParallelFor(bx,

--- a/Source/rotation/Castro_rotation_F.H
+++ b/Source/rotation/Castro_rotation_F.H
@@ -11,7 +11,7 @@ extern "C"
 
   void set_rot_period(const amrex::Real* period);
 
-  void get_omega(const amrex::Real time, amrex::Real* omega);
+  void get_omega(amrex::Real* omega);
 
   void ca_fill_rotational_potential
     (const int* lo, const int* hi,

--- a/Source/rotation/Rotation_frequency.F90
+++ b/Source/rotation/Rotation_frequency.F90
@@ -6,19 +6,16 @@ module rotation_frequency_module
 
 contains
 
-  subroutine get_omega(time, omega) bind(C, name="get_omega")
+  subroutine get_omega(omega) bind(C, name="get_omega")
 
     use prob_params_module, only: coord_type
-    use meth_params_module, only: rot_period, rot_period_dot, rot_axis
+    use meth_params_module, only: rot_period, rot_axis
     use amrex_constants_module, only: ZERO, TWO, M_PI
-
     use amrex_fort_module, only : rt => amrex_real
+
     implicit none
 
-    real(rt), intent(in), value :: time
     real(rt), intent(inout) :: omega(3)
-
-    real(rt) :: curr_period
 
     ! If rot_period is less than zero, that means rotation is disabled, and so we should effectively
     ! shut off the source term by setting omega = 0. Note that by default rot_axis == 3 for Cartesian
@@ -32,13 +29,7 @@ contains
 
        if (rot_period > ZERO) then
 
-          ! If we have a time rate of change of the rotational period,
-          ! adjust it accordingly in the calculation of omega. We assume
-          ! that the change has been linear and started at t == 0.
-
-          curr_period = rot_period + rot_period_dot * time
-
-          omega(rot_axis) = TWO * M_PI / curr_period
+          omega(rot_axis) = TWO * M_PI / rot_period
 
        endif
 
@@ -49,48 +40,6 @@ contains
     endif
 
   end subroutine get_omega
-
-
-
-  function get_domegadt(time) result(domegadt)
-
-    use prob_params_module, only: coord_type
-    use meth_params_module, only: rot_period, rot_period_dot
-    use amrex_constants_module, only: ZERO, TWO, M_PI
-
-    use amrex_fort_module, only : rt => amrex_real
-    implicit none
-
-    real(rt)         :: time
-    real(rt)         :: domegadt(3)
-
-    real(rt)         :: curr_period, curr_omega(3)
-
-    !$gpu
-
-    domegadt(:) = ZERO
-
-    if (coord_type == 0 .or. coord_type .eq. 1) then
-
-       if (rot_period > ZERO) then
-
-          ! Rate of change of the rotational frequency is given by
-          ! d( ln(period) ) / dt = - d( ln(omega) ) / dt
-
-          curr_period = rot_period + rot_period_dot * time
-          call get_omega(time, curr_omega)
-
-          domegadt = -curr_omega * (rot_period_dot / curr_period)
-
-       endif
-
-    else
-#ifndef AMREX_USE_GPU
-       call castro_error("Error:: rotation_nd.f90 :: unknown coord_type")
-#endif
-    endif
-
-  end function get_domegadt
 
   subroutine set_rot_period(period) bind(C, name='set_rot_period')
 


### PR DESCRIPTION
## PR summary

The functionality that permitted the rotation rate to change as a function of time, `castro.rotation_include_domegadt` and `castro.rotational_dPdt`, has been removed.

## PR motivation

These parameters were never used for science.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
