### PR TITLE
Don't prevent problems from having initial dt < epsilon

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -523,7 +523,7 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
 
         // Determine whether we're below the cutoff timestep.
 
-        if (dt_subcycle < dt_cutoff * time || (time == 0.0 && dt_subcycle < eps)) {
+        if (dt_subcycle <= dt_cutoff * time) {
             if (ParallelDescriptor::IOProcessor()) {
                 std::cout << std::endl;
                 std::cout << "  The subcycle mechanism requested subcycled timesteps of maximum length dt = " << dt_subcycle << "," << std::endl


### PR DESCRIPTION

## PR summary

#1160 attempted to catch problems whose initial dt was zero from subcycling indefinitely. However, it unintentionally broke certain radiation problems with dt < 1.e-15. This resolves the issue by just making the check on dt_subcycle a <= rather than a <, so that we'll catch dt == 0 at time == 0 but not catch dt merely being very small.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
