### PR TITLE
Remove remaining calls to amrex_filccn

### DIFF
--- a/Exec/gravity_tests/DustCollapse/bc_fill_nd.F90
+++ b/Exec/gravity_tests/DustCollapse/bc_fill_nd.F90
@@ -12,7 +12,6 @@ contains
 
   subroutine hypfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C, name="hypfill")
 
-    use amrex_filcc_module, only: amrex_filccn
     use amrex_constants_module, only: HALF
 #ifndef AMREX_USE_CUDA
     use castro_error_module, only: castro_error
@@ -37,9 +36,6 @@ contains
     real(rt) :: mom,momc
 
     !$gpu
-
-    ! Do this for all the variables, but we will overwrite the momenta below
-    call amrex_filccn(lo, hi, adv, adv_lo, adv_hi, NVAR, domlo, domhi, delta, xlo, bc)
 
 #if AMREX_SPACEDIM == 3
 #ifndef AMREX_USE_CUDA
@@ -267,8 +263,6 @@ contains
 
   subroutine denfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C,name="denfill")
 
-    use amrex_filcc_module, only: amrex_filccn
-
     implicit none
 
     integer,  intent(in   ) :: lo(3), hi(3)
@@ -280,8 +274,6 @@ contains
     real(rt), intent(in   ), value :: time
 
     !$gpu
-
-    call amrex_filccn(lo, hi, adv, adv_lo, adv_hi, 1, domlo, domhi, delta, xlo, bc)
 
   end subroutine denfill
 

--- a/Exec/gravity_tests/hydrostatic_adjust/bc_fill_nd.F90
+++ b/Exec/gravity_tests/hydrostatic_adjust/bc_fill_nd.F90
@@ -12,7 +12,6 @@ contains
 
   subroutine hypfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C, name="hypfill")
 
-    use amrex_filcc_module, only: amrex_filccn
     use amrex_constants_module, only: ZERO, HALF
     use meth_params_module, only : NVAR, URHO, UEDEN, UMX, UMY, UMZ, UTEMP, UEINT, UFS
     use probdata_module, only: hse_rho_top, hse_t_top, hse_X_top, &
@@ -33,9 +32,6 @@ contains
 
     integer :: n, i, j, k
     real(rt) :: vel
-
-    ! call the generic ghostcell filling routine
-    call amrex_filccn(lo, hi, adv, adv_lo, adv_hi, NVAR, domlo, domhi, delta, xlo, bc)
 
     ! override the generic routine at the top physical boundary
     ! by resetting the velocity to zero there.
@@ -123,8 +119,6 @@ contains
 
   subroutine denfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C, name="denfill")
 
-    use amrex_filcc_module, only: amrex_filccn
-
     implicit none
 
     integer,  intent(in   ) :: lo(3), hi(3)
@@ -134,8 +128,6 @@ contains
     real(rt), intent(in   ) :: delta(3), xlo(3)
     real(rt), intent(inout) :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3))
     real(rt), intent(in   ), value :: time
-
-    call amrex_filccn(lo, hi, adv, adv_lo, adv_hi, 1, domlo, domhi, delta, xlo, bc)
 
   end subroutine denfill
 

--- a/Exec/hydro_tests/Noh/bc_fill_nd.F90
+++ b/Exec/hydro_tests/Noh/bc_fill_nd.F90
@@ -10,7 +10,6 @@ contains
 
   subroutine hypfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C, name="hypfill")
 
-    use amrex_filcc_module, only: amrex_filccn
     use amrex_constants_module, only: ONE, TWO
     use meth_params_module, only: NVAR, URHO, UTEMP, UMX, UMZ, UEDEN, UEINT, UFS
     use castro_util_module, only: position
@@ -37,8 +36,6 @@ contains
 
     real(rt) :: pres_init = 1.0e-6_rt
     real(rt) :: rho_init = 1.0e0_rt
-
-    call amrex_filccn(lo, hi, adv, adv_lo, adv_hi, NVAR, domlo, domhi, delta, xlo, bc)
 
     ! Overwrite the outer boundary conditions
 
@@ -81,8 +78,6 @@ contains
 
   subroutine denfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C, name="denfill")
 
-    use amrex_filcc_module, only: amrex_filccn
-
     implicit none
 
     include 'AMReX_bc_types.fi'
@@ -94,8 +89,6 @@ contains
     real(rt), intent(in   ) :: delta(3), xlo(3)
     real(rt), intent(inout) :: adv(adv_lo(1):adv_hi(1),adv_lo(2):adv_hi(2),adv_lo(3):adv_hi(3))
     real(rt), intent(in   ), value :: time
