### PR TITLE
Convert ca_clamp_temp to pure device function

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -64,6 +64,7 @@ constexpr int Shock = USHK;
 using std::istream;
 using std::ostream;
 
+#define AMREX_ARR4_TO_FORTRAN_ANYD(a) a.p,&((a).begin.x),amrex::GpuArray<int,3>{(a).end.x-1,(a).end.y-1,(a).end.z-1}.data()
 
 enum StateType { State_Type = 0,
 #ifdef RADIATION

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3572,9 +3572,11 @@ Castro::computeTemp(
       });
 
       if (clamp_ambient_temp == 1) {
-#pragma gpu box(bx)
-          ca_clamp_temp(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
-                        BL_TO_FORTRAN_ANYD(u_fab));
+          amrex::ParallelFor(bx,
+          [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+          {
+              ca_clamp_temp(i, j, k, AMREX_ARR4_TO_FORTRAN_ANYD(u));
+          });
       }
 
   }

--- a/Source/driver/Castro_F.H
+++ b/Source/driver/Castro_F.H
@@ -150,8 +150,9 @@ extern "C"
   void ca_find_center(amrex::Real* data, amrex::Real* center, const int* icen,
                       const amrex::Real* dx, const amrex::Real* problo);
 
+  AMREX_GPU_DEVICE
   void ca_clamp_temp
-    (const int* lo, const int* hi, BL_FORT_FAB_ARG_3D(state));
+    (int i, int j, int k, BL_FORT_FAB_ARG_3D(state));
 
   void ca_reset_internal_e
     (const int* lo, const int* hi,


### PR DESCRIPTION

## PR summary

Convert ca_clamp_temp to a CUDA Fortran device function for the CUDA build.

## PR motivation

This removes the need for #pragma gpu for this function.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
