### PR TITLE
Enforce castro.speed_limit on the magnitude of the velocity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # 20.08
 
+   * If castro.speed_limit is set to a number greater than zero, this
+     will now be strictly enforced on the magnitude of the velocity. (#1115)
+
    * We now have the ability to access the problem-specific runtime
      parameters in C++ (#1093)
 

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -1127,6 +1127,15 @@ public:
     void enforce_min_density (amrex::MultiFab& state, int ng);
 
 ///
+/// Ensure the magnitude of the velocity is not larger than ``castro.speed_limit``
+/// in any zone.
+///
+/// @param state        state
+/// @param ng           number of ghost cells
+///
+    void enforce_speed_limit (amrex::MultiFab& state, int ng);
+
+///
 /// Given ``State_Type`` state data, perform a number of cleaning steps to make
 /// sure the data is sensible.
 ///

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3067,6 +3067,52 @@ Castro::enforce_min_density (MultiFab& state_in, int ng)
 }
 
 void
+Castro::enforce_speed_limit (MultiFab& state_in, int ng)
+{
+    BL_PROFILE("Castro::enforce_speed_limit()");
+
+    // This routine sets the velocity in state_in to be no larger than the
+    // speed limit, if one has been applied.
+
+    if (castro::speed_limit <= 0.0_rt) return;
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+    for (MFIter mfi(state_in, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+
+        const Box& bx = mfi.growntilebox(ng);
+
+        auto u = state_in[mfi].array();
+
+        amrex::ParallelFor(bx,
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        {
+            Real rho = u(i,j,k,URHO);
+            Real rhoInv = 1.0_rt / rho;
+
+            Real vx = u(i,j,k,UMX) * rhoInv;
+            Real vy = u(i,j,k,UMY) * rhoInv;
+            Real vz = u(i,j,k,UMZ) * rhoInv;
+
+            Real v = std::sqrt(vx * vx + vy * vy + vz * vz);
+
+            if (v > castro::speed_limit) {
+                Real reduce_factor = castro::speed_limit / v;
+
+                u(i,j,k,UMX) *= reduce_factor;
+                u(i,j,k,UMY) *= reduce_factor;
+                u(i,j,k,UMZ) *= reduce_factor;
+
+                u(i,j,k,UEDEN) -= 0.5_rt * rhoInv * (rho * vx * rho * vx - u(i,j,k,UMX) * u(i,j,k,UMX) +
+                                                     rho * vy * rho * vy - u(i,j,k,UMY) * u(i,j,k,UMY) +
+                                                     rho * vz * rho * vz - u(i,j,k,UMZ) * u(i,j,k,UMZ));
+            }
+        });
+    }
+}
+
+void
 Castro::avgDown (int state_indx)
 {
     BL_PROFILE("Castro::avgDown(state_indx)");
@@ -4203,6 +4249,10 @@ Castro::clean_state(
     // Enforce a minimum density.
 
     enforce_min_density(state_in, ng);
+
+    // Enforce the speed limit.
+
+    enforce_speed_limit(state_in, ng);
 
     // Ensure all species are normalized.
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -182,7 +182,8 @@ limit_fluxes_on_small_dens   int           0                  y
 limit_fluxes_on_large_vel    int           0                  y
 
 # If we're limiting the fluxes to avoid large velocities, this is the speed limit.
-speed_limit                  Real          2.99792458e10      y
+# Only applies if set to be greater than 0.
+speed_limit                  Real          0.0                y
 
 # permits sponge to be turned on and off
 do_sponge                    int           0                  y

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -181,8 +181,8 @@ limit_fluxes_on_small_dens   int           0                  y
 # Should we limit the momentum fluxes so that we do not create large velocities?
 limit_fluxes_on_large_vel    int           0                  y
 
-# If we're limiting the fluxes to avoid large velocities, this is the speed limit.
-# Only applies if set to be greater than 0.
+# Enforce the magnitude of the velocity to be no larger than this number (and
+# optionally limit the fluxes as well). Only applies if it is greater than 0.
 speed_limit                  Real          0.0                y
 
 # permits sponge to be turned on and off

--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -978,6 +978,8 @@ Castro::limit_hydro_fluxes_on_large_vel(const Box& bx,
     // on velocities that are too large instead. The comments are minimal since
     // the algorithm is effectively the same.
 
+    if (castro::speed_limit <= 0.0_rt) return;
+
     const Real* dx = geom.CellSize();
 
     Real dtdx = dt / dx[idir];


### PR DESCRIPTION

## PR summary

Previously this parameter only applied if we were using castro.limit_fluxes_on_large_vel.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