-
-    call amrex_filccn(lo, hi, adv, adv_lo, adv_hi, 1, domlo, domhi, delta, xlo, bc)
 
   end subroutine denfill
 

--- a/Exec/hydro_tests/double_mach_reflection/bc_ext_fill_nd.F90
+++ b/Exec/hydro_tests/double_mach_reflection/bc_ext_fill_nd.F90
@@ -34,7 +34,6 @@ contains
     use eos_type_module, only: eos_t, eos_input_rt
     use network, only: nspec
     use model_parser_module, only: model_r, model_state, npts_model, idens_model, itemp_model, ispec_model
-    use amrex_filcc_module, only: amrex_filccn
 
     integer,  intent(in   ) :: lo(3), hi(3)
     integer,  intent(in   ) :: adv_lo(3), adv_hi(3)
@@ -241,7 +240,6 @@ contains
 #ifndef AMREX_USE_CUDA
     use castro_error_module, only: castro_error
 #endif
-    use amrex_filcc_module, only: amrex_filccn
 
     implicit none
 

--- a/Exec/science/Detonation/bc_fill_nd.F90
+++ b/Exec/science/Detonation/bc_fill_nd.F90
@@ -53,7 +53,6 @@ contains
 
   subroutine hypfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C, name="hypfill")
 
-    use amrex_filcc_module, only: amrex_filccn
     use amrex_constants_module, only: HALF
     use meth_params_module, only: NVAR, fill_ambient_bc
     use prob_params_module, only : problo
@@ -74,11 +73,6 @@ contains
     real(rt) :: x
 
     !$gpu
-
-    ! First, use the generic filling routines to make sure we have valid data everywhere
-    ! on physical domain ghost cells.
-
-    call amrex_filccn(lo, hi, adv, adv_lo, adv_hi, NVAR, domlo, domhi, delta, xlo, bc)
 
     ! Override the generic routine at the physical boundaries by
     ! setting the material to the ambient state. Note that we
@@ -129,8 +123,6 @@ contains
 
   subroutine denfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C, name="denfill")
 
-    use amrex_filcc_module, only: amrex_filccn
-
     implicit none
 
     include 'AMReX_bc_types.fi'
@@ -144,8 +136,6 @@ contains
     real(rt), intent(in   ), value :: time
 
     !$gpu
-
-    call amrex_filccn(lo, hi, adv, adv_lo, adv_hi, 1, domlo, domhi, delta, xlo, bc)
 
   end subroutine denfill
 

--- a/Source/problems/bc_ext_fill_nd.F90
+++ b/Source/problems/bc_ext_fill_nd.F90
@@ -33,7 +33,6 @@ contains
     use eos_type_module, only: eos_t, eos_input_rt
     use network, only: nspec
     use model_parser_module, only: idens_model, itemp_model, ispec_model, interpolate_sub
-    use amrex_filcc_module, only: amrex_filccn
 
     integer,  intent(in   ) :: lo(3), hi(3)
     integer,  intent(in   ) :: adv_lo(3), adv_hi(3)
@@ -901,7 +900,6 @@ contains
 #ifndef AMREX_USE_CUDA
     use castro_error_module, only: castro_error
 #endif
-    use amrex_filcc_module, only: amrex_filccn
 
     implicit none
 

--- a/Source/problems/bc_fill_nd.F90
+++ b/Source/problems/bc_fill_nd.F90
@@ -13,7 +13,6 @@ contains
 
   subroutine hypfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C, name="hypfill")
 
-    use amrex_filcc_module, only: amrex_filccn
     use meth_params_module, only: fill_ambient_bc, ambient_fill_dir, ambient_outflow_vel, UMX, UMY, UMZ, UEDEN, URHO, UEINT
     use ambient_module, only: ambient_state
     use amrex_bc_types_module, only: amrex_bc_foextrap, amrex_bc_hoextrap
@@ -126,7 +125,6 @@ contains
 
   subroutine denfill(lo, hi, adv, adv_lo, adv_hi, domlo, domhi, delta, xlo, time, bc) bind(C, name="denfill")
 
-    use amrex_filcc_module, only: amrex_filccn
     use meth_params_module, only: fill_ambient_bc, URHO, ambient_fill_dir
     use ambient_module, only: ambient_state
     use amrex_bc_types_module, only: amrex_bc_foextrap, amrex_bc_hoextrap


### PR DESCRIPTION

## PR summary

PR #837 removed the need for any problem setup to call amrex_filccn in its local bc_fill_nd.F90 routines, hypfill and denfill, because now we will always call the AMReX BC routines prior to entering hypfill or denfill. However that PR did not remove the calls to it from the problem setups that used it, noting that these calls are now redundant. These calls are now removed.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
