### PR TITLE
remove references to unused rpar parameters

### DIFF
--- a/Source/driver/timestep_nd.F90
+++ b/Source/driver/timestep_nd.F90
@@ -117,8 +117,6 @@ contains
              call eos(eos_input_rt, eos_state)
              call eos_to_burn(eos_state, state_new)
 
-             state_new % dx = minval(dx(1:dim))
-
 #ifndef SIMPLIFIED_SDC
              state_new % self_heat = self_heat
 #else

--- a/Source/reactions/React_nd.F90
+++ b/Source/reactions/React_nd.F90
@@ -47,7 +47,7 @@ contains
     real(rt) , intent(inout) :: failed
 
     integer          :: i, j, k, n
-    real(rt)         :: rhoInv, dx_min
+    real(rt)         :: rhoInv
     logical          :: do_burn
 
     type (burn_t) :: burn_state_in, burn_state_out
@@ -59,13 +59,8 @@ contains
     ! This interface is currently unsupported with simplified SDC.
 #ifndef SIMPLIFIED_SDC
 
-    ! Minimum zone width
-
-    dx_min = minval(dx_level(1:dim, amr_level))
-
     !$acc data &
     !$acc copyin(lo, hi, r_lo, r_hi, s_lo, s_hi, dt_react, time) &
-    !$acc copyin(dx_min) &
     !$acc copy(state, reactions) if(do_acc == 1)
 
     !$acc parallel if(do_acc == 1)
@@ -126,8 +121,6 @@ contains
              else
                 burn_state_in % k = -1
              endif
-
-             burn_state_in % dx = dx_min
 
              ! Ensure we start with no RHS or Jacobian calls registered.
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

We removed the t_sound based burning limiter, this now removes references to those parameters.  This is needed
once we merge https://github.com/starkiller-astro/Microphysics/pull/388

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
