### PR TITLE
Add wdmerger relaxation test case

### DIFF
--- a/Exec/science/wdmerger/tests/wdmerger_relaxation/GNUmakefile
+++ b/Exec/science/wdmerger/tests/wdmerger_relaxation/GNUmakefile
@@ -1,0 +1,1 @@
+include ../../GNUmakefile

--- a/Exec/science/wdmerger/tests/wdmerger_relaxation/README.md
+++ b/Exec/science/wdmerger/tests/wdmerger_relaxation/README.md
@@ -1,0 +1,2 @@
+This test checks the initial relaxation phase. We set a relatively large damping
+factor and run until the relaxation is turned off (at approximately 12s).

--- a/Exec/science/wdmerger/tests/wdmerger_relaxation/inputs
+++ b/Exec/science/wdmerger/tests/wdmerger_relaxation/inputs
@@ -1,0 +1,27 @@
+FILE = ../../inputs_3d
+
+amr.probin_file = probin
+
+stop_time = 12.0
+
+castro.init_shrink = 0.1
+
+amr.n_cell = 64 64 64
+
+amr.max_level = 0
+
+amr.max_grid_size = 128
+
+amr.blocking_factor = 16
+
+castro.do_rotation = 1
+castro.state_in_rotating_frame = 1
+
+amr.check_int = -1
+amr.check_per = -1.0
+
+amr.plot_int = -1
+amr.plot_per = 5.0
+
+amr.small_plot_per = 1.0
+amr.small_plot_vars = density

--- a/Exec/science/wdmerger/tests/wdmerger_relaxation/probin
+++ b/Exec/science/wdmerger/tests/wdmerger_relaxation/probin
@@ -1,0 +1,91 @@
+&fortin 
+
+  mass_P = 0.90
+  mass_S = 0.90
+
+  central_density_P = -1.0d0
+  central_density_S = -1.0d0
+
+  nsub = 4
+
+  problem = 1
+
+  roche_radius_factor = 3.0d0
+
+  relaxation_damping_factor = 1.0d-1
+  relaxation_density_cutoff = 1.0d3
+  relaxation_cutoff_time = -1.0d2
+
+  radial_damping_factor = 1.0d-1
+  initial_radial_velocity_factor = -1.0d-3
+
+  max_stellar_tagging_level = 20
+  stellar_density_threshold = 1.0d0
+
+/
+
+&ambient
+
+  ambient_density = 1.0d-4
+  ambient_temp = 1.0d7
+
+/
+
+&tagging
+
+/
+
+&sponge
+
+  sponge_lower_radius  = 0.0d0
+  sponge_upper_radius  = 0.0d0
+  sponge_lower_density = 1.0d0
+  sponge_upper_density = 1.0d0
+  sponge_timescale     = 0.01d0
+
+/
+
+&extern
+
+  ! Note that some of the parameters in this
+  ! namelist are specific to the default EOS,
+  ! network, and/or integrator used in the 
+  ! makefile. If you try a different set of 
+  ! microphysics routines be sure to check that
+  ! the parameters in here are consistent, as
+  ! Fortran does not like seeing unknown variables
+  ! in the namelist.
+
+  small_x = 1.d-12
+
+  use_eos_coulomb = T
+  eos_input_is_constant = T
+
+  burning_mode = 1
+
+  do_constant_volume_burn = T
+  call_eos_in_rhs = T
+
+  rtol_spec = 1.d-6
+  atol_spec = 1.d-6
+
+  rtol_temp = 1.d-6
+  atol_temp = 1.d-6
+
+  rtol_enuc = 1.d-6
+  atol_enuc = 1.d-6
+
+  abort_on_failure = F
+  retry_burn = F
+
+  renormalize_abundances = T
+
+  MAX_TEMP = 1.d10
+
+  ! Note that not every network has tabular
+  ! rates enabled, so for some networks the
+  ! following option will have no effect.
+
+  use_tables = T
+
+/


### PR DESCRIPTION

## PR summary

Add a test case which explicitly exercises both the wdmerger relaxation functionality and the logic that disables it when the WDs have begun overflowing their Roche lobe.

## PR motivation

I created this so I could test #1057.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
