### PR TITLE
Add C++ sets to auto prob params

### DIFF
--- a/Util/scripts/prob_params.template
+++ b/Util/scripts/prob_params.template
@@ -117,4 +117,6 @@ contains
 
   @@cxx_gets@@
 
+  @@cxx_sets@@
+
 end module probparam_f90_to_cxx


### PR DESCRIPTION

## PR summary

Now if we need to modify a parameter from C++, we can make sure the updated value gets back to Fortran.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
