### PR TITLE
Call probdata_init() for all problem setups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
      automatically generated, so if you have a legacy probdata.F90 file
      containing a module with that name it should be renamed. (#1210)
 
+   * Initialization of these problem parameters is now done automatically for
+     you, so a call to probdata_init() is no longer required in amrex_probinit(). (#1226)
+
    * The external heat source term routines have been ported to C++
      (#1191).  Any problem using an external heat source should look
      convert the code over to C++.

--- a/Docs/source/creating_a_problem.rst
+++ b/Docs/source/creating_a_problem.rst
@@ -81,15 +81,13 @@ Here we describe the main problem initialization routines.
 
 * ``probinit()``:
 
-  This routine is primarily responsible for reading in the ``probin``
-  file (by defining the ``&fortin`` namelist) and doing any one-time
+  This routine is primarily responsible for doing any one-time
   initialization for the problem (like reading in an
   initial model through the ``model_parser_module``—see the
   ``toy_convect`` problem setup for an example).
 
-  By convention, this is where we read and initialize the problem parameters
-  by calling ``probdata_init()``.  The parameters will then be defined in
-  ``probdata_module`` defined in ``probdata.F90``.
+  This routine can also postprocess any of the parameters defined
+  in the ``_prob_params`` file, which are defined in ``probdata_module``.
 
   .. note:: many problems set the value of the ``center()`` array
      from ``prob_params_module`` here.  This is used to note the

--- a/Exec/gravity_tests/DustCollapse/Prob_nd.F90
+++ b/Exec/gravity_tests/DustCollapse/Prob_nd.F90
@@ -20,8 +20,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   r_old_s = r_old
 
   ! in 3-d we center the sphere at (center_x, center_y, center_z)

--- a/Exec/gravity_tests/StarGrav/Prob_nd.F90
+++ b/Exec/gravity_tests/StarGrav/Prob_nd.F90
@@ -12,8 +12,6 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! read initial model
   call read_model_file(model_name)
 

--- a/Exec/gravity_tests/code_comp/Prob_nd.F90
+++ b/Exec/gravity_tests/code_comp/Prob_nd.F90
@@ -15,9 +15,6 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-
-  call probdata_init(name, namlen)
-
 #if AMREX_SPACEDIM == 1
   center(1) = ZERO
 

--- a/Exec/gravity_tests/evrard_collapse/Prob_nd.F90
+++ b/Exec/gravity_tests/evrard_collapse/Prob_nd.F90
@@ -15,8 +15,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   ! Given the inputs of small_dens and small_temp, figure out small_pres.
 
   if (small_dens > 0.0e0_rt .and. small_temp > 0.0e0_rt) then

--- a/Exec/gravity_tests/hse_convergence/Prob_nd.F90
+++ b/Exec/gravity_tests/hse_convergence/Prob_nd.F90
@@ -25,8 +25,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      call castro_error("Error: helium-4 not present")
   end if
 
-  call probdata_init(name, namlen)
-
   model_params % T_base = temp_base
   model_params % dens_base = dens_base
   model_params % xn(:) = 100*small_x

--- a/Exec/gravity_tests/hse_convergence_general/Prob_nd.F90
+++ b/Exec/gravity_tests/hse_convergence_general/Prob_nd.F90
@@ -33,10 +33,6 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
   integer :: nx_model
   integer :: ng
 
-  ! get the problm parameters
-  call probdata_init(name, namlen)
-
-
   ! check to make sure that small_dens is less than low_density_cutoff
   ! if not, funny things can happen above the atmosphere
   if (small_dens >= 0.99_rt * low_density_cutoff) then

--- a/Exec/gravity_tests/hydrostatic_adjust/Prob_nd.F90
+++ b/Exec/gravity_tests/hydrostatic_adjust/Prob_nd.F90
@@ -18,8 +18,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   ! Read in the initial model
 
   call read_model_file(model_name)

--- a/Exec/gravity_tests/uniform_cube_sphere/Prob_nd.F90
+++ b/Exec/gravity_tests/uniform_cube_sphere/Prob_nd.F90
@@ -8,8 +8,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   integer,  intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
 end subroutine amrex_probinit
 
 

--- a/Exec/hydro_tests/KH/Prob_nd.F90
+++ b/Exec/hydro_tests/KH/Prob_nd.F90
@@ -13,9 +13,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
    integer, intent(in) :: name(namlen)
    real(rt), intent(in) :: problo(3), probhi(3)
 
-
-   call probdata_init(name, namlen)
-
    ! Force a different pressure choice for problem 5
 
    if (problem .eq. 5) then

--- a/Exec/hydro_tests/RT/Prob_nd.F90
+++ b/Exec/hydro_tests/RT/Prob_nd.F90
@@ -10,8 +10,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   integer,  intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! set local variable defaults
   split(:) = frac * (problo(:) + probhi(:))
 

--- a/Exec/hydro_tests/Sedov/Prob_nd.F90
+++ b/Exec/hydro_tests/Sedov/Prob_nd.F90
@@ -28,8 +28,6 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
      center = HALF * (problo + probhi)
   end if
 
-  call probdata_init(name, namlen)
-
   xn_zone(:) = ZERO
   xn_zone(1) = ONE
 

--- a/Exec/hydro_tests/Sod/Prob_nd.F90
+++ b/Exec/hydro_tests/Sod/Prob_nd.F90
@@ -16,8 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   split(1) = frac*(problo(1)+probhi(1))
   split(2) = frac*(problo(2)+probhi(2))
   split(3) = frac*(problo(3)+probhi(3))

--- a/Exec/hydro_tests/Sod_stellar/Prob_nd.F90
+++ b/Exec/hydro_tests/Sod_stellar/Prob_nd.F90
@@ -17,8 +17,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   real(rt)         xn(nspec)
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   split(1) = frac*(problo(1)+probhi(1))
   split(2) = frac*(problo(2)+probhi(2))
   split(3) = frac*(problo(3)+probhi(3))

--- a/Exec/hydro_tests/Vortices_LWAcoustics/Prob_nd.F90
+++ b/Exec/hydro_tests/Vortices_LWAcoustics/Prob_nd.F90
@@ -12,8 +12,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   integer,  intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! Define rho_0
   rho_0 = p_ref**(1e0_rt/gamma_const)
 

--- a/Exec/hydro_tests/acoustic_pulse/Prob_nd.F90
+++ b/Exec/hydro_tests/acoustic_pulse/Prob_nd.F90
@@ -12,8 +12,6 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   integer,  intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! set explosion center
   center(:) = HALF * (problo(:) + probhi(:))
 

--- a/Exec/hydro_tests/acoustic_pulse_general/Prob_nd.F90
+++ b/Exec/hydro_tests/acoustic_pulse_general/Prob_nd.F90
@@ -16,8 +16,6 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   type(eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   ! set explosion center
   center(:) = ZERO
   center(1) = HALF*(problo(1) + probhi(1))

--- a/Exec/hydro_tests/double_bubble/Prob_nd.F90
+++ b/Exec/hydro_tests/double_bubble/Prob_nd.F90
@@ -18,8 +18,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
                     single
 
 
-  call probdata_init(name, namlen)
-
   ! model composition
   xn_model(:) = 0.0e0_rt
   xn_model(1) = 1.0e0_rt

--- a/Exec/hydro_tests/double_mach_reflection/Prob_nd.F90
+++ b/Exec/hydro_tests/double_mach_reflection/Prob_nd.F90
@@ -21,8 +21,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   call castro_error("ERROR: this problem only works for 2-d")
 #endif
 
-  call probdata_init(name, namlen)
-
   ! set local variable defaults -- the 'center' variables are the
   ! location of the
 

--- a/Exec/hydro_tests/gamma_law_bubble/Prob_nd.F90
+++ b/Exec/hydro_tests/gamma_law_bubble/Prob_nd.F90
@@ -11,8 +11,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   integer,  intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! set center variable in prob_params_module
   center(1) = frac*(problo(1)+probhi(1))
   center(2) = frac*(problo(2)+probhi(2))

--- a/Exec/hydro_tests/gresho_vortex/Prob_nd.F90
+++ b/Exec/hydro_tests/gresho_vortex/Prob_nd.F90
@@ -18,8 +18,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   integer,  intent(in   ) :: name(namlen)
   real(rt), intent(in   ) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! problem center
   center(:) = (problo(:) + probhi(:)) / 2.e0_rt
 

--- a/Exec/hydro_tests/heating_verification/Prob_nd.F90
+++ b/Exec/hydro_tests/heating_verification/Prob_nd.F90
@@ -17,8 +17,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   real(rt) :: xn(nspec)
   type(eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   ! compute T_in from the input data
   xn(:) = 0.0_rt
   xn(1) = 1.0_rt

--- a/Exec/hydro_tests/oddeven/Prob_nd.F90
+++ b/Exec/hydro_tests/oddeven/Prob_nd.F90
@@ -11,8 +11,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   integer,  intent(in   ) :: name(namlen)
   real(rt), intent(in   ) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! set center, domain extrema
   center(:) = (problo(:) + probhi(:)) / 2.e0_rt
 

--- a/Exec/hydro_tests/riemann_test_zone/Prob_nd.F90
+++ b/Exec/hydro_tests/riemann_test_zone/Prob_nd.F90
@@ -19,8 +19,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   integer :: lo(3), hi(3), loa(3), hia(3)
 
-  call probdata_init(name, namlen)
-
   ! call the Riemann solver
   lo(:) = [1, 1, 0]
   hi(:) = [1, 1, 0]

--- a/Exec/hydro_tests/rotating_torus/Prob_nd.F90
+++ b/Exec/hydro_tests/rotating_torus/Prob_nd.F90
@@ -20,8 +20,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   real(rt) :: omega(3)
 
-  call probdata_init(name, namlen)
-
 #ifdef ROTATION
   call get_omega(omega)
 #else

--- a/Exec/hydro_tests/symmetry/Prob_nd.F90
+++ b/Exec/hydro_tests/symmetry/Prob_nd.F90
@@ -12,8 +12,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   integer,  intent(in   ) :: name(namlen)
   real(rt), intent(in   ) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   center(:) = HALF * (problo(:) + probhi(:))
 
 end subroutine amrex_probinit

--- a/Exec/hydro_tests/test_convect/Prob_nd.F90
+++ b/Exec/hydro_tests/test_convect/Prob_nd.F90
@@ -15,8 +15,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   real(rt) :: offset
   integer :: i
 
-  call probdata_init(name, namlen)
-
   ! Read initial model
   call read_model_file(model_name)
 

--- a/Exec/hydro_tests/toy_convect/Prob_nd.F90
+++ b/Exec/hydro_tests/toy_convect/Prob_nd.F90
@@ -15,9 +15,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   real(rt) :: offset
   integer :: i
 
-  ! Namelist defaults
-  call probdata_init(name, namlen)
-
   if (num_vortices > max_num_vortices) then
      call castro_error("num_vortices too large, please increase max_num_vortices and the size of xloc_vortices")
   end if

--- a/Exec/mhd_tests/Alfven/Prob_nd.F90
+++ b/Exec/mhd_tests/Alfven/Prob_nd.F90
@@ -16,9 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
-
   !give value to B 
   B_x  = B_0/M_SQRT_2
   B_y  = B_0/M_SQRT_2

--- a/Exec/mhd_tests/BrioWu/Prob_nd.F90
+++ b/Exec/mhd_tests/BrioWu/Prob_nd.F90
@@ -16,8 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   split(1) = frac*(problo(1)+probhi(1))
   split(2) = frac*(problo(2)+probhi(2))
   split(3) = frac*(problo(3)+probhi(3))

--- a/Exec/mhd_tests/DaiWoodward/Prob_nd.F90
+++ b/Exec/mhd_tests/DaiWoodward/Prob_nd.F90
@@ -16,8 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   split(1) = frac*(problo(1)+probhi(1))
   split(2) = frac*(problo(2)+probhi(2))
   split(3) = frac*(problo(3)+probhi(3))

--- a/Exec/mhd_tests/FastRarefaction/Prob_nd.F90
+++ b/Exec/mhd_tests/FastRarefaction/Prob_nd.F90
@@ -16,8 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   split(1) = frac*(problo(1)+probhi(1))
   split(2) = frac*(problo(2)+probhi(2))
   split(3) = frac*(problo(3)+probhi(3))

--- a/Exec/mhd_tests/LoopAdvection/Prob_nd.F90
+++ b/Exec/mhd_tests/LoopAdvection/Prob_nd.F90
@@ -16,8 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   ! compute the internal energy (erg/cc) for the left and right state
   xn(:) = 0.0e0_rt
   xn(1) = 1.0e0_rt

--- a/Exec/mhd_tests/MagnetosonicWaves/Prob_nd.F90
+++ b/Exec/mhd_tests/MagnetosonicWaves/Prob_nd.F90
@@ -16,9 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
-
   !get unitary vectors for k and b
   !such that b is 45 degrees from k
 

--- a/Exec/mhd_tests/OrszagTang/Prob_nd.F90
+++ b/Exec/mhd_tests/OrszagTang/Prob_nd.F90
@@ -16,8 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   !temporarily give B_0 value here
   B_0 = 1.0 / (TWO*M_SQRT_PI)
 

--- a/Exec/mhd_tests/RT/Prob_nd.F90
+++ b/Exec/mhd_tests/RT/Prob_nd.F90
@@ -10,8 +10,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   integer,  intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! set local variable defaults
   split(:) = frac * (problo(:) + probhi(:))
 

--- a/Exec/mhd_tests/species/Prob_nd.F90
+++ b/Exec/mhd_tests/species/Prob_nd.F90
@@ -16,8 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   split(1) = frac*(problo(1)+probhi(1))
   split(2) = frac*(problo(2)+probhi(2))
   split(3) = frac*(problo(3)+probhi(3))

--- a/Exec/radiation_tests/Rad2Tshock/Prob_nd.F90
+++ b/Exec/radiation_tests/Rad2Tshock/Prob_nd.F90
@@ -14,8 +14,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   type(eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   ! set some defaults we will need later in the BCs
   eos_state % rho = rho0
   eos_state % T   =   T0

--- a/Exec/radiation_tests/RadBreakout/Prob_nd.F90
+++ b/Exec/radiation_tests/RadBreakout/Prob_nd.F90
@@ -13,8 +13,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   integer untin, i
   character(1) dummy
 
-  call probdata_init(name, namlen)
-
   xmin = problo(1)
   xmax = probhi(1)
 

--- a/Exec/radiation_tests/RadFront/Prob_nd.F90
+++ b/Exec/radiation_tests/RadFront/Prob_nd.F90
@@ -13,8 +13,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   type(eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   eos_state % rho = rho_0
   eos_state % T   = T_0
   eos_state % xn  = 0.e0_rt

--- a/Exec/radiation_tests/RadShestakovBolstad/Prob_nd.F90
+++ b/Exec/radiation_tests/RadShestakovBolstad/Prob_nd.F90
@@ -10,8 +10,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
 end subroutine amrex_probinit
 
 ! ::: -----------------------------------------------------------

--- a/Exec/radiation_tests/RadSlope/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSlope/Prob_nd.F90
@@ -10,8 +10,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  !call probdata_init(name, namlen)
-
 end subroutine amrex_probinit
 
 ! ::: -----------------------------------------------------------

--- a/Exec/radiation_tests/RadSourceTest/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSourceTest/Prob_nd.F90
@@ -18,9 +18,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   real(rt) :: X_in(nspec), e_0
   type(eos_t) :: eos_state
 
-
-  call probdata_init(name, namlen)
-
   ! get T_0 corresponding to rhoe_0 and rho_0 through the EOS
   e_0 = rhoe_0/rho_0
   X_in(:) = 0.0

--- a/Exec/radiation_tests/RadSphere/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSphere/Prob_nd.F90
@@ -11,8 +11,6 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(C, name="amrex_pr
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
 end subroutine amrex_probinit
 
 ! ::: -----------------------------------------------------------

--- a/Exec/radiation_tests/RadSuOlsonMG/Prob_nd.F90
+++ b/Exec/radiation_tests/RadSuOlsonMG/Prob_nd.F90
@@ -11,8 +11,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   t0 = tau0 / (epsilon*c_light*kapbar)
   x0 = x0 / kapbar
   qn(0) = a_rad * Temp0**4 * c_light * kapbar * Q * p0

--- a/Exec/radiation_tests/RadThermalWave/Prob_nd.F90
+++ b/Exec/radiation_tests/RadThermalWave/Prob_nd.F90
@@ -9,11 +9,6 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
   integer,  intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  integer i
-
-  ! get the problem parameters
-  call probdata_init(name, namlen)
-
 end subroutine amrex_probinit
 
 

--- a/Exec/reacting_tests/bubble_convergence/Prob_nd.F90
+++ b/Exec/reacting_tests/bubble_convergence/Prob_nd.F90
@@ -25,8 +25,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
      call castro_error("Error: helium-4 not present")
   end if
 
-  call probdata_init(name, namlen)
-
   model_params % T_base = temp_base
   model_params % dens_base = dens_base
   model_params % xn(:) = 100*small_x

--- a/Exec/reacting_tests/nse_test/Prob_nd.F90
+++ b/Exec/reacting_tests/nse_test/Prob_nd.F90
@@ -17,8 +17,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   real(rt) :: smallx
 
-  call probdata_init(name, namlen)
-
   ! get the species indices
   ihe4 = network_species_index("helium-4")
   ic12 = network_species_index("carbon-12")

--- a/Exec/reacting_tests/reacting_bubble/Prob_nd.F90
+++ b/Exec/reacting_tests/reacting_bubble/Prob_nd.F90
@@ -17,8 +17,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type(eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   ! Read initial model
   call read_model_file(model_name)
 

--- a/Exec/reacting_tests/reacting_convergence/Prob_nd.F90
+++ b/Exec/reacting_tests/reacting_convergence/Prob_nd.F90
@@ -18,8 +18,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type(eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   ! set explosion center
   center(:) = ZERO
   center(1) = HALF*(problo(1) + probhi(1))

--- a/Exec/reacting_tests/toy_flame/Prob_nd.F90
+++ b/Exec/reacting_tests/toy_flame/Prob_nd.F90
@@ -21,8 +21,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   real(rt) :: lambda_f, v_f
 
-  call probdata_init(name, namlen)
-
   ! output flame speed and width estimates
   eos_state%rho = rho_burn_ref
   eos_state%T = T_burn_ref

--- a/Exec/scf_tests/single_star/Prob_nd.F90
+++ b/Exec/scf_tests/single_star/Prob_nd.F90
@@ -13,8 +13,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
 end subroutine amrex_probinit
 
 subroutine ca_initdata(level, time, lo, hi, nscal, &

--- a/Exec/science/Detonation/Prob_nd.F90
+++ b/Exec/science/Detonation/Prob_nd.F90
@@ -17,8 +17,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   type(eos_t) :: eos_state
 
-  call probdata_init(name, namlen)
-
   ! get the species indices
   ihe4 = network_species_index("helium-4")
   ic12 = network_species_index("carbon-12")

--- a/Exec/science/bwp-rad/Prob_nd.F90
+++ b/Exec/science/bwp-rad/Prob_nd.F90
@@ -13,8 +13,6 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   integer :: name(namlen)
   real(rt) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! read initial model
   call read_model_file(model_name)
 

--- a/Exec/science/convective_flame/Prob_nd.F90
+++ b/Exec/science/convective_flame/Prob_nd.F90
@@ -22,8 +22,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   real(rt) :: dx_model
   integer :: ng
 
-  call probdata_init(name, namlen)
-
   refine_cutoff_height = problo(2) + refine_cutoff_frac * (probhi(2) - problo(2))
 
   ! get the species indices

--- a/Exec/science/flame/Prob_nd.F90
+++ b/Exec/science/flame/Prob_nd.F90
@@ -22,8 +22,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C, name="amre
 
   integer :: ifuel1, iash1, ifuel2, iash2, ifuel3, iash3, ifuel4, iash4
 
-  call probdata_init(name, namlen)
-
   ifuel1 = network_species_index(fuel1_name)
   iash1 = network_species_index(ash1_name)
 

--- a/Exec/science/flame_wave/Prob_nd.F90
+++ b/Exec/science/flame_wave/Prob_nd.F90
@@ -39,10 +39,6 @@ subroutine amrex_probinit (init, name, namlen, problo, probhi) bind(c)
 
   type(eos_t) :: eos_state
 
-  ! get the problm parameters
-  call probdata_init(name, namlen)
-
-
   ! check to make sure that small_dens is less than low_density_cutoff
   ! if not, funny things can happen above the atmosphere
   if (small_dens >= 0.99_rt * low_density_cutoff) then

--- a/Exec/science/nova/Prob_nd.F90
+++ b/Exec/science/nova/Prob_nd.F90
@@ -15,8 +15,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
   real(rt) :: offset
   integer :: i
 
-  call probdata_init(name, namlen)
-
   ! Read initial model
   call read_model_file(model_name)
 

--- a/Exec/science/planet/Prob_nd.F90
+++ b/Exec/science/planet/Prob_nd.F90
@@ -22,8 +22,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   integer :: i
 
-  call probdata_init(name, namlen)
-
   ! Read initial model
   call read_model_file(model_name)
 

--- a/Exec/science/rotating_star/Prob_nd.F90
+++ b/Exec/science/rotating_star/Prob_nd.F90
@@ -13,8 +13,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C)
   integer, intent(in) :: name(namlen)
   real(rt), intent(in) :: problo(3), probhi(3)
 
-  call probdata_init(name, namlen)
-
   ! read initial model
   call read_model_file(model_name)
 

--- a/Exec/science/subchandra/Prob_nd.F90
+++ b/Exec/science/subchandra/Prob_nd.F90
@@ -15,8 +15,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(C)
 
   integer untin, i
 
-  call probdata_init(name, namlen)
-
   ! read initial model
   call read_model_file(model_name)
 

--- a/Exec/science/wdmerger/problem_io.f90
+++ b/Exec/science/wdmerger/problem_io.f90
@@ -23,10 +23,6 @@ contains
 
     ioproc = is_ioprocessor .ne. 0
 
-    ! Read in probdata.
-
-    call probdata_init(name, namlen)
-
   end subroutine initialize_io
   
 end module problem_io_module

--- a/Exec/science/xrb_mixed/Prob_nd.F90
+++ b/Exec/science/xrb_mixed/Prob_nd.F90
@@ -16,8 +16,6 @@ subroutine amrex_probinit(init, name, namlen, problo, probhi) bind(c)
 
   integer :: i
 
-  call probdata_init(name, namlen)
-
   if (num_vortices > max_num_vortices) then
      call castro_error("num_vortices too large, please increase max_num_vortices and the size of xloc_vortices")
   end if

--- a/Exec/unit_tests/diffusion_test/Prob_nd.F90
+++ b/Exec/unit_tests/diffusion_test/Prob_nd.F90
@@ -26,10 +26,6 @@ subroutine amrex_probinit(init,name,namlen,problo,probhi) bind(c)
 
   type (eos_t) :: eos_state
 
-
-  ! get the problem parameters
-  call probdata_init(name, namlen)
-
   ! set center, domain extrema
   if (coord_type == 0) then
      center(1) = HALF*(problo(1)+probhi(1))

--- a/Exec/unit_tests/model_burner/Prob_nd.F90
+++ b/Exec/unit_tests/model_burner/Prob_nd.F90
@@ -17,8 +17,6 @@ subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
   integer :: k, n
 
-  call probdata_init(name, namlen)
-
   ! read the initial model
   call read_model_file(model_name)
 

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -17,6 +17,7 @@
 
 #include <AMReX_buildInfo.H>
 #include <microphysics_F.H>
+#include <prob_parameters_F.H>
 
 using std::string;
 using namespace amrex;
@@ -200,6 +201,16 @@ Castro::variableSetUp ()
   // initializations (e.g., set phys_bc)
   read_params();
 
+  // read the probdata parameters
+  const int probin_file_length = probin_file.length();
+  Vector<int> probin_file_name(probin_file_length);
+
+  for (int i = 0; i < probin_file_length; i++) {
+    probin_file_name[i] = probin_file[i];
+  }
+
+  probdata_init(probin_file_name.dataPtr(), &probin_file_length);
+
   // Read in the input values to Fortran.
   ca_set_castro_method_params();
 
@@ -335,13 +346,6 @@ Castro::variableSetUp ()
 
   // Read in the parameters for the tagging criteria
   // and store them in the Fortran module.
-
-  const int probin_file_length = probin_file.length();
-  Vector<int> probin_file_name(probin_file_length);
-
-  for (int i = 0; i < probin_file_length; i++) {
-    probin_file_name[i] = probin_file[i];
-  }
 
   ca_get_tagging_params(probin_file_name.dataPtr(),&probin_file_length);
 

--- a/Util/scripts/prob_params.template
+++ b/Util/scripts/prob_params.template
@@ -15,7 +15,7 @@ module probdata_module
 
 end module probdata_module
 
-subroutine probdata_init(name, namlen)
+subroutine probdata_init(name, namlen) bind(C, name='probdata_init')
 
   use probdata_module
   use castro_error_module, only: castro_error

--- a/Util/scripts/write_probdata.py
+++ b/Util/scripts/write_probdata.py
@@ -56,6 +56,8 @@ CXX_F_HEADER = """
 extern "C"
 {
 #endif
+
+void probdata_init(const int* name, const int* namlen);
 """
 
 CXX_F_FOOTER = """


### PR DESCRIPTION

## PR summary

Rather than rely on problems to manually call `probdata_init()` in `amrex_probinit()`, this is now called by default for all setups.

## PR motivation

While this has no specific benefit at present (other than simplifying code), it becomes functionally relevant when we start adding parameters to `_default_prob_params` (#1222).

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
