### PR TITLE
Throw an error if building with both OpenMP and CUDA

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -99,6 +99,12 @@ ifeq ($(USE_CUDA),TRUE)
   USE_GPU_PRAGMA = TRUE
   DEFINES += -DCUDA
   CUDA_VERBOSE = FALSE
+
+  # We don't currently support host-side OpenMP being enabled
+  # when using CUDA. Throw an error to prevent this case.
+  ifeq ($(USE_OMP),TRUE)
+    $(error OpenMP is not supported by Castro when building with CUDA)
+  endif
 endif
 
 # Allow a problem to specify that we want to initialize


### PR DESCRIPTION

## PR summary

## PR motivation

I plan to eventually build support for this case, but I don't expect it to work correctly right now, so we should disable it for safety.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
