### PR TITLE
Use the new AMReX face interpolator for grad phi

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # 20.08
 
+   * An issue with gravity.max_solve_level resulting in accesses to invalid data
+     (#469, #1118) has been resolved. (#1123)
+
    * If castro.speed_limit is set to a number greater than zero, this
      will now be strictly enforced on the magnitude of the velocity. (#1115)
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -2200,9 +2200,9 @@ Castro::post_regrid (int lbase,
 
                GradPhiPhysBCFunct gp_phys_bc;
 
-               // We need to use a nodal interpolater.
+               // We need to use a interpolater that works with data on faces.
 
-               Interpolater* gp_interp = &node_bilinear_interp;
+               Interpolater* gp_interp = &face_linear_interp;
 
                Vector<MultiFab*> grad_phi_coarse = amrex::GetVecOfPtrs(gravity->get_grad_phi_prev(level-1));
                Vector<MultiFab*> grad_phi_fine = amrex::GetVecOfPtrs(gravity->get_grad_phi_curr(level));

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -826,9 +826,9 @@ Gravity::actual_multilevel_solve (int crse_level, int finest_level_in,
 
         GradPhiPhysBCFunct gp_phys_bc;
 
-        // We need to use a nodal interpolater.
+        // We need to use a interpolater that works with data on faces.
 
-        Interpolater* gp_interp = &node_bilinear_interp;
+        Interpolater* gp_interp = &face_linear_interp;
 
         // For the BCs, we will use the Gravity_Type BCs for convenience, but these will
         // not do anything because we do not fill on physical boundaries.


### PR DESCRIPTION

## PR summary

This fixes #469 and fixes #1118 by ensuring that the interpolator for grad phi (used when gravity.max_solve_level is in play) is valid for nodal data.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
