### PR TITLE
Fix cases of illegal accesses to cellsizearray

### DIFF
--- a/Source/driver/Derive.cpp
+++ b/Source/driver/Derive.cpp
@@ -1251,9 +1251,17 @@ extern "C"
     [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
     {
       Real dBx = dat(i+1,j,k,0) - dat(i,j,k,0);
+      der(i,j,k,0) = dBx / dx[0];
+
+#if AMREX_SPACEDIM >= 2
       Real dBy = dat(i,j+1,k,1) - dat(i,j,k,1);
+      der(i,j,k,0) += dBy / dx[1];
+#endif
+
+#if AMREX_SPACEDIM == 3
       Real dBz = dat(i,j,k+1,2) - dat(i,j,k,2);
-      der(i,j,k,0) = dBx/dx[0] + dBy/dx[1] + dBz/dx[2];
+      der(i,j,k,0) += dBz / dx[2];
+#endif
     });
   }
 

--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -394,7 +394,13 @@ void Castro::construct_new_gravity_source(MultiFab& source, MultiFab& state_old,
 
     if (!do_grav) return;
 
-    const auto dx = geom.CellSizeArray();
+    GpuArray<Real, 3> dx;
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+        dx[i] = geom.CellSizeArray()[i];
+    }
+    for (int i = AMREX_SPACEDIM; i < 3; ++i) {
+        dx[i] = 0.0_rt;
+    }
 
 #ifdef HYBRID_MOMENTUM
     GeometryData geomdata = geom.data();

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1262,9 +1262,10 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
           Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]), R_min);
           Real RInv = 1.0_rt / R;
 
-          update_arr(i,j,k,UMR) = update_arr(i,j,k,UMR) - ((loc[0] * RInv) * (qx_arr(i+1,j,k,GDPRES) - qx_arr(i,j,k,GDPRES)) / dx_arr[0] +
-                                                           (loc[1] * RInv) * (qy_arr(i,j+1,k,GDPRES) - qy_arr(i,j,k,GDPRES)) / dx_arr[1]);
-
+          update_arr(i,j,k,UMR) = update_arr(i,j,k,UMR) - ((loc[0] * RInv) * (qx_arr(i+1,j,k,GDPRES) - qx_arr(i,j,k,GDPRES)) / dx_arr[0]);
+#if AMREX_SPACEDIM >= 2
+          update_arr(i,j,k,UMR) -= (loc[1] * RInv) * (qy_arr(i,j+1,k,GDPRES) - qy_arr(i,j,k,GDPRES)) / dx_arr[1]);
+#endif
       });
 #endif
 

