### PR TITLE
Fix compilation of uniform_cube_sphere

### DIFF
--- a/Exec/gravity_tests/uniform_cube_sphere/Prob.cpp
+++ b/Exec/gravity_tests/uniform_cube_sphere/Prob.cpp
@@ -114,7 +114,7 @@ void Castro::problem_post_init()
 
     }
 
-    gravity->multilevel_solve_for_new_phi(0, parent->finestLevel(), 0);
+    gravity->multilevel_solve_for_new_phi(0, parent->finestLevel());
 
     const int norm_power = 2;
 


### PR DESCRIPTION

## PR summary

This was broken in #1078.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
