### PR TITLE
Enable multipole BCs in 1D

### DIFF
--- a/Source/gravity/Gravity.H
+++ b/Source/gravity/Gravity.H
@@ -382,7 +382,6 @@ public:
 ///
   void make_radial_phi(int level, const amrex::MultiFab& Rhs, amrex::MultiFab& phi, int fill_interior);
 
-#if (BL_SPACEDIM > 1)
 ///
 /// Implement multipole boundary conditions
 ///
@@ -397,7 +396,7 @@ public:
 /// Initialize multipole gravity
 ///
   void init_multipole_grav();
-#endif
+
 #if (BL_SPACEDIM == 3)
 
 ///

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -1853,6 +1853,15 @@ Gravity::init_multipole_grav()
             }
         }
 
+        // In 1D spherical, every term above l == 0 cancels out since the integration
+        // of the Legendre polynomial from 0 to pi is zero.
+
+        if (l > 0) {
+            if (AMREX_SPACEDIM == 1 && parent->Geom(0).Coord() == 2) {
+                multipole::parity_q0(l) = 0.0_rt;
+            }
+        }
+
         for (int m = 1; m <= l; ++m) {
 
             // The parity properties of the associated Legendre polynomials are:


### PR DESCRIPTION

## PR summary

At the moment this has no effect since Poisson gravity is not enabled in 1D.

## PR motivation

This is the last step needed to be able to remove make_radial_phi.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
