### PR TITLE
Convert docs to use main branch instead of master

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: github pages
 on:
   push:
     branches:
-      - master
+      - main
       - development
 
 jobs:
@@ -42,9 +42,9 @@ jobs:
         run: python3 -m pip install -r ./requirements.txt
 
       - name: Build docs
-        if: ${{ endsWith(github.ref, 'master') }}
+        if: ${{ endsWith(github.ref, 'main') }}
         env:
-          GITHUB_BRANCH: 'master'
+          GITHUB_BRANCH: 'main'
         run: ./deploy_docs_action.sh
 
       - name: Build docs 

--- a/Docs/source/Introduction.rst
+++ b/Docs/source/Introduction.rst
@@ -47,12 +47,12 @@ Development Model
 =================
 
 Castro is developed on github (https://github.com/amrex-astro/Castro
-). The ``master`` branch is stable and can be used for day-to-day
+). The ``main`` branch is stable and can be used for day-to-day
 science.  New changes are made via pull requests to the
 ``development`` branch.  This is where the ongoing regression testing
 is done (both on CPU and GPU).
 
-At the start of each month, we merge ``development`` → ``master`` and
+At the start of each month, we merge ``development`` → ``main`` and
 apply a tag of the form ``YY.MM`` (e.g. ``20.02`` for Feb. 2020).  We
 also create a github release and mint a Zenodo DOI using the
 information in the ``.zenodo.json`` file at the root level.

--- a/Docs/source/Preface.rst
+++ b/Docs/source/Preface.rst
@@ -56,7 +56,7 @@ including the CCSE and Stony Brook University.
 
 Castro *core developers* are those who have made substantial
 contributions to the code. The process for becoming a core developer
-is described in the `README.md <https://github.com/AMReX-Astro/Castro/blob/master/README.md>`_ in the Castro root directory.
+is described in the `README.md <https://github.com/AMReX-Astro/Castro/blob/main/README.md>`_ in the Castro root directory.
 Current Castro core developers are:
 
   * Ann Almgren
@@ -79,7 +79,7 @@ page, https://github.com/AMReX-Astro/Castro
 External contributions are welcomed. Fork the Castro repo, modify your
 local copy, and issue a pull-request to the AMReX-Astro/Castro
 project. Further guidelines are given in the `README.md
-<https://github.com/AMReX-Astro/Castro/blob/master/README.md>`_ file.
+<https://github.com/AMReX-Astro/Castro/blob/main/README.md>`_ file.
 
 To get help, subscribe to the *castro-help* google group mailing list:
 https://groups.google.com/forum/#!forum/castro-help
@@ -90,7 +90,7 @@ Acknowledging and Citing Castro
 If you use Castro in your research, we would appreciate it if you
 cited the relevant code papers describing its design, features, and
 testing. A list of these can be found in the `CITATION
-<https://github.com/AMReX-Astro/Castro/blob/master/CITATION>`_ file in
+<https://github.com/AMReX-Astro/Castro/blob/main/CITATION>`_ file in
 the root ``Castro/`` directory.
 
 The development Castro is supported by the science application

--- a/Docs/source/_templates/dev_layout.html
+++ b/Docs/source/_templates/dev_layout.html
@@ -6,6 +6,6 @@
 {% block sidebartitle %}
 {{ super() }}
     <div class="branch">
-        Branch: <a href="{{ pathto('../', 1) }}{{ pagename }}{{file_suffix}}">master</a> | <a href="{{ pathto('', 1) }}{{ pagename }}{{file_suffix}}">development</a>
+        Branch: <a href="{{ pathto('../', 1) }}{{ pagename }}{{file_suffix}}">main</a> | <a href="{{ pathto('', 1) }}{{ pagename }}{{file_suffix}}">development</a>
     </div>
 {% endblock %}

--- a/Docs/source/_templates/layout.html
+++ b/Docs/source/_templates/layout.html
@@ -6,6 +6,6 @@
 {% block sidebartitle %}
 {{ super() }}
     <div class="branch">
-        Branch: <a href="{{ pathto('', 1) }}{{ pagename }}{{file_suffix}}">master</a> | <a href="{{ pathto('', 1) }}dev/{{ pagename }}{{file_suffix}}">development</a>
+        Branch: <a href="{{ pathto('', 1) }}{{ pagename }}{{file_suffix}}">main</a> | <a href="{{ pathto('', 1) }}dev/{{ pagename }}{{file_suffix}}">development</a>
     </div>
 {% endblock %}

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -71,8 +71,8 @@ source_suffix = '.rst'
 # see https://github.com/phn/pytpm/issues/3#issuecomment-12133978
 numpydoc_show_class_members = False
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'Castro'
@@ -194,7 +194,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Castro.tex', 'Castro Documentation',
+    (main_doc, 'Castro.tex', 'Castro Documentation',
      'Castro development team', 'manual'),
 ]
 
@@ -204,7 +204,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'Castro', 'Castro Documentation',
+    (main_doc, 'Castro', 'Castro Documentation',
      [author], 1)
 ]
 
