### PR TITLE
Implement new AMReX tagging format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # 20.10
 
    * A new refinement scheme using the inputs file rather than the Fortran
-     tagging namelist has been added. (#1243). The scheme looks like:
+     tagging namelist has been added. (#1243) As an example, consider:
 
      ```
      amr.refinement_indicators = dens temp
@@ -19,7 +19,7 @@
      schemes. For each defined name, amr.refine.<name> accepts predefined fields
      describing when to tag. In the current implementation, these are `max_level`
      (maximum level to refine to), `start_time` (when to start tagging), `end_time`
-     (when to stop tagging), `value_greater` (value above which we refine), and
+     (when to stop tagging), `value_greater` (value above which we refine),
      `value_less` (value below which to refine), and `field_name` (name of the
      string defining the field in the code). If a refinement indicator is added,
      either `value_greater` or `value_less` must be provided. (In the future we

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,30 @@
 # 20.10
 
+   * A new refinement scheme using the inputs file rather than the Fortran
+     tagging namelist has been added. (#1243). The scheme looks like:
+
+     ```
+     amr.refinement_indicators = dens temp
+
+     amr.refine.dens.max_level = 1
+     amr.refine.dens.value_greater = 2.0
+     amr.refine.dens.field_name = Density
+
+     amr.refine.temp.max_level = 2
+     amr.refine.temp.value_less = 1.0
+     amr.refine.temp.field_name = Temp
+     ```
+
+     `amr.refinement_indicators` is a list of user-defined names for refinement
+     schemes. For each defined name, amr.refine.<name> accepts predefined fields
+     describing when to tag. In the current implementation, these are `max_level`
+     (maximum level to refine to), `start_time` (when to start tagging), `end_time`
+     (when to stop tagging), `value_greater` (value above which we refine), and
+     `value_less` (value below which to refine), and `field_name` (name of the
+     string defining the field in the code). If a refinement indicator is added,
+     either `value_greater` or `value_less` must be provided. (In the future we
+     will support other refinement schemes such as gradients.)
+
    * Automatic problem parameter configuration is now available to every
      problem by placing a _prob_params file in your problem directory.
      Examples can be found in most of the problems in Castro/Exec, and you

--- a/Docs/source/AMR.rst
+++ b/Docs/source/AMR.rst
@@ -179,6 +179,30 @@ problem_tagging_3d.f90 to our work directory and set it up as follows:
 
     end subroutine set_problem_tags
 
+We also provide a mechanism for defining a limited set of refinement
+schemes from the inputs file; for example,
+
+::
+
+   amr.refinement_indicators = dens temp
+
+   amr.refine.dens.max_level = 1
+   amr.refine.dens.value_greater = 2.0
+   amr.refine.dens.field_name = Density
+
+   amr.refine.temp.max_level = 2
+   amr.refine.temp.value_less = 1.0
+   amr.refine.temp.field_name = Temp
+
+``amr.refinement_indicators`` is a list of user-defined names for refinement
+schemes. For each defined name, ``amr.refine.<name>`` accepts predefined fields
+describing when to tag. These are ``max_level`` (maximum level to refine to),
+``start_time`` (when to start tagging), ``end_time`` (when to stop tagging),
+``value_greater`` (value above which we refine), ``value_less`` (value below
+which to refine), and ``field_name`` (name of the string defining the field
+in the code). If a refinement indicator is added, either ``value_greater`` or
+``value_less`` must be provided.
+
 .. _sec:amr_synchronization:
 
 Synchronization Algorithm

--- a/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
+++ b/Exec/science/wdmerger/tests/wdmerger_3D/inputs_test_wdmerger_3D
@@ -45,6 +45,12 @@ amr.n_cell = 96 96 96                              # Number of cells on the coar
 amr.max_level = 1                                  # Maximum level number allowed
 amr.ref_ratio = 2
 
+amr.refinement_indicators = temperature
+
+amr.refine.temperature.max_level = 4
+amr.refine.temperature.value_greater = 2.e8
+amr.refine.temperature.field_name = Temp
+
 amr.max_grid_size = 32                             # Maximum grid size at each level
 amr.blocking_factor = 16                           # Grid sizes must be a multiple of this
 

--- a/Exec/science/wdmerger/tests/wdmerger_3D/probin_test_wdmerger_3D
+++ b/Exec/science/wdmerger/tests/wdmerger_3D/probin_test_wdmerger_3D
@@ -28,8 +28,6 @@
 /
 
 &tagging 
-  max_temperr_lev    = 4
-  temperr            = 2.d8
 /
 
 &sponge

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -1181,6 +1181,11 @@ public:
     static amrex::Vector<int> qpass_map;
 
 ///
+/// Vector storing list of custom error tags.
+///
+    static amrex::Vector<amrex::AMRErrorTag> custom_error_tags;
+
+///
 /// This MultiFab is on the coarser level.  This is useful for the coarser level
 ///     to mask out the finer level.  We only build this when it is needed.
 ///     This coarse MultiFab has to live on the fine level because it must be updated


### PR DESCRIPTION

## PR summary

The refinement scheme from AMReX-Codes/amrex#1166 is implemented. Rather than using the Fortran tagging namelist, applications may use the inputs file. The scheme looks like:

```
amr.refinement_indicators = dens temp

amr.refine.dens.max_level = 1
amr.refine.dens.value_greater = 2.0
amr.refine.dens.field_name = Density

amr.refine.temp.max_level = 2
amr.refine.temp.value_less = 1.0
amr.refine.temp.field_name = Temp
```

`amr.refinement_indicators` is a list of user-defined names for refinement schemes. For each defined name, `amr.refine.<name>` accepts predefined fields describing when to tag. In the current implementation, these are `max_level` (maximum level to refine to), `start_time` (when to start tagging), `end_time` (when to stop tagging), `value_greater` (value above which we refine), and `value_less` (value below which to refine), and `field_name` (name of the string defining the field in the code). If a refinement indicator is added, either `value_greater` or `value_less` must be provided. (In the future we will support other refinement schemes such as gradients.)

A wdmerger setup is converted to the new scheme as a test.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
