### PR TITLE
Always refine on non-zero dxnuc in Detonation collision

### DIFF
--- a/Exec/science/Detonation/probin-collision
+++ b/Exec/science/Detonation/probin-collision
@@ -31,7 +31,7 @@
   dengrad_rel = 0.5
   max_dengrad_rel_lev = 0
 
-  dxnuc_min = 0.01
+  dxnuc_min = 1.d-16
   max_dxnuc_lev = 20
 /
 


### PR DESCRIPTION

## PR summary

It seems to be the case for this problem that if we refine from the very beginning of the burning, even if we just subcycle the hydro on the fine levels with castro.reactions_max_solve_level=0, that helps avoid the spurious prompt ignition with a low base resolution. With the previous dxnuc_min, we were responding far too late to move the setup away from its course to ignition.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