--- a/Source/hydro/fourth_order.cpp
+++ b/Source/hydro/fourth_order.cpp
@@ -761,8 +761,18 @@ Castro::fourth_avisc(const Box& bx,
   const auto dx = geom.CellSizeArray();
 
   Real dxinv = 1.0_rt / dx[0];
+
+#if AMREX_SPACEDIM >= 2
   Real dyinv = 1.0_rt / dx[1];
+#else
+  Real dyinv = 0.0_rt;
+#endif
+
+#if AMREX_SPACEDIM == 3
   Real dzinv = 1.0_rt / dx[2];
+#else
+  Real dzinv = 0.0_rt;
+#endif
 
   amrex::ParallelFor(bx,
   [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept

--- a/Source/mhd/Castro_mhd.cpp
+++ b/Source/mhd/Castro_mhd.cpp
@@ -634,24 +634,38 @@ Castro::just_the_mhd(Real time, Real dt)
 
           // magnetic update
 
+          Real dtdx = dt / dx[0];
+
           amrex::ParallelFor(nbx,
           [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
           {
-            Bxo_arr(i,j,k) = Bx_arr(i,j,k) + dt/dx[0] *
+            Bxo_arr(i,j,k) = Bx_arr(i,j,k) + dtdx *
               ((Ey_arr(i,j,k+1) - Ey_arr(i,j,k)) - (Ez_arr(i,j+1,k) - Ez_arr(i,j,k)));
           });
+
+#if AMREX_SPACEDIM >= 2
+          dtdx = dt / dx[1];
+#else
+          dtdx = 0.0_rt;
+#endif
 
           amrex::ParallelFor(nby,
           [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
           {
-            Byo_arr(i,j,k) = By_arr(i,j,k) + dt/dx[1] *
+            Byo_arr(i,j,k) = By_arr(i,j,k) + dtdx *
               ((Ez_arr(i+1,j,k) - Ez_arr(i,j,k)) - (Ex_arr(i,j,k+1) - Ex_arr(i,j,k)));
           });
+
+#if AMREX_SPACEDIM == 3
+          dtdx = dt / dx[2];
+#else
+          dtdx = 0.0_rt;
+#endif
 
           amrex::ParallelFor(nbz,
           [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
           {
-            Bzo_arr(i,j,k) = Bz_arr(i,j,k) + dt/dx[2] *
+            Bzo_arr(i,j,k) = Bz_arr(i,j,k) + dtdx *
               ((Ex_arr(i,j+1,k) - Ex_arr(i,j,k)) - (Ey_arr(i+1,j,k) - Ey_arr(i,j,k)));
           });
 

--- a/Source/mhd/ct_upwind.cpp
+++ b/Source/mhd/ct_upwind.cpp
@@ -27,7 +27,13 @@ Castro::corner_couple(const Box& bx,
   // the normal direction (for the interface states) is d1
   // the transverse direction (for the flux difference) is d2
 
-  const auto dx = geom.CellSizeArray();
+  GpuArray<Real, 3> dx;
+  for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+      dx[i] = geom.CellSizeArray()[i];
+  }
+  for (int i = AMREX_SPACEDIM; i < 3; ++i) {
+      dx[i] = 0.0_rt;
+  }
 
   // cl and cr are the offsets to the indices for the conserved state fluxes
   // they will be offset in d2 to capture the flux difference
@@ -215,7 +221,13 @@ Castro::half_step(const Box& bx,
 
   // Final transverse flux corrections to the conservative state
 
-  const auto dx = geom.CellSizeArray();
+  GpuArray<Real, 3> dx;
+  for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+      dx[i] = geom.CellSizeArray()[i];
+  }
+  for (int i = AMREX_SPACEDIM; i < 3; ++i) {
+      dx[i] = 0.0_rt;
+  }
 
   // c1l, c1r are for indexing flxd1 offsets, c2l, c2r are for flxd2
 

--- a/Source/mhd/mhd_util.cpp
+++ b/Source/mhd/mhd_util.cpp
@@ -16,8 +16,18 @@ Castro::check_for_mhd_cfl_violation(const Box& bx,
   auto dx = geom.CellSizeArray();
 
   Real dtdx = dt / dx[0];
+
+#if AMREX_SPACEDIM >= 2
   Real dtdy = dt / dx[1];
+#else
+  Real dtdy = 0.0_rt;
+#endif
+
+#if AMREX_SPACEDIM == 3
   Real dtdz = dt / dx[2];
+#else
+  Real dtdz = 0.0_rt;
+#endif
 
   ReduceOps<ReduceOpMax> reduce_op;
   ReduceData<Real> reduce_data(reduce_op);
@@ -124,8 +134,12 @@ Castro::consup_mhd(const Box& bx,
   const auto dx = geom.CellSizeArray();
 
   Real dxinv = 1.0_rt/dx[0];
+#if AMREX_SPACEDIM >= 2
   Real dyinv = 1.0_rt/dx[1];
+#endif
+#if AMREX_SPACEDIM == 3
   Real dzinv = 1.0_rt/dx[2];
+#endif
 
   amrex::ParallelFor(bx, NUM_STATE,
   [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
@@ -138,10 +152,13 @@ Castro::consup_mhd(const Box& bx,
       update(i,j,k,n) = 0.0_rt;
 #endif
     } else {
-      update(i,j,k,n) =
-        (flux0(i,j,k,n) - flux0(i+1,j,k,n)) * dxinv +
-        (flux1(i,j,k,n) - flux1(i,j+1,k,n)) * dyinv +
-        (flux2(i,j,k,n) - flux2(i,j,k+1,n)) * dzinv;
+      update(i,j,k,n) = (flux0(i,j,k,n) - flux0(i+1,j,k,n)) * dxinv;
+#if AMREX_SPACEDIM >= 2
+      update(i,j,k,n) += (flux1(i,j,k,n) - flux1(i,j+1,k,n)) * dyinv;
+#endif
+#if AMREX_SPACEDIM == 3
+      update(i,j,k,n) += (flux2(i,j,k,n) - flux2(i,j,k+1,n)) * dzinv;
+#endif
     }
 
   });
@@ -224,9 +241,13 @@ Castro::prim_half(const Box& bx,
     Real q_zone[NQ];
 
     for (int n = 0; n < NUM_STATE+3; n++) {
-      divF[n] = (flxx(i+1,j,k,n) - flxx(i,j,k,n)) / dx[0] +
-                (flxy(i,j+1,k,n) - flxy(i,j,k,n)) / dx[1] +
-                (flxz(i,j,k+1,n) - flxz(i,j,k,n)) / dx[2];
+      divF[n] = (flxx(i+1,j,k,n) - flxx(i,j,k,n)) / dx[0];
+#if AMREX_SPACEDIM >= 2
+      divF[n] += (flxy(i,j+1,k,n) - flxy(i,j,k,n)) / dx[1];
+#endif
+#if AMREX_SPACEDIM == 3
+      divF[n] += (flxz(i,j,k+1,n) - flxz(i,j,k,n)) / dx[2];
+#endif
     }
 
     // that is a flux of conserved variables -- transform it to primitive

--- a/Source/sources/Castro_sponge.cpp
+++ b/Source/sources/Castro_sponge.cpp
@@ -174,8 +174,18 @@ Castro::apply_sponge(const Box& bx,
     GpuArray<Real, 3> r;
 
     r[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - center[0];
+
+#if AMREX_SPACEDIM >= 2
     r[1] = problo[1] + (static_cast<Real>(j) + 0.5_rt) * dx[1] - center[1];
+#else
+    r[1] = 0.0_rt;
+#endif
+
+#if AMREX_SPACEDIM == 3
     r[2] = problo[2] + (static_cast<Real>(k) + 0.5_rt) * dx[2] - center[2];
+#else
+    r[2] = 0.0_rt;
+#endif
 
     Real rho = state(i,j,k,URHO);
     Real rhoInv = 1.0_rt / rho;


### PR DESCRIPTION

## PR summary

CellSizeArray() is dimensioned as AMREX_SPACEDIM so we have to avoid accessing off the end of the array in 1D or 2D.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
