### PR TITLE
Fix tolerance specification to uniform_cube_sphere

### DIFF
--- a/Exec/gravity_tests/uniform_cube_sphere/inputs
+++ b/Exec/gravity_tests/uniform_cube_sphere/inputs
@@ -31,7 +31,7 @@ castro.do_grav  = 1
 # GRAVITY
 gravity.gravity_type = PoissonGrav # Full self-gravity with the Poisson equation
 gravity.max_multipole_order = 0    # Multipole expansion includes terms up to r**(-max_multipole_order)
-gravity.abs_tol = 1.e-12           # Relative tolerance for multigrid solver
+gravity.rel_tol = 1.e-12           # Relative tolerance for multigrid solver
 gravity.direct_sum_bcs = 1         # Calculate boundary conditions exactly
 
 # DIAGNOSTICS & VERBOSITY


### PR DESCRIPTION

## PR summary

This should have been using the relative tolerance but was using the absolute tolerance.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