@@ -215,7 +215,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Castro', 'Castro Documentation',
+    (main_doc, 'Castro', 'Castro Documentation',
      author, 'Castro', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/Docs/source/debugging.rst
+++ b/Docs/source/debugging.rst
@@ -55,7 +55,7 @@ offers suggestions for performance improvements.
 It can also be run locally. This requires the ``clang-tidy`` and
 ``bear`` packages, and the python script ``run-clang-tidy.py`` (which
 can be downloaded from `here
-<https://github.com/AMReX-Astro/cpp-linter-action/blob/master/run-clang-tidy.py>`_). The
+<https://github.com/AMReX-Astro/cpp-linter-action/blob/main/run-clang-tidy.py>`_). The
 analysis is performed by first compiling a problem using the ``bear``
 package, then running the python script to analyze the source
 files. From within a problem directory, run

--- a/Docs/source/development.rst
+++ b/Docs/source/development.rst
@@ -149,19 +149,19 @@ Microphysics, and wait for AMReX to release a ``20.03`` tag, then do::
 Then we can proceed with issuing our own release.
 
 
-Each month the ``development`` branch is merged into ``master`` and a
+Each month the ``development`` branch is merged into ``main`` and a
 release is tagged.  This needs to be done in coordination with its
 submodule dependencies.  The general procedure is:
 
-  * Do 'git pull' in both master and development branches.  (Use `git
+  * Do 'git pull' in both main and development branches.  (Use `git
     checkout xxx` to change to branch xxx.
 
-  * In master branch, do `git merge development`.  Fix any conflicts
+  * In main branch, do `git merge development`.  Fix any conflicts
     if there are any.  (There should not be any conflicts unless a
-    commit is checked into master directly without going through
+    commit is checked into main directly without going through
     development.)
 
-  * In master branch, commit new release notes (``CHANGES.md``)
+  * In main branch, commit new release notes (``CHANGES.md``)
     summarizing changes since last major release.
 
   * Tag the new release: ``git tag -m "Castro YY.MM" YY.MM``
@@ -172,7 +172,7 @@ submodule dependencies.  The general procedure is:
 
   * ``git checkout development``
 
-  * ``git merge master``
+  * ``git merge main``
 
   * ``git push``
 

--- a/Docs/source/getting_started.rst
+++ b/Docs/source/getting_started.rst
@@ -42,7 +42,7 @@ is installed on your machine—we recommend version 1.7.x or higher.
 
    .. note::
 
-      By default, you will be on the ``master`` branch of the source.
+      By default, you will be on the ``main`` branch of the source.
       Development on Castro (and its primary dependencies, AMReX and
       Microphysics) is done in the ``development`` branch, so you
       should work there if you want the latest source::
@@ -52,7 +52,7 @@ is installed on your machine—we recommend version 1.7.x or higher.
       The Castro team runs nightly regression testing on the
       ``development`` branch, so bugs are usually found and fixed
       relatively quickly, but it is generally less stable than staying
-      on the ``master`` branch.
+      on the ``main`` branch.
 
 #. We recommend setting the ``CASTRO_HOME`` environment
    variable to point to the path name where you have put Castro.
@@ -65,7 +65,7 @@ is installed on your machine—we recommend version 1.7.x or higher.
        git pull --recurse-submodules
 
    The recommended frequency for doing this is monthly, if you are on the
-   stable ``master`` branch of the code; we issue a new release of the code
+   stable ``main`` branch of the code; we issue a new release of the code
    at the beginning of each month.
 
 #. (optional, for developers) If you prefer, you can maintain AMReX and

--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -1,4 +1,4 @@
-.. pyro documentation master file, created by
+.. Castro documentation main file, created by
    sphinx-quickstart on Mon Dec 25 18:42:54 2017.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/deploy_docs_action.sh
+++ b/deploy_docs_action.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e # Exit with nonzero exit code if anything fails
 
-# Build the documentation from the MASTER_BRANCH or DEV_BRANCH
+# Build the documentation from the MAIN_BRANCH or DEV_BRANCH
 # and push it to TARGET_BRANCH.
-MASTER_BRANCH="master"
+MAIN_BRANCH="main"
 DEV_BRANCH="development"
 TARGET_BRANCH="gh-pages"
 
@@ -21,7 +21,7 @@ make html
 cd ../
 
 mkdir -p out/docs/
-if [ "$GITHUB_BRANCH" = "$MASTER_BRANCH" ]; then
+if [ "$GITHUB_BRANCH" = "$MAIN_BRANCH" ]; then
     mkdir -p out/docs
     mv Docs/build/html/* out/docs
 else 


### PR DESCRIPTION


<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This converts the docs action to target the main branch instead of the master branch, converts all mentions of the master branch in the docs to main and changes the links in the docs so that they point to the main branch instead of master. This PR will therefore break a few links in the development docs until the master-> main conversion has been carried out.

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
