### PR TITLE
fix a bounds issue in ca_initgroups3

### DIFF
--- a/Source/radiation/Rad_nd.F90
+++ b/Source/radiation/Rad_nd.F90
@@ -2536,7 +2536,7 @@ subroutine ca_initgroups3(nugr, dnugr, dlognugr, xnugr, ngr, ngr0, ngr1)
 
   implicit none
 
-  real(rt), intent(in) :: nugr(0:ngr-1), dnugr(0:ngr-1), dlognugr(0:ngr-1), xnugr(0:ngr+2)
+  real(rt), intent(in) :: nugr(0:ngr-1), dnugr(0:ngr-1), dlognugr(0:ngr-1), xnugr(0:ngr)
   integer :: ngr, ngr0, ngr1
 
   ! Local variables
@@ -2563,7 +2563,7 @@ subroutine ca_initgroups3(nugr, dnugr, dlognugr, xnugr, ngr, ngr0, ngr1)
 
   allocate(nugroup( 0:ngroups-1))
   allocate(dnugroup(0:ngroups-1))
-  allocate(xnu(0:ngroups+2))
+  allocate(xnu(0:ngroups))
   allocate(dlognu(0:ngroups-1))
   allocate(erg2rhoYe(0:ngroups-1))
   allocate(lognugroup( 0:ngroups-1))


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

In `RadMultiGroup.cpp` we are allocating `xnu` as size `nGroups+1`, but in the Fortran, we dimensioned it as `0:ngroups+2`.

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
