### PR TITLE
Problem parameters not in namelist also have a C++ version

### DIFF
--- a/Exec/hydro_tests/toy_convect/Prob_nd.F90
+++ b/Exec/hydro_tests/toy_convect/Prob_nd.F90
@@ -18,6 +18,10 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   ! Namelist defaults
   call probdata_init(name, namlen)
 
+  if (num_vortices > max_num_vortices) then
+     call castro_error("num_vortices too large, please increase max_num_vortices and the size of xloc_vortices")
+  end if
+
   ! Read initial model
   call read_model_file(model_name)
 

--- a/Exec/hydro_tests/toy_convect/_prob_params
+++ b/Exec/hydro_tests/toy_convect/_prob_params
@@ -14,7 +14,9 @@ velpert_height_loc  real                6.5e3_rt      y
 
 num_vortices        integer             1             y
 
-xloc_vortices       real                0.0_rt        n       num_vortices
+max_num_vortices    integer             10            n
+
+xloc_vortices       real                0.0_rt        n       10
 
 ih1                 integer             -1
 

--- a/Exec/science/wdmerger/Castro_ext_src.H
+++ b/Exec/science/wdmerger/Castro_ext_src.H
@@ -30,7 +30,7 @@ void do_ext_src(int i, int j, int k,
         // the smaller of the two WD timescales. Generally this should be the primary, but we'll
         // be careful just in case.
 
-        const Real dynamical_timescale = amrex::min(wdmerger::t_ff_p, wdmerger::t_ff_s);
+        const Real dynamical_timescale = amrex::min(t_ff_P, t_ff_S);
 
         // The relaxation damping factor should be less than unity, so that the damping
         // timescale is less than the dynamical timescale. This ensures that the stars
@@ -101,7 +101,7 @@ void do_ext_src(int i, int j, int k,
         // how to do the implicit coupling follows the reasoning
         // described above for the relaxation damping.
 
-        const Real dynamical_timescale = amrex::max(wdmerger::t_ff_p, wdmerger::t_ff_s);
+        const Real dynamical_timescale = amrex::max(t_ff_P, t_ff_S);
 
         const Real relaxation_damping_timescale = relaxation_damping_factor * dynamical_timescale;
 

--- a/Exec/science/wdmerger/Prob.cpp
+++ b/Exec/science/wdmerger/Prob.cpp
@@ -533,9 +533,9 @@ void Castro::volInBoundary (Real time, Real& vol_P, Real& vol_S, Real rho_cutoff
 
 void
 Castro::gwstrain (Real time,
-		  Real& h_Plus_1, Real& h_cross_1,
-		  Real& h_Plus_2, Real& h_cross_2,
-		  Real& h_Plus_3, Real& h_cross_3,
+		  Real& h_plus_1, Real& h_cross_1,
+		  Real& h_plus_2, Real& h_cross_2,
+		  Real& h_plus_3, Real& h_cross_3,
 		  bool local) {
 
     BL_PROFILE("Castro::gwstrain()");
@@ -761,9 +761,9 @@ Castro::gwstrain (Real time,
     // Now that we have the second time derivative of the quadrupole
     // tensor, we can calculate the transverse-trace gauge strain tensor.
 
-    gw_strain_tensor(&h_Plus_1, &h_cross_1,
-		     &h_Plus_2, &h_cross_2,
-		     &h_Plus_3, &h_cross_3,
+    gw_strain_tensor(&h_plus_1, &h_cross_1,
+		     &h_plus_2, &h_cross_2,
+		     &h_plus_3, &h_cross_3,
 		     Qtt.dataPtr(), &time);
 
 }
@@ -934,7 +934,7 @@ void Castro::check_to_stop(Real time, bool dump) {
             // should be expanded in the future to cover that case.
 
             Real rho_E = 0.0;
-            Real rho_Phi = 0.0;
+            Real rho_phi = 0.0;
 
             // Note that we'll define the total energy using only
             // gas energy + gravitational. Rotation is never on
@@ -951,11 +951,11 @@ void Castro::check_to_stop(Real time, bool dump) {
 
 #ifdef GRAVITY
             if (do_grav) {
-                rho_Phi += volWgtSum("rho_PhiGrav", curTime,  local_flag, fine_mask);
+                rho_phi += volWgtSum("rho_phiGrav", curTime,  local_flag, fine_mask);
             }
 #endif
 
-            E_tot = rho_E + 0.5 * rho_Phi;
+            E_tot = rho_E + 0.5 * rho_phi;
 
             amrex::ParallelDescriptor::ReduceRealSum(E_tot);
 

--- a/Exec/science/wdmerger/Prob.cpp
+++ b/Exec/science/wdmerger/Prob.cpp
@@ -75,25 +75,39 @@ Castro::wd_update (Real time, Real dt)
     BL_ASSERT(level == 0 || (!parent->subCycle() && level == parent->finestLevel()));
 
     // Get the current stellar data
-    get_star_data(com_p, com_s, vel_p, vel_s, &mass_p, &mass_s, &t_ff_p, &t_ff_s);
+    get_f90_com_P(com_P);
+    get_f90_com_S(com_S);
+    get_f90_vel_P(vel_P);
+    get_f90_vel_S(vel_S);
+    get_f90_mass_P(&mass_P);
+    get_f90_mass_S(&mass_S);
+    get_f90_t_ff_P(&t_ff_P);
+    get_f90_t_ff_S(&t_ff_S);
 
     // Update the problem center using the system bulk velocity
     update_center(&time);
 
     for ( int i = 0; i < 3; i++ ) {
-      com_p[i] += vel_p[i] * dt;
-      com_s[i] += vel_s[i] * dt;
+      com_P[i] += vel_P[i] * dt;
+      com_S[i] += vel_S[i] * dt;
     }
 
     // Now send this first estimate of the COM to Fortran, and then re-calculate
     // a more accurate result using it as a starting point.
 
-    set_star_data(com_p, com_s, vel_p, vel_s, &mass_p, &mass_s, &t_ff_p, &t_ff_s);
+    set_f90_com_P(com_P);
+    set_f90_com_S(com_S);
+    set_f90_vel_P(vel_P);
+    set_f90_vel_S(vel_S);
+    get_f90_mass_P(&mass_P);
+    get_f90_mass_S(&mass_S);
+    get_f90_t_ff_P(&t_ff_P);
+    get_f90_t_ff_S(&t_ff_S);
 
     // Save relevant current data.
 
-    Real old_mass_p = mass_p;
-    Real old_mass_s = mass_s;
+    Real old_mass_P = mass_P;
+    Real old_mass_S = mass_S;
 
     ReduceOps<ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum,
               ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum,
@@ -254,28 +268,28 @@ Castro::wd_update (Real time, Real dt)
 
               }
 
-              Real com_p_x = dmSymmetric * rSymmetric[0] * primary_factor;
-              Real com_p_y = dmSymmetric * rSymmetric[1] * primary_factor;
-              Real com_p_z = dmSymmetric * rSymmetric[2] * primary_factor;
+              Real com_P_x = dmSymmetric * rSymmetric[0] * primary_factor;
+              Real com_P_y = dmSymmetric * rSymmetric[1] * primary_factor;
+              Real com_P_z = dmSymmetric * rSymmetric[2] * primary_factor;
 
-              Real com_s_x = dmSymmetric * rSymmetric[0] * secondary_factor;
-              Real com_s_y = dmSymmetric * rSymmetric[1] * secondary_factor;
-              Real com_s_z = dmSymmetric * rSymmetric[2] * secondary_factor;
+              Real com_S_x = dmSymmetric * rSymmetric[0] * secondary_factor;
+              Real com_S_y = dmSymmetric * rSymmetric[1] * secondary_factor;
+              Real com_S_z = dmSymmetric * rSymmetric[2] * secondary_factor;
 
-              Real vel_p_x = momSymmetric[0] * vol(i,j,k) * primary_factor;
-              Real vel_p_y = momSymmetric[1] * vol(i,j,k) * primary_factor;
-              Real vel_p_z = momSymmetric[2] * vol(i,j,k) * primary_factor;
+              Real vel_P_x = momSymmetric[0] * vol(i,j,k) * primary_factor;
+              Real vel_P_y = momSymmetric[1] * vol(i,j,k) * primary_factor;
+              Real vel_P_z = momSymmetric[2] * vol(i,j,k) * primary_factor;
 
-              Real vel_s_x = momSymmetric[0] * vol(i,j,k) * secondary_factor;
-              Real vel_s_y = momSymmetric[1] * vol(i,j,k) * secondary_factor;
-              Real vel_s_z = momSymmetric[2] * vol(i,j,k) * secondary_factor;
+              Real vel_S_x = momSymmetric[0] * vol(i,j,k) * secondary_factor;
+              Real vel_S_y = momSymmetric[1] * vol(i,j,k) * secondary_factor;
+              Real vel_S_z = momSymmetric[2] * vol(i,j,k) * secondary_factor;
 
-              Real m_p = dmSymmetric * primary_factor;
-              Real m_s = dmSymmetric * secondary_factor;
+              Real m_P = dmSymmetric * primary_factor;
+              Real m_S = dmSymmetric * secondary_factor;
 
-              return {com_p_x, com_p_y, com_p_z, com_s_x, com_s_y, com_s_z,
-                      vel_p_x, vel_p_y, vel_p_z, vel_s_x, vel_s_y, vel_s_z,
-                      m_p, m_s};
+              return {com_P_x, com_P_y, com_P_z, com_S_x, com_S_y, com_S_z,
+                      vel_P_x, vel_P_y, vel_P_z, vel_S_x, vel_S_y, vel_S_z,
+                      m_P, m_S};
           });
 
       }
@@ -289,68 +303,68 @@ Castro::wd_update (Real time, Real dt)
     bool local_flag = true;
 
     for (int i = 0; i <= 6; ++i)
-        Castro::volInBoundary(time, vol_p[i], vol_s[i], pow(10.0,i), local_flag);
+        Castro::volInBoundary(time, vol_P[i], vol_S[i], pow(10.0,i), local_flag);
 
     // Do all of the reductions.
 
     ReduceTuple hv = reduce_data.value();
 
-    com_p[0] = amrex::get<0>(hv);
-    com_p[1] = amrex::get<1>(hv);
-    com_p[2] = amrex::get<2>(hv);
-    com_s[0] = amrex::get<3>(hv);
-    com_s[1] = amrex::get<4>(hv);
-    com_s[2] = amrex::get<5>(hv);
-    vel_p[0] = amrex::get<6>(hv);
-    vel_p[1] = amrex::get<7>(hv);
-    vel_p[2] = amrex::get<8>(hv);
-    vel_s[0] = amrex::get<9>(hv);
-    vel_s[1] = amrex::get<10>(hv);
-    vel_s[2] = amrex::get<11>(hv);
-    mass_p   = amrex::get<12>(hv);
-    mass_s   = amrex::get<13>(hv);
+    com_P[0] = amrex::get<0>(hv);
+    com_P[1] = amrex::get<1>(hv);
+    com_P[2] = amrex::get<2>(hv);
+    com_S[0] = amrex::get<3>(hv);
+    com_S[1] = amrex::get<4>(hv);
+    com_S[2] = amrex::get<5>(hv);
+    vel_P[0] = amrex::get<6>(hv);
+    vel_P[1] = amrex::get<7>(hv);
+    vel_P[2] = amrex::get<8>(hv);
+    vel_S[0] = amrex::get<9>(hv);
+    vel_S[1] = amrex::get<10>(hv);
+    vel_S[2] = amrex::get<11>(hv);
+    mass_P   = amrex::get<12>(hv);
+    mass_S   = amrex::get<13>(hv);
 
     const int nfoo_sum = 28;
     Real foo_sum[nfoo_sum] = { 0.0 };
 
     for (int i = 0; i <= 6; ++i) {
-      foo_sum[i  ] = vol_p[i];
-      foo_sum[i+7] = vol_s[i];
+      foo_sum[i  ] = vol_P[i];
+      foo_sum[i+7] = vol_S[i];
     }
 
-    foo_sum[14] = mass_p;
-    foo_sum[15] = mass_s;
+    foo_sum[14] = mass_P;
+    foo_sum[15] = mass_S;
 
     for (int i = 0; i <= 2; ++i) {
-      foo_sum[i+16] = com_p[i];
-      foo_sum[i+19] = com_s[i];
-      foo_sum[i+22] = vel_p[i];
-      foo_sum[i+25] = vel_s[i];
+      foo_sum[i+16] = com_P[i];
+      foo_sum[i+19] = com_S[i];
+      foo_sum[i+22] = vel_P[i];
+      foo_sum[i+25] = vel_S[i];
     }
 
     amrex::ParallelDescriptor::ReduceRealSum(foo_sum, nfoo_sum);
 
     for (int i = 0; i <= 6; ++i) {
-      vol_p[i] = foo_sum[i  ];
-      vol_s[i] = foo_sum[i+7];
+      vol_P[i] = foo_sum[i  ];
+      vol_S[i] = foo_sum[i+7];
     }
 
-    mass_p = foo_sum[14];
-    mass_s = foo_sum[15];
+    mass_P = foo_sum[14];
+    mass_S = foo_sum[15];
 
     for (int i = 0; i <= 2; ++i) {
-      com_p[i] = foo_sum[i+16];
-      com_s[i] = foo_sum[i+19];
-      vel_p[i] = foo_sum[i+22];
-      vel_s[i] = foo_sum[i+25];
+      com_P[i] = foo_sum[i+16];
+      com_S[i] = foo_sum[i+19];
+      vel_P[i] = foo_sum[i+22];
+      vel_S[i] = foo_sum[i+25];
     }
 
     // Compute effective WD radii
 
     for (int i = 0; i <= 6; ++i) {
 
-        rad_p[i] = std::pow(vol_p[i] * 3.0 / 4.0 / M_PI, 1.0/3.0);
-        rad_s[i] = std::pow(vol_s[i] * 3.0 / 4.0 / M_PI, 1.0/3.0);
+        rad_P[i] = std::pow(vol_P[i] * 3.0 / 4.0 / M_PI, 1.0/3.0);
+        rad_S[i] = std::pow(vol_S[i] * 3.0 / 4.0 / M_PI, 1.0/3.0);
 
     }
 
@@ -358,14 +372,14 @@ Castro::wd_update (Real time, Real dt)
 
     for ( int i = 0; i < 3; i++ ) {
 
-      if ( mass_p > 0.0 ) {
-        com_p[i] = com_p[i] / mass_p;
-        vel_p[i] = vel_p[i] / mass_p;
+      if ( mass_P > 0.0 ) {
+        com_P[i] = com_P[i] / mass_P;
+        vel_P[i] = vel_P[i] / mass_P;
       }
 
-      if ( mass_s > 0.0 ) {
-        com_s[i] = com_s[i] / mass_s;
-        vel_s[i] = vel_s[i] / mass_s;
+      if ( mass_S > 0.0 ) {
+        com_S[i] = com_S[i] / mass_S;
+        vel_S[i] = vel_S[i] / mass_S;
       }
 
     }
@@ -373,35 +387,35 @@ Castro::wd_update (Real time, Real dt)
     // For 1D we force the masses to remain constant
 
 #if (BL_SPACEDIM == 1)
-    mass_p = old_mass_p;
-    mass_s = old_mass_s;
+    mass_P = old_mass_P;
+    mass_S = old_mass_S;
 #endif
 
-    if (mass_p > 0.0 && dt > 0.0)
-      mdot_p = (mass_p - old_mass_p) / dt;
+    if (mass_P > 0.0 && dt > 0.0)
+      mdot_P = (mass_P - old_mass_P) / dt;
     else
-      mdot_p = 0.0;
+      mdot_P = 0.0;
 
-    if (mass_s > 0.0 && dt > 0.0)
-      mdot_s = (mass_s - old_mass_s) / dt;
+    if (mass_S > 0.0 && dt > 0.0)
+      mdot_S = (mass_S - old_mass_S) / dt;
     else
-      mdot_s = 0.0;
+      mdot_S = 0.0;
 
     // Free-fall timescale ~ 1 / sqrt(G * rho_avg}
 
-    if (mass_p > 0.0 && vol_p[2] > 0.0) {
-      rho_avg_p = mass_p / vol_p[2];
-      t_ff_p = sqrt(3.0 * M_PI / (32.0 * C::Gconst * rho_avg_p));
+    if (mass_P > 0.0 && vol_P[2] > 0.0) {
+      rho_avg_P = mass_P / vol_P[2];
+      t_ff_P = sqrt(3.0 * M_PI / (32.0 * C::Gconst * rho_avg_P));
     }
 
-    if (mass_s > 0.0 && vol_s[2] > 0.0) {
-      rho_avg_s = mass_s / vol_s[2];
-      t_ff_s = sqrt(3.0 * M_PI / (32.0 * C::Gconst * rho_avg_s));
+    if (mass_S > 0.0 && vol_S[2] > 0.0) {
+      rho_avg_S = mass_S / vol_S[2];
+      t_ff_S = sqrt(3.0 * M_PI / (32.0 * C::Gconst * rho_avg_S));
     }
 
     // Send this updated information back to the Fortran module
 
-    set_star_data(com_p, com_s, vel_p, vel_s, &mass_p, &mass_s, &t_ff_p, &t_ff_s);
+    set_star_data(com_P, com_S, vel_P, vel_S, &mass_P, &mass_S, &t_ff_P, &t_ff_S);
 
 }
 
@@ -413,7 +427,7 @@ Castro::wd_update (Real time, Real dt)
 // We also impose a distance requirement so that we only look
 // at zones that are within twice the original radius of the white dwarf.
 
-void Castro::volInBoundary (Real time, Real& vol_p, Real& vol_s, Real rho_cutoff, bool local)
+void Castro::volInBoundary (Real time, Real& vol_P, Real& vol_S, Real rho_cutoff, bool local)
 {
     BL_PROFILE("Castro::volInBoundary()");
 
@@ -421,8 +435,8 @@ void Castro::volInBoundary (Real time, Real& vol_p, Real& vol_s, Real rho_cutoff
 
     BL_ASSERT(level == 0);
 
-    vol_p = 0.0;
-    vol_s = 0.0;
+    vol_P = 0.0;
+    vol_S = 0.0;
 
     for (int lev = 0; lev <= parent->finestLevel(); lev++) {
 
@@ -499,13 +513,13 @@ void Castro::volInBoundary (Real time, Real& vol_p, Real& vol_s, Real rho_cutoff
 
       ReduceTuple hv = reduce_data.value();
 
-      vol_p += amrex::get<0>(hv);
-      vol_s += amrex::get<1>(hv);
+      vol_P += amrex::get<0>(hv);
+      vol_S += amrex::get<1>(hv);
 
     }
 
     if (!local)
-      amrex::ParallelDescriptor::ReduceRealSum({vol_p, vol_s});
+      amrex::ParallelDescriptor::ReduceRealSum({vol_P, vol_S});
 
     ca_set_amr_info(level, -1, -1, -1.0, -1.0);
 
@@ -519,9 +533,9 @@ void Castro::volInBoundary (Real time, Real& vol_p, Real& vol_s, Real rho_cutoff
 
 void
 Castro::gwstrain (Real time,
-		  Real& h_plus_1, Real& h_cross_1,
-		  Real& h_plus_2, Real& h_cross_2,
-		  Real& h_plus_3, Real& h_cross_3,
+		  Real& h_Plus_1, Real& h_cross_1,
+		  Real& h_Plus_2, Real& h_cross_2,
+		  Real& h_Plus_3, Real& h_cross_3,
 		  bool local) {
 
     BL_PROFILE("Castro::gwstrain()");
@@ -747,9 +761,9 @@ Castro::gwstrain (Real time,
     // Now that we have the second time derivative of the quadrupole
     // tensor, we can calculate the transverse-trace gauge strain tensor.
 
-    gw_strain_tensor(&h_plus_1, &h_cross_1,
-		     &h_plus_2, &h_cross_2,
-		     &h_plus_3, &h_cross_3,
+    gw_strain_tensor(&h_Plus_1, &h_cross_1,
+		     &h_Plus_2, &h_cross_2,
+		     &h_Plus_3, &h_cross_3,
 		     Qtt.dataPtr(), &time);
 
 }
@@ -798,24 +812,9 @@ void Castro::problem_post_init() {
   pp.query("ts_te_stopping_criterion", ts_te_stopping_criterion);
   pp.query("T_stopping_criterion", T_stopping_criterion);
 
-  // Get the problem number fom Fortran.
-
-  get_problem_number(&problem);
-
-  // Get the relaxation status.
-
-  get_relaxation_status(&relaxation_is_done);
-
   // Update the rotational period; some problems change this from what's in the inputs parameters.
 
   get_period(&rotational_period);
-
-  // Initialize the energy storage array.
-
-  for (int i = 0; i < num_previous_ener_timesteps; ++i)
-    total_ener_array[i] = -1.e200;
-
-  set_total_ener_array(total_ener_array);
 
   // Execute the post timestep diagnostics here,
   // so that the results at t = 0 and later are smooth.
@@ -841,25 +840,11 @@ void Castro::problem_post_restart() {
   pp.query("ts_te_stopping_criterion", ts_te_stopping_criterion);
   pp.query("T_stopping_criterion", T_stopping_criterion);
 
-  // Get the problem number from Fortran.
-
-  get_problem_number(&problem);
-
-  // Get the relaxation status.
-
-  get_relaxation_status(&relaxation_is_done);
-
   // Get the rotational period.
 
   get_period(&rotational_period);
 
-  // Get the energy data from Fortran.
-
-  get_total_ener_array(total_ener_array);
-
-  // Get the extrema.
-
-  get_extrema(&T_global_max, &rho_global_max, &ts_te_global_max);
+  // Reset current values of extrema.
 
   T_curr_max = T_global_max;
   rho_curr_max = rho_global_max;
@@ -949,7 +934,7 @@ void Castro::check_to_stop(Real time, bool dump) {
             // should be expanded in the future to cover that case.
 
             Real rho_E = 0.0;
-            Real rho_phi = 0.0;
+            Real rho_Phi = 0.0;
 
             // Note that we'll define the total energy using only
             // gas energy + gravitational. Rotation is never on
@@ -966,11 +951,11 @@ void Castro::check_to_stop(Real time, bool dump) {
 
 #ifdef GRAVITY
             if (do_grav) {
-                rho_phi += volWgtSum("rho_phiGrav", curTime,  local_flag, fine_mask);
+                rho_Phi += volWgtSum("rho_PhiGrav", curTime,  local_flag, fine_mask);
             }
 #endif
 
-            E_tot = rho_E + 0.5 * rho_phi;
+            E_tot = rho_E + 0.5 * rho_Phi;
 
             amrex::ParallelDescriptor::ReduceRealSum(E_tot);
 
@@ -1152,7 +1137,7 @@ Castro::update_relaxation(Real time, Real dt) {
     // Check to make sure whether we should be doing the relaxation here.
     // Update the relaxation conditions if we are not stopping.
 
-    if (problem != 1 || relaxation_is_done || mass_p <= 0.0 || mass_s <= 0.0 || dt <= 0.0) return;
+    if (problem != 1 || relaxation_is_done || mass_P <= 0.0 || mass_S <= 0.0 || dt <= 0.0) return;
 
     // Construct the update to the rotation frequency. We calculate
     // the gravitational force at the end of the timestep, set the
@@ -1204,8 +1189,8 @@ Castro::update_relaxation(Real time, Real dt) {
 
     // Construct omega from this.
 
-    Real force_p[3] = { 0.0 };
-    Real force_s[3] = { 0.0 };
+    Real force_P[3] = { 0.0 };
+    Real force_S[3] = { 0.0 };
 
     for (int lev = coarse_level; lev <= finest_level; ++lev) {
 
@@ -1308,29 +1293,29 @@ Castro::update_relaxation(Real time, Real dt) {
 
         ReduceTuple hv = reduce_data.value();
 
-        force_p[0] += amrex::get<0>(hv);
-        force_p[1] += amrex::get<1>(hv);
-        force_p[2] += amrex::get<2>(hv);
+        force_P[0] += amrex::get<0>(hv);
+        force_P[1] += amrex::get<1>(hv);
+        force_P[2] += amrex::get<2>(hv);
 
-        force_s[0] += amrex::get<3>(hv);
-        force_s[1] += amrex::get<4>(hv);
-        force_s[2] += amrex::get<5>(hv);
+        force_S[0] += amrex::get<3>(hv);
+        force_S[1] += amrex::get<4>(hv);
+        force_S[2] += amrex::get<5>(hv);
 
     }
 
     // Do the reduction over processors.
 
-    amrex::ParallelDescriptor::ReduceRealSum({force_p[0], force_p[1], force_p[2], force_s[0], force_s[1], force_s[2]});
+    amrex::ParallelDescriptor::ReduceRealSum({force_P[0], force_P[1], force_P[2], force_S[0], force_S[1], force_S[2]});
 
     // Divide by the mass of the stars to obtain the acceleration, and then get the new rotation frequency.
 
-    Real fp = std::sqrt(std::pow(force_p[0], 2) + std::pow(force_p[1], 2) + std::pow(force_p[2], 2));
-    Real fs = std::sqrt(std::pow(force_s[0], 2) + std::pow(force_s[1], 2) + std::pow(force_s[2], 2));
+    Real fp = std::sqrt(std::pow(force_P[0], 2) + std::pow(force_P[1], 2) + std::pow(force_P[2], 2));
+    Real fs = std::sqrt(std::pow(force_S[0], 2) + std::pow(force_S[1], 2) + std::pow(force_S[2], 2));
 
-    Real ap = std::sqrt(std::pow(com_p[0], 2) + std::pow(com_p[1], 2) + std::pow(com_p[2], 2));
-    Real as = std::sqrt(std::pow(com_s[0], 2) + std::pow(com_s[1], 2) + std::pow(com_s[2], 2));
+    Real ap = std::sqrt(std::pow(com_P[0], 2) + std::pow(com_P[1], 2) + std::pow(com_P[2], 2));
+    Real as = std::sqrt(std::pow(com_S[0], 2) + std::pow(com_S[1], 2) + std::pow(com_S[2], 2));
 
-    Real omega = 0.5 * ( std::sqrt((fp / mass_p) / ap) + std::sqrt((fs / mass_s) / as) );
+    Real omega = 0.5 * ( std::sqrt((fp / mass_P) / ap) + std::sqrt((fs / mass_S) / as) );
 
     Real period = 2.0 * M_PI / omega;
 
@@ -1354,7 +1339,7 @@ Castro::update_relaxation(Real time, Real dt) {
     // First, calculate the location of the L1 Lagrange point.
 
     GpuArray<Real, 3> L1, L2, L3;
-    get_lagrange_points(mass_p, mass_s, com_p, com_s, L1, L2, L3);
+    get_lagrange_points(mass_P, mass_S, com_P, com_S, L1, L2, L3);
 
     const auto dx = geom.CellSizeArray();
     GeometryData geomdata = geom.data();
@@ -1487,7 +1472,7 @@ Castro::update_relaxation(Real time, Real dt) {
     Real relaxation_cutoff_time;
     get_relaxation_cutoff_time(&relaxation_cutoff_time);
 
-    if (relaxation_cutoff_time > 0.0 && time > relaxation_cutoff_time * std::max(t_ff_p, t_ff_s)) {
+    if (relaxation_cutoff_time > 0.0 && time > relaxation_cutoff_time * std::max(t_ff_P, t_ff_S)) {
         relaxation_is_done = 1;
         amrex::Print() << "Disabling relaxation at time " << time
                        << "s because the maximum number of dynamical timescales has passed."

--- a/Exec/science/wdmerger/Prob.cpp
+++ b/Exec/science/wdmerger/Prob.cpp
@@ -99,10 +99,10 @@ Castro::wd_update (Real time, Real dt)
     set_f90_com_S(com_S);
     set_f90_vel_P(vel_P);
     set_f90_vel_S(vel_S);
-    get_f90_mass_P(&mass_P);
-    get_f90_mass_S(&mass_S);
-    get_f90_t_ff_P(&t_ff_P);
-    get_f90_t_ff_S(&t_ff_S);
+    set_f90_mass_P(&mass_P);
+    set_f90_mass_S(&mass_S);
+    set_f90_t_ff_P(&t_ff_P);
+    set_f90_t_ff_S(&t_ff_S);
 
     // Save relevant current data.
 

--- a/Exec/science/wdmerger/Problem_Derive.cpp
+++ b/Exec/science/wdmerger/Problem_Derive.cpp
@@ -457,7 +457,7 @@ void ca_derphieffpm_p(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/
         // Don't do anything here if the star no longer exists,
         // or if it never existed.
 
-        if (wdmerger::mass_p <= 0.0_rt) return;
+        if (mass_P <= 0.0_rt) return;
 
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0];
@@ -474,11 +474,11 @@ void ca_derphieffpm_p(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/
         loc[2] = 0.0_rt;
 #endif
 
-        Real r = std::sqrt((loc[0] - wdmerger::com_p[0]) * (loc[0] - wdmerger::com_p[0]) +
-                           (loc[1] - wdmerger::com_p[1]) * (loc[1] - wdmerger::com_p[1]) +
-                           (loc[2] - wdmerger::com_p[2]) * (loc[2] - wdmerger::com_p[2]));
+        Real r = std::sqrt((loc[0] - com_P[0]) * (loc[0] - com_P[0]) +
+                           (loc[1] - com_P[1]) * (loc[1] - com_P[1]) +
+                           (loc[2] - com_P[2]) * (loc[2] - com_P[2]));
 
-        der(i,j,k,0) = -C::Gconst * wdmerger::mass_p / r + dat(i,j,k,0);
+        der(i,j,k,0) = -C::Gconst * mass_P / r + dat(i,j,k,0);
     });
 }
 
@@ -502,7 +502,7 @@ void ca_derphieffpm_s(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/
         // Don't do anything here if the star no longer exists,
         // or if it never existed.
 
-        if (wdmerger::mass_s <= 0.0_rt) return;
+        if (mass_S <= 0.0_rt) return;
 
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0];
@@ -519,11 +519,11 @@ void ca_derphieffpm_s(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/
         loc[2] = 0.0_rt;
 #endif
 
-        Real r = std::sqrt((loc[0] - wdmerger::com_s[0]) * (loc[0] - wdmerger::com_s[0]) +
-                           (loc[1] - wdmerger::com_s[1]) * (loc[1] - wdmerger::com_s[1]) +
-                           (loc[2] - wdmerger::com_s[2]) * (loc[2] - wdmerger::com_s[2]));
+        Real r = std::sqrt((loc[0] - com_S[0]) * (loc[0] - com_S[0]) +
+                           (loc[1] - com_S[1]) * (loc[1] - com_S[1]) +
+                           (loc[2] - com_S[2]) * (loc[2] - com_S[2]));
 
-        der(i,j,k,0) = -C::Gconst * wdmerger::mass_s / r + dat(i,j,k,0);
+        der(i,j,k,0) = -C::Gconst * mass_S / r + dat(i,j,k,0);
     });
 }
 
@@ -582,7 +582,7 @@ void ca_derprimarymask(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*
         // Don't do anything here if the star no longer exists,
         // or if it never existed.
 
-        if (wdmerger::mass_p <= 0.0_rt) return;
+        if (mass_P <= 0.0_rt) return;
 
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0];
@@ -603,16 +603,16 @@ void ca_derprimarymask(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*
 
         if (dat(i,j,k,0) < stellar_density_threshold) return;
 
-        Real r_P = std::sqrt((loc[0] - wdmerger::com_p[0]) * (loc[0] - wdmerger::com_p[0]) +
-                             (loc[1] - wdmerger::com_p[1]) * (loc[1] - wdmerger::com_p[1]) +
-                             (loc[2] - wdmerger::com_p[2]) * (loc[2] - wdmerger::com_p[2]));
+        Real r_P = std::sqrt((loc[0] - com_P[0]) * (loc[0] - com_P[0]) +
+                             (loc[1] - com_P[1]) * (loc[1] - com_P[1]) +
+                             (loc[2] - com_P[2]) * (loc[2] - com_P[2]));
 
-        Real r_S = std::sqrt((loc[0] - wdmerger::com_s[0]) * (loc[0] - wdmerger::com_s[0]) +
-                             (loc[1] - wdmerger::com_s[1]) * (loc[1] - wdmerger::com_s[1]) +
-                             (loc[2] - wdmerger::com_s[2]) * (loc[2] - wdmerger::com_s[2]));
+        Real r_S = std::sqrt((loc[0] - com_S[0]) * (loc[0] - com_S[0]) +
+                             (loc[1] - com_S[1]) * (loc[1] - com_S[1]) +
+                             (loc[2] - com_S[2]) * (loc[2] - com_S[2]));
 
-        Real phi_p = -C::Gconst * wdmerger::mass_p / r_P + dat(i,j,k,1);
-        Real phi_s = -C::Gconst * wdmerger::mass_s / r_S + dat(i,j,k,1);
+        Real phi_p = -C::Gconst * mass_P / r_P + dat(i,j,k,1);
+        Real phi_s = -C::Gconst * mass_S / r_S + dat(i,j,k,1);
 
         if (phi_p < 0.0_rt && phi_p < phi_s) {
             der(i,j,k,0) = 1.0_rt;
@@ -642,7 +642,7 @@ void ca_dersecondarymask(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncom
         // Don't do anything here if the star no longer exists,
         // or if it never existed.
 
-        if (wdmerger::mass_s <= 0.0_rt) return;
+        if (mass_S <= 0.0_rt) return;
 
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0];
@@ -663,16 +663,16 @@ void ca_dersecondarymask(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncom
 
         if (dat(i,j,k,0) < stellar_density_threshold) return;
 
-        Real r_P = std::sqrt((loc[0] - wdmerger::com_p[0]) * (loc[0] - wdmerger::com_p[0]) +
-                             (loc[1] - wdmerger::com_p[1]) * (loc[1] - wdmerger::com_p[1]) +
-                             (loc[2] - wdmerger::com_p[2]) * (loc[2] - wdmerger::com_p[2]));
+        Real r_P = std::sqrt((loc[0] - com_P[0]) * (loc[0] - com_P[0]) +
+                             (loc[1] - com_P[1]) * (loc[1] - com_P[1]) +
+                             (loc[2] - com_P[2]) * (loc[2] - com_P[2]));
 
-        Real r_S = std::sqrt((loc[0] - wdmerger::com_s[0]) * (loc[0] - wdmerger::com_s[0]) +
-                             (loc[1] - wdmerger::com_s[1]) * (loc[1] - wdmerger::com_s[1]) +
-                             (loc[2] - wdmerger::com_s[2]) * (loc[2] - wdmerger::com_s[2]));
+        Real r_S = std::sqrt((loc[0] - com_S[0]) * (loc[0] - com_S[0]) +
+                             (loc[1] - com_S[1]) * (loc[1] - com_S[1]) +
+                             (loc[2] - com_S[2]) * (loc[2] - com_S[2]));
 
-        Real phi_p = -C::Gconst * wdmerger::mass_p / r_P + dat(i,j,k,1);
-        Real phi_s = -C::Gconst * wdmerger::mass_s / r_S + dat(i,j,k,1);
+        Real phi_p = -C::Gconst * mass_P / r_P + dat(i,j,k,1);
+        Real phi_s = -C::Gconst * mass_S / r_S + dat(i,j,k,1);
 
         if (phi_s < 0.0_rt && phi_s < phi_p) {
             der(i,j,k,0) = 1.0_rt;

--- a/Exec/science/wdmerger/sum_integrated_quantities.cpp
+++ b/Exec/science/wdmerger/sum_integrated_quantities.cpp
@@ -65,7 +65,7 @@ Castro::sum_integrated_quantities ()
 
     // Mass transfer rate
 
-    Real mdot = 0.5 * (std::abs(mdot_p) + std::abs(mdot_s));
+    Real mdot = 0.5 * (std::abs(mdot_P) + std::abs(mdot_S));
 
     // Center of mass of the system.
 
@@ -82,17 +82,17 @@ Castro::sum_integrated_quantities ()
 
     // Stellar centers of mass and velocities.
 
-    Real com_p_mag = 0.0;
-    Real com_s_mag = 0.0;
+    Real com_P_mag = 0.0;
+    Real com_S_mag = 0.0;
 
-    Real vel_p_mag = 0.0;
-    Real vel_s_mag = 0.0;
+    Real vel_P_mag = 0.0;
+    Real vel_S_mag = 0.0;
 
-    Real vel_p_rad = 0.0;
-    Real vel_s_rad = 0.0;
+    Real vel_P_rad = 0.0;
+    Real vel_S_rad = 0.0;
 
-    Real vel_p_phi = 0.0;
-    Real vel_s_phi = 0.0;
+    Real vel_P_phi = 0.0;
+    Real vel_S_phi = 0.0;
 
     // Gravitational wave amplitudes.
     
@@ -281,39 +281,39 @@ Castro::sum_integrated_quantities ()
 
     }
 
-    com_p_mag += std::pow( std::pow(com_p[0],2) + std::pow(com_p[1],2) + std::pow(com_p[2],2), 0.5 );
-    com_s_mag += std::pow( std::pow(com_s[0],2) + std::pow(com_s[1],2) + std::pow(com_s[2],2), 0.5 );
-    vel_p_mag += std::pow( std::pow(vel_p[0],2) + std::pow(vel_p[1],2) + std::pow(vel_p[2],2), 0.5 );
-    vel_s_mag += std::pow( std::pow(vel_s[0],2) + std::pow(vel_s[1],2) + std::pow(vel_s[2],2), 0.5 );
+    com_P_mag += std::pow( std::pow(com_P[0],2) + std::pow(com_P[1],2) + std::pow(com_P[2],2), 0.5 );
+    com_S_mag += std::pow( std::pow(com_S[0],2) + std::pow(com_S[1],2) + std::pow(com_S[2],2), 0.5 );
+    vel_P_mag += std::pow( std::pow(vel_P[0],2) + std::pow(vel_P[1],2) + std::pow(vel_P[2],2), 0.5 );
+    vel_S_mag += std::pow( std::pow(vel_S[0],2) + std::pow(vel_S[1],2) + std::pow(vel_S[2],2), 0.5 );
 
 #if (BL_SPACEDIM == 3)
-    if (mass_p > 0.0) {
-      vel_p_rad = (com_p[axis_1 - 1] / com_p_mag) * vel_p[axis_1 - 1] + (com_p[axis_2 - 1] / com_p_mag) * vel_p[axis_2 - 1];
-      vel_p_phi = (com_p[axis_1 - 1] / com_p_mag) * vel_p[axis_2 - 1] - (com_p[axis_2 - 1] / com_p_mag) * vel_p[axis_1 - 1];
+    if (mass_P > 0.0) {
+      vel_P_rad = (com_P[axis_1 - 1] / com_P_mag) * vel_P[axis_1 - 1] + (com_P[axis_2 - 1] / com_P_mag) * vel_P[axis_2 - 1];
+      vel_P_phi = (com_P[axis_1 - 1] / com_P_mag) * vel_P[axis_2 - 1] - (com_P[axis_2 - 1] / com_P_mag) * vel_P[axis_1 - 1];
     }
 
-    if (mass_s > 0.0) {
-      vel_s_rad = (com_s[axis_1 - 1] / com_s_mag) * vel_s[axis_1 - 1] + (com_s[axis_2 - 1] / com_s_mag) * vel_s[axis_2 - 1];
-      vel_s_phi = (com_s[axis_1 - 1] / com_s_mag) * vel_s[axis_2 - 1] - (com_s[axis_2 - 1] / com_s_mag) * vel_s[axis_1 - 1];
+    if (mass_S > 0.0) {
+      vel_S_rad = (com_S[axis_1 - 1] / com_S_mag) * vel_S[axis_1 - 1] + (com_S[axis_2 - 1] / com_S_mag) * vel_S[axis_2 - 1];
+      vel_S_phi = (com_S[axis_1 - 1] / com_S_mag) * vel_S[axis_2 - 1] - (com_S[axis_2 - 1] / com_S_mag) * vel_S[axis_1 - 1];
     }
 #else
-    if (mass_p > 0.0) {
-      vel_p_rad = vel_p[axis_1 - 1];
-      vel_p_phi = vel_p[axis_3 - 1];
+    if (mass_P > 0.0) {
+      vel_P_rad = vel_P[axis_1 - 1];
+      vel_P_phi = vel_P[axis_3 - 1];
     }
 
-    if (mass_s > 0.0) {
-      vel_s_rad = vel_s[axis_1 - 1];
-      vel_s_phi = vel_s[axis_3 - 1];
+    if (mass_S > 0.0) {
+      vel_S_rad = vel_S[axis_1 - 1];
+      vel_S_phi = vel_S[axis_3 - 1];
     }
 #endif
 
-    if (mass_p > 0.0 && mass_s > 0.0) {
+    if (mass_P > 0.0 && mass_S > 0.0) {
 
       // Calculate the distance between the primary and secondary.
 
       for ( int i = 0; i < 3; i++ )
-	wd_dist[i] = com_s[i] - com_p[i];
+	wd_dist[i] = com_S[i] - com_P[i];
 
       separation = norm(wd_dist);
 
@@ -721,25 +721,25 @@ Castro::sum_integrated_quantities ()
 
 	   log << std::scientific;
 
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << mass_p;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << mdot_p;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_p_mag;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_p[0];
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_p[1];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << mass_P;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << mdot_P;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_P_mag;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_P[0];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_P[1];
 #if (BL_SPACEDIM == 3)
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_p[2];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_P[2];
 #endif
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_p_mag;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_p_rad;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_p_phi;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_p[0];
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_p[1];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_P_mag;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_P_rad;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_P_phi;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_P[0];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_P[1];
 #if (BL_SPACEDIM == 3)
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_p[2];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_P[2];
 #endif
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << t_ff_p;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << t_ff_P;
 	   for (int i = 0; i <= 6; ++i)
-	       log << std::setw(datwidth) << std::setprecision(dataprecision) << rad_p[i];
+	       log << std::setw(datwidth) << std::setprecision(dataprecision) << rad_P[i];
 
 	   log << std::endl;
 
@@ -815,25 +815,25 @@ Castro::sum_integrated_quantities ()
 
 	   log << std::scientific;
 
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << mass_s;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << mdot_s;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_s_mag;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_s[0];
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_s[1];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << mass_S;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << mdot_S;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_S_mag;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_S[0];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_S[1];
 #if (BL_SPACEDIM == 3)
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_s[2];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << com_S[2];
 #endif
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_s_mag;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_s_rad;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_s_phi;
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_s[0];
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_s[1];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_S_mag;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_S_rad;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_S_phi;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_S[0];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_S[1];
 #if (BL_SPACEDIM == 3)
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_s[2];
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << vel_S[2];
 #endif
-	   log << std::setw(datwidth) << std::setprecision(dataprecision) << t_ff_s;
+	   log << std::setw(datwidth) << std::setprecision(dataprecision) << t_ff_S;
 	   for (int i = 0; i <= 6; ++i)
-	       log << std::setw(datwidth) << std::setprecision(dataprecision) << rad_s[i];
+	       log << std::setw(datwidth) << std::setprecision(dataprecision) << rad_S[i];
 
 	   log << std::endl;
 

--- a/Exec/science/wdmerger/wdmerger_data.H
+++ b/Exec/science/wdmerger/wdmerger_data.H
@@ -4,6 +4,9 @@
 #include <AMReX.H>
 #include <AMReX_REAL.H>
 
+#include <prob_parameters.H>
+#include <prob_parameters_F.H>
+
 namespace wdmerger
 {
     // Input parameters
@@ -15,63 +18,31 @@ namespace wdmerger
 
     // Data we want to store, for interfacing with the Fortran
 
-    extern AMREX_GPU_MANAGED int relaxation_is_done;
-    extern AMREX_GPU_MANAGED int problem;
-
-    // Stellar masses
-
-    extern AMREX_GPU_MANAGED amrex::Real mass_p;
-    extern AMREX_GPU_MANAGED amrex::Real mass_s;
-
     // Rate of change of stellar masses
 
-    extern AMREX_GPU_MANAGED amrex::Real mdot_p;
-    extern AMREX_GPU_MANAGED amrex::Real mdot_s;
-
-    // Stellar centers of mass and velocities
-
-    extern AMREX_GPU_MANAGED amrex::Real com_p[3];
-    extern AMREX_GPU_MANAGED amrex::Real com_s[3];
-
-    extern AMREX_GPU_MANAGED amrex::Real vel_p[3];
-    extern AMREX_GPU_MANAGED amrex::Real vel_s[3];
+    extern AMREX_GPU_MANAGED amrex::Real mdot_P;
+    extern AMREX_GPU_MANAGED amrex::Real mdot_S;
 
     // Radii of the WDs at various density thresholds.
 
-    extern AMREX_GPU_MANAGED amrex::Real rad_p[7];
-    extern AMREX_GPU_MANAGED amrex::Real rad_s[7];
+    extern AMREX_GPU_MANAGED amrex::Real rad_P[7];
+    extern AMREX_GPU_MANAGED amrex::Real rad_S[7];
 
     // Effective volume of the stars at various density cutoffs.
 
-    extern AMREX_GPU_MANAGED amrex::Real vol_p[7];
-    extern AMREX_GPU_MANAGED amrex::Real vol_s[7];
+    extern AMREX_GPU_MANAGED amrex::Real vol_P[7];
+    extern AMREX_GPU_MANAGED amrex::Real vol_S[7];
 
     // Average density of the stars.
 
-    extern AMREX_GPU_MANAGED amrex::Real rho_avg_p;
-    extern AMREX_GPU_MANAGED amrex::Real rho_avg_s;
-
-    // Gravitational free-fall timescale of the stars.
-
-    extern AMREX_GPU_MANAGED amrex::Real t_ff_p;
-    extern AMREX_GPU_MANAGED amrex::Real t_ff_s;
-
-    // Global extrema of various quantities over the whole simulation
-
-    extern AMREX_GPU_MANAGED amrex::Real T_global_max;
-    extern AMREX_GPU_MANAGED amrex::Real rho_global_max;
-    extern AMREX_GPU_MANAGED amrex::Real ts_te_global_max;
+    extern AMREX_GPU_MANAGED amrex::Real rho_avg_P;
+    extern AMREX_GPU_MANAGED amrex::Real rho_avg_S;
 
     // Current values of the above extrema
 
     extern AMREX_GPU_MANAGED amrex::Real T_curr_max;
     extern AMREX_GPU_MANAGED amrex::Real rho_curr_max;
     extern AMREX_GPU_MANAGED amrex::Real ts_te_curr_max;
-
-    // Value of the total energy on the domain over the last several timesteps
-
-    const int num_previous_ener_timesteps = 5;
-    extern AMREX_GPU_MANAGED amrex::Real total_ener_array[num_previous_ener_timesteps];
 }
 
 #endif

--- a/Exec/science/wdmerger/wdmerger_data.cpp
+++ b/Exec/science/wdmerger/wdmerger_data.cpp
@@ -2,43 +2,23 @@
 
 using namespace amrex;
 
-AMREX_GPU_MANAGED int wdmerger::relaxation_is_done = 0;
-AMREX_GPU_MANAGED int wdmerger::problem = -1;
 AMREX_GPU_MANAGED int wdmerger::use_stopping_criterion = 1;
 AMREX_GPU_MANAGED int wdmerger::use_energy_stopping_criterion = 0;
 AMREX_GPU_MANAGED Real wdmerger::ts_te_stopping_criterion = 1.e200;
 AMREX_GPU_MANAGED Real wdmerger::T_stopping_criterion = 1.e200;
 
-AMREX_GPU_MANAGED Real wdmerger::mass_p = 0.0;
-AMREX_GPU_MANAGED Real wdmerger::mass_s = 0.0;
+AMREX_GPU_MANAGED Real wdmerger::mdot_P = 0.0;
+AMREX_GPU_MANAGED Real wdmerger::mdot_S = 0.0;
 
-AMREX_GPU_MANAGED Real wdmerger::mdot_p = 0.0;
-AMREX_GPU_MANAGED Real wdmerger::mdot_s = 0.0;
+AMREX_GPU_MANAGED Real wdmerger::rad_P[7] = { 0.0 };
+AMREX_GPU_MANAGED Real wdmerger::rad_S[7] = { 0.0 };
 
-AMREX_GPU_MANAGED Real wdmerger::com_p[3] = { 0.0 };
-AMREX_GPU_MANAGED Real wdmerger::com_s[3] = { 0.0 };
+AMREX_GPU_MANAGED Real wdmerger::vol_P[7] = { 0.0 };
+AMREX_GPU_MANAGED Real wdmerger::vol_S[7] = { 0.0 };
 
-AMREX_GPU_MANAGED Real wdmerger::vel_p[3] = { 0.0 };
-AMREX_GPU_MANAGED Real wdmerger::vel_s[3] = { 0.0 };
-
-AMREX_GPU_MANAGED Real wdmerger::rad_p[7] = { 0.0 };
-AMREX_GPU_MANAGED Real wdmerger::rad_s[7] = { 0.0 };
-
-AMREX_GPU_MANAGED Real wdmerger::vol_p[7] = { 0.0 };
-AMREX_GPU_MANAGED Real wdmerger::vol_s[7] = { 0.0 };
-
-AMREX_GPU_MANAGED Real wdmerger::rho_avg_p = 0.0;
-AMREX_GPU_MANAGED Real wdmerger::rho_avg_s = 0.0;
-
-AMREX_GPU_MANAGED Real wdmerger::t_ff_p = 0.0;
-AMREX_GPU_MANAGED Real wdmerger::t_ff_s = 0.0;
-
-AMREX_GPU_MANAGED Real wdmerger::T_global_max = 0.0;
-AMREX_GPU_MANAGED Real wdmerger::rho_global_max = 0.0;
-AMREX_GPU_MANAGED Real wdmerger::ts_te_global_max = 0.0;
+AMREX_GPU_MANAGED Real wdmerger::rho_avg_P = 0.0;
+AMREX_GPU_MANAGED Real wdmerger::rho_avg_S = 0.0;
 
 AMREX_GPU_MANAGED Real wdmerger::T_curr_max = 0.0;
 AMREX_GPU_MANAGED Real wdmerger::rho_curr_max = 0.0;
 AMREX_GPU_MANAGED Real wdmerger::ts_te_curr_max = 0.0;
-
-AMREX_GPU_MANAGED Real wdmerger::total_ener_array[num_previous_ener_timesteps] = { 0.0 };

--- a/Exec/science/xrb_mixed/Prob_nd.F90
+++ b/Exec/science/xrb_mixed/Prob_nd.F90
@@ -18,6 +18,10 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   call probdata_init(name, namlen)
 
+  if (num_vortices > max_num_vortices) then
+     call castro_error("num_vortices too large, please increase max_num_vortices and the size of xloc_vortices")
+  end if
+
   ! Read initial model
   call read_model_file(model_name)
 

--- a/Exec/science/xrb_mixed/_prob_params
+++ b/Exec/science/xrb_mixed/_prob_params
@@ -14,4 +14,6 @@ velpert_height_loc    real           6.5e3_rt      y
 
 num_vortices          integer        1             y
 
-xloc_vortices         real           0.0_rt        n        num_vortices
+max_num_vortices      integer        10            n
+
+xloc_vortices         real           0.0_rt        n        10


### PR DESCRIPTION

## PR summary

Previously you could add parameters to _prob_params that were not in the Fortran namelist. No C++ version was made of these parameters. However, there is a need for even the ones not in the namelist to have a C++ version, since we may set those variables in probinit and want them later in C++. This implements that change, with the exception of parameters whose size depends on a Fortran module parameter (since we have no direct analogue of that in C++). As a demonstration, many of the wdmerger C++ problem parameters (which were manually managed as duplicates of the corresponding Fortran parameters) are converted to this new format.

## PR motivation

This will also be helpful for finishing up #1222 since we will need `center` in C++.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
