### PR TITLE
Remove dependence on AMReX C_CellMG which is now removed

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -292,14 +292,6 @@ ifeq ($(USE_PARTICLES), TRUE)
  Pdirs += Particle
 endif
 
-ifeq ($(USE_RAD), TRUE)
-  Pdirs += LinearSolvers/C_CellMG
-else
-ifeq ($(USE_MLMG), TRUE)
-  Pdirs += LinearSolvers/C_CellMG
-endif
-endif
-
 ifeq ($(USE_MLMG), TRUE)
    DEFINES += -DCASTRO_MLMG
    Pdirs += LinearSolvers/MLMG


### PR DESCRIPTION

## PR summary

This was removed in AMReX-Codes/amrex#1238.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
