### PR TITLE
Always use previous phi as guess for solve

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -2013,13 +2013,11 @@ Castro::post_restart ()
             {
                 if (gravity->NoComposite() != 1)
                 {
-                   int use_previous_phi = 1;
-
                    // Update the maximum density, used in setting the solver tolerance.
 
                    gravity->update_max_rhs();
 
-                   gravity->multilevel_solve_for_new_phi(0,parent->finestLevel(),use_previous_phi);
+                   gravity->multilevel_solve_for_new_phi(0, parent->finestLevel());
                    if (gravity->test_results_of_solves() == 1)
                        gravity->test_composite_phi(level);
                 }
@@ -2218,15 +2216,13 @@ Castro::post_regrid (int lbase,
             if ( (level == lbase) && cur_time > 0.)
             {
                 if ( gravity->get_gravity_type() == "PoissonGrav" && (gravity->NoComposite() != 1) ) {
-                    int use_previous_phi = 1;
-
                     // Update the maximum density, used in setting the solver tolerance.
 
                     if (level == 0) {
                       gravity->update_max_rhs();
                     }
 
-                    gravity->multilevel_solve_for_new_phi(level,new_finest,use_previous_phi);
+                    gravity->multilevel_solve_for_new_phi(level, new_finest);
 
                 }
 

--- a/Source/gravity/Gravity.H
+++ b/Source/gravity/Gravity.H
@@ -197,10 +197,8 @@ public:
 ///
 /// @param level                        Base level index
 /// @param finest_level                 Fine level index
-/// @param use_previous_phi_as_guess    integer, should we use the previous phi as a guess?
 ///
-  void multilevel_solve_for_new_phi (int level, int finest_level,
-                                     int use_previous_phi_as_guess = 0);
+  void multilevel_solve_for_new_phi (int level, int finest_level);
 
 ///
 /// Actually do the multilevel solve for new phi from base level to finest level
@@ -209,12 +207,10 @@ public:
 /// @param finest_level     Fine level index
 /// @param grad_phi         gradient of phi
 /// @param is_new           Should we use the new state (1) or previous state (0)?
-/// @param use_previous_phi_as_guess    integer, should we use the previous phi as a guess?
 ///
   void actual_multilevel_solve      (int level, int finest_level,
                                      const amrex::Vector<amrex::Vector<amrex::MultiFab*> >& grad_phi,
-                                     int is_new,
-                                     int use_previous_phi_as_guess = 0);
+                                     int is_new);
 
 
 ///

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -696,7 +696,7 @@ Gravity::GetCrsePhi(int level,
 }
 
 void
-Gravity::multilevel_solve_for_new_phi (int level, int finest_level_in, int use_previous_phi_as_guess)
+Gravity::multilevel_solve_for_new_phi (int level, int finest_level_in)
 {
     BL_PROFILE("Gravity::multilevel_solve_for_new_phi()");
 
@@ -713,15 +713,13 @@ Gravity::multilevel_solve_for_new_phi (int level, int finest_level_in, int use_p
     }
 
     int is_new = 1;
-    actual_multilevel_solve(level,finest_level_in,amrex::GetVecOfVecOfPtrs(grad_phi_curr),
-                            is_new,use_previous_phi_as_guess);
+    actual_multilevel_solve(level, finest_level_in, amrex::GetVecOfVecOfPtrs(grad_phi_curr), is_new);
 }
 
 void
 Gravity::actual_multilevel_solve (int crse_level, int finest_level_in,
                                   const Vector<Vector<MultiFab*> >& grad_phi,
-                                  int is_new,
-                                  int use_previous_phi_as_guess)
+                                  int is_new)
 {
     BL_PROFILE("Gravity::actual_multilevel_solve()");
 
@@ -739,17 +737,9 @@ Gravity::actual_multilevel_solve (int crse_level, int finest_level_in,
         } else {
             phi_p[ilev] = &LevelData[amr_lev]->get_old_data(PhiGrav_Type);
         }
-
-        if (!use_previous_phi_as_guess)
-            phi_p[ilev]->setVal(0.);
     }
 
     const auto& rhs = get_rhs(crse_level, nlevels, is_new);
-
-    if (!use_previous_phi_as_guess && crse_level == 0 && !(parent->Geom(0).isAllPeriodic()))
-    {
-        make_radial_phi(0, *rhs[0], *phi_p[0], 1);
-    }
 
     Vector<Vector<MultiFab*> > grad_phi_p(nlevels);
     for (int ilev = 0; ilev < nlevels; ilev++)


### PR DESCRIPTION

## PR summary

The Poisson solve has an option to not use the previous gravitational potential as a guess for the new solve (instead, a monopole solve is done and used to fill the domain). This is only used after initialization or restart. This option is now turned off, so that we always use the previous phi. At initialization we will pay a (one-time) larger cost to do the solve, but this should have no other effects.

## PR motivation

I would like to remove make_radial_phi; for the most part we don't need it and it makes monopole gravity harder to maintain. If this bit is removed then the only remaining use of make_radial_phi is in the BCs for the Poisson solve, and there it can be replaced entirely with the multipole BCs.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
