### PR TITLE
change the preprocessor check from naux to NAUX_NET

### DIFF
--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -683,7 +683,7 @@ Castro::variableSetUp ()
       name_react = "rho_omegadot_" + short_spec_names_cxx[i];
       desc_lst.setComponent(Reactions_Type, i, name_react, bc,genericBndryFunc);
     }
-#if naux > 0
+#if NAUX_NET > 0
   std::string name_aux;
   for (int i = 0; i < NumAux; ++i) {
       set_scalar_bc(bc,phys_bc);

--- a/Source/driver/timestep_nd.F90
+++ b/Source/driver/timestep_nd.F90
@@ -25,7 +25,7 @@ contains
     use meth_params_module, only : NVAR, URHO, UEINT, UTEMP, UFS, dtnuc_e, dtnuc_T, &
                                    dtnuc_X, dtnuc_X_threshold, small_temp
     use prob_params_module, only : dim
-#if naux > 0
+#if NAUX_NET > 0
     use meth_params_module, only : UFX
 #endif
     use actual_rhs_module, only: actual_rhs
@@ -103,7 +103,7 @@ contains
              state_new % T   = snew(i,j,k,UTEMP)
              state_new % e   = snew(i,j,k,UEINT) * rhoninv
              state_new % xn  = snew(i,j,k,UFS:UFS+nspec-1) * rhoninv
-#if naux > 0
+#if NAUX_NET > 0
              state_new % aux = snew(i,j,k,UFX:UFX+naux-1) * rhoninv
 #endif
 

--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -110,7 +110,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt)
                     burn_state.xn[n] = U(i,j,k,UFS+n) * rhoInv;
                 }
 
-#if naux > 0
+#if NAUX_NET > 0
                 for (int n = 0; n < NumAux; ++n) {
                     burn_state.aux[n] = U(i,j,k,UFX+n) * rhoInv;
                 }
@@ -148,7 +148,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt)
                         for (int n = 0; n < NumSpec; ++n) {
                             reactions(i,j,k,n) = U(i,j,k,URHO) * (burn_state.xn[n] - U(i,j,k,UFS+n) * rhoInv) / dt;
                         }
-#if naux > 0
+#if NAUX_NET > 0
                         for (int n = 0; n < NumAux; ++n) {
                             reactions(i,j,k,n+NumSpec) = U(i,j,k,URHO) * (burn_state.aux[n] - U(i,j,k,UFX+n) * rhoInv) / dt;
                         }
@@ -196,7 +196,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt)
                 for (int n = 0; n < NumSpec; ++n) {
                     U(i,j,k,UFS+n) += reactions(i,j,k,n) * dt;
                 }
-#if naux > 0
+#if NAUX_NET > 0
                 for (int n = 0; n < NumAux; ++n) {
                     U(i,j,k,UFX+n) += reactions(i,j,k,n+NumSpec) * dt;
                 }

--- a/Source/reactions/React_nd.F90
+++ b/Source/reactions/React_nd.F90
@@ -16,7 +16,7 @@ contains
     use network           , only : nspec, naux
     use meth_params_module, only : NVAR, URHO, UEDEN, UEINT, UTEMP, &
                                    UFS
-#if naux > 0
+#if NAUX_NET > 0
     use meth_params_module, only : UFX
 #endif
 #ifdef SHOCK_VAR
@@ -103,7 +103,7 @@ contains
                 burn_state_in % xn(n) = state(i,j,k,UFS+n-1) * rhoInv
              enddo
 
-#if naux > 0
+#if NAUX_NET > 0
              do n = 1, naux
                 burn_state_in % aux(n) = state(i,j,k,UFX+n-1) * rhoInv
              enddo
@@ -173,7 +173,7 @@ contains
                    do n = 1, nspec
                       reactions(i,j,k,n) = state(i,j,k,URHO) * (burn_state_out % xn(n) - burn_state_in % xn(n)) / dt_react
                    end do
-#if naux > 0
+#if NAUX_NET > 0
                    do n = 1, naux
                       reactions(i,j,k,n+nspec) = state(i,j,k,URHO) * (burn_state_out % aux(n) - burn_state_in % aux(n)) / dt_react
                    end do

--- a/Source/reactions/react_util.F90
+++ b/Source/reactions/react_util.F90
@@ -101,7 +101,7 @@ contains
 
     burn_state % xn(1:nspec_evolve) = max(min(burn_state % xn(1:nspec_evolve), ONE), SMALL_X_SAFE) 
 
-#if naux > 0
+#if NAUX_NET > 0
     do n = 1, naux
        burn_state % aux(n) = state(UFX+n-1) * rhoInv
     enddo

--- a/Source/sdc/sdc_util.cpp
+++ b/Source/sdc/sdc_util.cpp
@@ -418,7 +418,7 @@ void Castro::ca_store_reaction_state(const Box& bx,
         R_store(i,j,k,n) = R_old(i,j,k,UFS+n);
     });
 
-#if naux > 0
+#if NAUX_NET > 0
     AMREX_PARALLEL_FOR_4D(bx, NumAux, i, j, k, n,
     {
         R_store(i,j,k,n) = R_old(i,j,k,UFX+n);


### PR DESCRIPTION
it is not clear that the naux check every worked (it didn't in
Microphysics), but now the network explicitly sets NAUX_NET

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
