### PR TITLE
Remove direct id cpu access

### DIFF
--- a/Exec/unit_tests/particles_test/Prob.cpp
+++ b/Exec/unit_tests/particles_test/Prob.cpp
@@ -65,8 +65,8 @@ void Castro::problem_post_simulation(Vector<std::unique_ptr<AmrLevel> >& amr_lev
 			ifs >> p.m_rdata.arr[AMREX_SPACEDIM+n];
 		}
 
-		p.m_idata.id  = ParticleType::NextID();
-		p.m_idata.cpu = MyProc;
+		p.id()  = ParticleType::NextID();
+		p.cpu() = MyProc;
 
 		nparticles.push_back(p);
 	}
@@ -92,7 +92,7 @@ void Castro::problem_post_simulation(Vector<std::unique_ptr<AmrLevel> >& amr_lev
 
 			// find the original particle and calculate change in position
 			for (; !match && it != nparticles.end(); ++it) {
-				if (it->m_idata.id == p.m_idata.id)
+                            if (it->id() == p.id())
 					match = true;
 			}
 


### PR DESCRIPTION
These data members are currently implemented using an anonymous struct, which is not part of the C++ standard. They will be removed from amrex as part of a larger effort to eliminate common compiler warnings. You can still get and set them with p.id() and p.cpu().