### PR TITLE
ca_initdata does not abort if unused

### DIFF
--- a/Source/problems/Prob_nd.F90
+++ b/Source/problems/Prob_nd.F90
@@ -48,9 +48,7 @@ subroutine ca_initdata(level,time,lo,hi,nvar, &
                             state_lo(2):state_hi(2), &
                             state_lo(3):state_hi(3),nvar)
 
-  ! Remove this call if you're defining your own problem; it is here to
-  ! ensure that you cannot run CASTRO if you haven't got your own copy of this function.
-
-  call castro_error("Prob_nd.f90 has not been defined for this problem!")
+  ! This call does nothing by default; it should be copied to a problem directory
+  ! and overwritten for the problem setup of interest.
 
 end subroutine ca_initdata


### PR DESCRIPTION

## PR summary

The state data is initialized to zero before the call to ca_initdata and there is a check to ensure rho and T are > 0, so we will still get an abort if for some reason ca_initdata was not overridden for a given problem.

## PR motivation

This will allow us to implement a C++ version of ca_initdata without requiring a special ifdef.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
