### PR TITLE
Calculate rotational acceleration inline and remove Rotation_Type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # 20.08
 
+   * Rotation_Type has been removed from StateData. (#1128)
+
    * castro.use_post_step_regrid now unconditionally regrids after
      every timestep on every level. (#898)
 

--- a/Docs/source/io.rst
+++ b/Docs/source/io.rst
@@ -240,8 +240,8 @@ Native variables
 These variables come directly from the ``StateData``, either the
 ``State_Type`` (for the hydrodynamic variables), ``Reactions_Type``
 (for the nuclear energy generation quantities). ``PhiGrav_Type`` and
-``Gravity_Type`` (for the gravity quantities), ``PhiRot_Type`` and
-``Rotation_Type`` (for the rotation quantities) and ``Rad_Type`` (for
+``Gravity_Type`` (for the gravity quantities), ``PhiRot_Type`` 
+(for the rotation quantities) and ``Rad_Type`` (for
 radiation quantities).
 
 
@@ -280,8 +280,6 @@ radiation quantities).
 | ``grav_z``                        |                                                   |                                      |
 +-----------------------------------+---------------------------------------------------+--------------------------------------+
 | ``phiRot``                        | Effective centrifugal potential                   | :math:`{\rm erg~g^{-1}}`             |
-+-----------------------------------+---------------------------------------------------+--------------------------------------+
-| ``rot_x``. ``rot_y``, ``rot_z``   | Rotational acceleration                           | :math:`{\rm cm~s^{-2}}`              |
 +-----------------------------------+---------------------------------------------------+--------------------------------------+
 | ``rmom``                          | Radial momentum (defined for                      | :math:`{\rm g~cm^{-2}~s^{-1}}`       |
 |                                   | ``HYBRID_MOMENTUM``)                              |                                      |

--- a/Docs/source/software.rst
+++ b/Docs/source/software.rst
@@ -301,13 +301,6 @@ The current ``StateData`` names Castro carries are:
    When rotation is enabled, this will store the effective potential
    corresponding to the centrifugal force.
 
--  ``Rotation_Type`` : this is the rotational acceleration.
-   There are always 3 components, regardless of the dimensionality
-   (consistent with our choice of always carrying all 3 velocity
-   components). This includes the terms corresponding to the Coriolis
-   force, the centrifugal force, as well as optional terms due to the
-   change in rotation rate, :math:`\Omega`.
-
 -  ``Source_Type`` : this holds the time-rate of change of
    the source terms, :math:`d\Sb/dt`, for each of the ``NUM_STATE``
    ``State_Type`` variables.

--- a/Exec/science/wdmerger/Problem_Derives.H
+++ b/Exec/science/wdmerger/Problem_Derives.H
@@ -84,7 +84,7 @@
     //
     derive_lst.add("rho_phiRot",IndexType::TheCellType(),1,ca_derrhophiRot,the_same_box);
     derive_lst.addComponent("rho_phiRot",desc_lst,State_Type,URHO,1);
-    derive_lst.addComponent("rho_phiRot",desc_lst,Rotation_Type,0,1);
+    derive_lst.addComponent("rho_phiRot",desc_lst,PhiRot_Type,0,1);
 #endif
 
 #ifdef GRAVITY

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -76,7 +76,6 @@ enum StateType { State_Type = 0,
 #endif
 #ifdef ROTATION
                  PhiRot_Type,
-                 Rotation_Type,
 #endif
                  Source_Type,
 #ifdef REACTIONS

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1313,9 +1313,6 @@ Castro::initData ()
     source_new.setVal(0., source_new.nGrow());
 
 #ifdef ROTATION
-    MultiFab& rot_new = get_new_data(Rotation_Type);
-    rot_new.setVal(0.);
-
     MultiFab& phirot_new = get_new_data(PhiRot_Type);
     phirot_new.setVal(0.);
 #endif
@@ -2071,13 +2068,11 @@ Castro::post_restart ()
 
 #ifdef ROTATION
     MultiFab& phirot_new = get_new_data(PhiRot_Type);
-    MultiFab& rot_new = get_new_data(Rotation_Type);
     MultiFab& S_new = get_new_data(State_Type);
     if (do_rotation) {
-      fill_rotation_field(phirot_new, rot_new, S_new, cur_time);
+      fill_rotation_field(phirot_new, S_new, cur_time);
     }  else {
       phirot_new.setVal(0.0);
-      rot_new.setVal(0.0);
     }
 #endif
 
@@ -2247,15 +2242,13 @@ Castro::post_init (Real stop_time)
 
 #ifdef ROTATION
     MultiFab& phirot_new = get_new_data(PhiRot_Type);
-    MultiFab& rot_new = get_new_data(Rotation_Type);
     MultiFab& S_new = get_new_data(State_Type);
     if (do_rotation) {
       Real cur_time = state[State_Type].curTime();
-      fill_rotation_field(phirot_new, rot_new, S_new, cur_time);
+      fill_rotation_field(phirot_new, S_new, cur_time);
     }
     else {
       phirot_new.setVal(0.0);
-      rot_new.setVal(0.0);
     }
 #endif
 
@@ -2379,15 +2372,13 @@ Castro::post_grown_restart ()
 
 #ifdef ROTATION
     MultiFab& phirot_new = get_new_data(PhiRot_Type);
-    MultiFab& rot_new = get_new_data(Rotation_Type);
     MultiFab& S_new = get_new_data(State_Type);
     if (do_rotation) {
       Real cur_time = state[State_Type].curTime();
-      fill_rotation_field(phirot_new, rot_new, S_new, cur_time);
+      fill_rotation_field(phirot_new, S_new, cur_time);
     }
     else {
       phirot_new.setVal(0.0);
-      rot_new.setVal(0.0);
     }
 #endif
 

--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -50,11 +50,12 @@ using namespace amrex;
 // 6: Simplified_SDC_Source_Type removed from Castro
 // 7: A weights field was added to Reactions_Type; number of ghost zones increased to NUM_GROW
 // 8: Reactions_Type modified to use rho * omegadot instead of omegadot; rho * auxdot added
+// 9: Rotation_Type was removed from Castro
 
 namespace
 {
     int input_version = -1;
-    int current_version = 8;
+    int current_version = 9;
 }
 
 // I/O routines for Castro

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -474,11 +474,6 @@ Castro::variableSetUp ()
                          StateDescriptor::Point, 1, 1,
                          &cell_cons_interp, state_data_extrap,
                          store_in_checkpoint);
-
-  store_in_checkpoint = false;
-  desc_lst.addDescriptor(Rotation_Type,IndexType::TheCellType(),
-                         StateDescriptor::Point,NUM_GROW,3,
-                         &cell_cons_interp,state_data_extrap,store_in_checkpoint);
 #endif
 
 
@@ -648,15 +643,6 @@ Castro::variableSetUp ()
   set_scalar_bc(bc,phys_bc);
   replace_inflow_bc(bc);
   desc_lst.setComponent(PhiRot_Type,0,"phiRot",bc,genericBndryFunc);
-  set_x_vel_bc(bc,phys_bc);
-  replace_inflow_bc(bc);
-  desc_lst.setComponent(Rotation_Type,0,"rot_x",bc,genericBndryFunc);
-  set_y_vel_bc(bc,phys_bc);
-  replace_inflow_bc(bc);
-  desc_lst.setComponent(Rotation_Type,1,"rot_y",bc,genericBndryFunc);
-  set_z_vel_bc(bc,phys_bc);
-  replace_inflow_bc(bc);
-  desc_lst.setComponent(Rotation_Type,2,"rot_z",bc,genericBndryFunc);
 #endif
 
   // Source term array will use source fill

--- a/Source/rotation/Castro_rotation.H
+++ b/Source/rotation/Castro_rotation.H
@@ -30,7 +30,7 @@
 /// @param state    Current state
 /// @param time     current time
 ///
-    void fill_rotation_field(amrex::MultiFab& phi, amrex::MultiFab& rot, amrex::MultiFab& state, amrex::Real time);
+    void fill_rotation_field(amrex::MultiFab& phi, amrex::MultiFab& state, amrex::Real time);
 
 
     AMREX_GPU_HOST_DEVICE
@@ -45,13 +45,11 @@
 /// term source
 ///
 /// @param bx        the box to operate over
-/// @param rot       the rotational acceleration
 /// @param source    the full hydrodynamical source term
 /// @param dt        current timestep
 ///
     void
     rsrc(const Box& bx,
-         Array4<Real const> const& rot,
          Array4<Real const> const& uold,
          Array4<Real> const& source, 
          const Real dt);
@@ -62,8 +60,6 @@
 /// @param bx       the box to operate over
 /// @param phi_old  rotational potential at old time
 /// @param phi_new  rotational potential at new time
-/// @param rold     rotational acceleration at old time
-/// @param rnew     rotational acceleration at new time
 /// @param uold     old time state
 /// @param unew     new time state
 /// @param source   full hydrodynamic state
@@ -77,8 +73,6 @@
     corrrsrc(const Box& bx,
              Array4<Real const> const& phi_old,
              Array4<Real const> const& phi_new,
-             Array4<Real const> const& rold,
-             Array4<Real const> const& rnew,
              Array4<Real const> const& uold,
              Array4<Real const> const& unew,
              Array4<Real> const& source,
@@ -87,18 +81,6 @@
              Array4<Real const> const& flux2,
              const Real dt,
              Array4<Real const> const& vol);
-
-///
-/// Compute the rotational acceleration over a box
-///
-/// @param bx         the box to operate over
-/// @param rot        the rotational acceleration
-/// @param state      the input state
-////
-    void
-    fill_rotational_acceleration(const Box& bx,
-                                 Array4<Real> const& rot,
-                                 Array4<Real const> const& state);
 
 ///
 /// Compute the rotational acceleration for a single zone

--- a/Source/rotation/Castro_rotation.cpp
+++ b/Source/rotation/Castro_rotation.cpp
@@ -13,20 +13,18 @@ Castro::construct_old_rotation_source(MultiFab& source, MultiFab& state_in, Real
     const Real strt_time = ParallelDescriptor::second();
 
     MultiFab& phirot_old = get_old_data(PhiRot_Type);
-    MultiFab& rot_old = get_old_data(Rotation_Type);
 
     // Fill the rotation data.
 
     if (!do_rotation) {
 
         phirot_old.setVal(0.0);
-        rot_old.setVal(0.0);
 
         return;
 
     }
 
-    fill_rotation_field(phirot_old, rot_old, state_in, time);
+    fill_rotation_field(phirot_old, state_in, time);
 
     const Real *dx = geom.CellSize();
     const int* domlo = geom.Domain().loVect();
@@ -39,7 +37,7 @@ Castro::construct_old_rotation_source(MultiFab& source, MultiFab& state_in, Real
     {
         const Box& bx = mfi.tilebox();
 
-        rsrc(bx, rot_old.array(mfi), state_in.array(mfi), source.array(mfi), dt);
+        rsrc(bx, state_in.array(mfi), source.array(mfi), dt);
 
     }
 
@@ -71,23 +69,20 @@ Castro::construct_new_rotation_source(MultiFab& source, MultiFab& state_old, Mul
     const Real strt_time = ParallelDescriptor::second();
 
     MultiFab& phirot_old = get_old_data(PhiRot_Type);
-    MultiFab& rot_old = get_old_data(Rotation_Type);
 
     MultiFab& phirot_new = get_new_data(PhiRot_Type);
-    MultiFab& rot_new = get_new_data(Rotation_Type);
 
     // Fill the rotation data.
 
     if (!do_rotation) {
 
         phirot_new.setVal(0.);
-        rot_new.setVal(0.);
 
         return;
 
     }
 
-    fill_rotation_field(phirot_new, rot_new, state_new, time);
+    fill_rotation_field(phirot_new, state_new, time);
 
     // Now do corrector part of rotation source term update
 
@@ -105,7 +100,6 @@ Castro::construct_new_rotation_source(MultiFab& source, MultiFab& state_old, Mul
 
             corrrsrc(bx,
                      phirot_old.array(mfi), phirot_new.array(mfi),
-                     rot_old.array(mfi), rot_new.array(mfi),
                      state_old.array(mfi), state_new.array(mfi),
                      source.array(mfi),
                      (*mass_fluxes[0]).array(mfi), (*mass_fluxes[1]).array(mfi), (*mass_fluxes[2]).array(mfi),
@@ -133,7 +127,7 @@ Castro::construct_new_rotation_source(MultiFab& source, MultiFab& state_old, Mul
 
 
 
-void Castro::fill_rotation_field(MultiFab& phi, MultiFab& rot, MultiFab& state_in, Real time)
+void Castro::fill_rotation_field(MultiFab& phi, MultiFab& state_in, Real time)
 {
 
     BL_PROFILE("Castro::fill_rotation_field()");
@@ -153,25 +147,6 @@ void Castro::fill_rotation_field(MultiFab& phi, MultiFab& rot, MultiFab& state_i
         const Box& bx = mfi.growntilebox(ng);
 
         fill_rotational_potential(bx, phi.array(mfi), time);
-
-    }
-
-    rot.setVal(0.0);
-
-    ng = state_in.nGrow();
-
-    if (ng > rot.nGrow())
-        amrex::Error("State MF has more ghost cells than rotation MF.");
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-    for (MFIter mfi(state_in, TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-
-        const Box& bx = mfi.growntilebox(ng);
-
-        fill_rotational_acceleration(bx, rot.array(mfi), state_in.array(mfi));
 
     }
 

--- a/Source/rotation/Rotation.cpp
+++ b/Source/rotation/Rotation.cpp
@@ -78,57 +78,6 @@ Castro::rotational_acceleration(GpuArray<Real, 3>& r, GpuArray<Real, 3>& v,
 
 
 void
-Castro::fill_rotational_acceleration(const Box& bx,
-                                     Array4<Real> const& rot,
-                                     Array4<Real const> const& state) {
-
-  GpuArray<Real, 3> center;
-  ca_get_center(center.begin());
-
-  auto problo = geom.ProbLoArray();
-
-  auto dx = geom.CellSizeArray();
-
-  auto coord_type = geom.Coord();
-
-  GpuArray<Real, 3> omega;
-  get_omega(omega.begin());
-
-  amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
-  {
-
-    GpuArray<Real, 3> r;
-
-    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt) - center[0];
-#if AMREX_SPACEDIM >= 2
-    r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt) - center[1];
-#else
-    r[1] = 0.0_rt;
-#endif
-#if AMREX_SPACEDIM == 3
-    r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt) - center[2];
-#else
-    r[2] = 0.0_rt;
-#endif
-
-    GpuArray<Real, 3> v;
-
-    v[0] = state(i,j,k,UMX) / state(i,j,k,URHO);
-    v[1] = state(i,j,k,UMY) / state(i,j,k,URHO);
-    v[2] = state(i,j,k,UMZ) / state(i,j,k,URHO);
-
-    bool coriolis = true;
-    Real Sr[3];
-    rotational_acceleration(r, v, omega, coriolis, Sr);
-
-    for (int idir = 0; idir < 3; idir++) {
-      rot(i,j,k,idir) = Sr[idir];
-    }
-  });
-}
-
-void
 Castro::fill_rotational_potential(const Box& bx,
                                   Array4<Real> const& phi,
                                   const Real time) {


### PR DESCRIPTION

## PR summary

Rather than calculate rotational acceleration first and then use it in the rotation sources, we calculate it on demand in the source evaluation. Rotation_Type is removed from StateData.

## PR motivation

This gets us part of the way to completing #1127.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
