### PR TITLE
Add riemann.h constants to a namespace

### DIFF
--- a/Source/hydro/riemann.H
+++ b/Source/hydro/riemann.H
@@ -3,9 +3,11 @@
 
 using namespace amrex;
 
-const Real smlp1 = 1.e-10_rt;
-const Real small = 1.e-8_rt;
-const Real smallu = 1.e-12_rt;
+namespace riemann_constants {
+    const Real smlp1 = 1.e-10_rt;
+    const Real small = 1.e-8_rt;
+    const Real smallu = 1.e-12_rt;
+}
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void
@@ -30,14 +32,14 @@ wsqge(const Real p, const Real v,
   // this is CG Eq. 34
   Real alpha = pstar - (gstar - 1.0_rt)*p/(gam - 1.0_rt);
   if (alpha == 0.0_rt) {
-    alpha = smlp1*(pstar + p);
+    alpha = riemann_constants::smlp1*(pstar + p);
   }
 
   Real beta = pstar + 0.5_rt*(gstar - 1.0_rt)*(pstar+p);
 
   wsq = (pstar-p)*beta/(v*alpha);
 
-  if (std::abs(pstar - p) < smlp1*(pstar + p)) {
+  if (std::abs(pstar - p) < riemann_constants::smlp1*(pstar + p)) {
     wsq = csq;
   }
   wsq = amrex::max(wsq, (0.5_rt * (gam - 1.0_rt)/gam)*csq);

--- a/Source/hydro/riemann_solvers.cpp
+++ b/Source/hydro/riemann_solvers.cpp
@@ -86,7 +86,7 @@ Castro::riemanncg(const Box& bx,
   const Real lsmall_dens = small_dens;
   const Real lsmall_pres = small_pres;
   const Real lsmall_temp = small_temp;
-  const Real lsmall = small;
+  const Real lsmall = riemann_constants::small;
 
   amrex::ParallelFor(bx,
   [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
@@ -422,7 +422,7 @@ Castro::riemanncg(const Box& bx,
 
     // for symmetry preservation, if ustar is really small, then we
     // set it to zero
-    if (std::abs(ustar) < smallu*0.5_rt*(std::abs(ul) + std::abs(ur))) {
+    if (std::abs(ustar) < riemann_constants::smallu*0.5_rt*(std::abs(ul) + std::abs(ur))) {
       ustar = 0.0_rt;
     }
 
@@ -620,7 +620,7 @@ Castro::riemannus(const Box& bx,
 
   const int luse_eos_in_riemann = use_eos_in_riemann;
 
-  const Real lsmall = small;
+  const Real lsmall = riemann_constants::small;
   const Real lsmall_dens = small_dens;
   const Real lsmall_pres = small_pres;
   const Real lT_guess = T_guess;
@@ -814,7 +814,7 @@ Castro::riemannus(const Box& bx,
 
     // for symmetry preservation, if ustar is really small, then we
     // set it to zero
-    if (std::abs(ustar) < smallu*0.5_rt*(std::abs(ul) + std::abs(ur))) {
+    if (std::abs(ustar) < riemann_constants::smallu*0.5_rt*(std::abs(ul) + std::abs(ur))) {
       ustar = 0.0_rt;
     }
 
@@ -1100,7 +1100,7 @@ Castro::HLLC(const Box& bx,
 
   const Real lsmall_dens = small_dens;
   const Real lsmall_pres = small_pres;
-  const Real lsmall = small;
+  const Real lsmall = riemann_constants::small;
 
   int coord = geom.Coord();
 
@@ -1170,7 +1170,7 @@ Castro::HLLC(const Box& bx,
     pstar = amrex::max(pstar, lsmall_pres);
     // for symmetry preservation, if ustar is really small, then we
     // set it to zero
-    if (std::abs(ustar) < smallu*0.5_rt*(std::abs(ul) + std::abs(ur))){
+    if (std::abs(ustar) < riemann_constants::smallu*0.5_rt*(std::abs(ul) + std::abs(ur))){
       ustar = 0.0_rt;
     }
 


### PR DESCRIPTION

## PR summary

This helps avoid conflicts with other global parameters.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
