### PR TITLE
Don't call EOS on zones with rho = 0

### DIFF
--- a/Source/gravity/Gravity_nd.F90
+++ b/Source/gravity/Gravity_nd.F90
@@ -428,6 +428,13 @@ contains
 
              else
 
+                ! We may be coming in here with a masked out zone (in a zone on a coarse
+                ! level underlying a fine level). We don't want to be calling the EOS in
+                ! this case, so we'll skip these masked out zones (which will have rho
+                ! exactly equal to zero).
+
+                if (var(i,j,k,URHO) == 0.0_rt) cycle
+
                 rhoInv = ONE / var(i,j,k,URHO)
 
                 eos_state % rho = var(i,j,k,URHO)


### PR DESCRIPTION

## PR summary

ca_compute_avgpres is called for GR gravity. For monopole gravity we add contributions from multiple levels but mask out the contributions from coarse zones underlying fine levels. This means that in some calls to this function the state will be zeroed out. In that case we want to avoid calling the EOS as this generates NaNs (e.g. when evaluating 1 / rho).

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
