### PR TITLE
Add gradient to inputs-based error tagging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,14 @@
 # 20.10
 
    * A new refinement scheme using the inputs file rather than the Fortran
-     tagging namelist has been added. (#1243) As an example, consider:
+     tagging namelist has been added. (#1243, #1245) As an example, consider:
 
      ```
      amr.refinement_indicators = dens temp
 
      amr.refine.dens.max_level = 1
      amr.refine.dens.value_greater = 2.0
-     amr.refine.dens.field_name = Density
+     amr.refine.dens.field_name = density
 
      amr.refine.temp.max_level = 2
      amr.refine.temp.value_less = 1.0
@@ -20,10 +20,10 @@
      describing when to tag. In the current implementation, these are `max_level`
      (maximum level to refine to), `start_time` (when to start tagging), `end_time`
      (when to stop tagging), `value_greater` (value above which we refine),
-     `value_less` (value below which to refine), and `field_name` (name of the
-     string defining the field in the code). If a refinement indicator is added,
-     either `value_greater` or `value_less` must be provided. (In the future we
-     will support other refinement schemes such as gradients.)
+     `value_less` (value below which to refine), `gradient` (absolute value of the
+     difference between adjacent cells above which we refine), and `field_name`
+     (name of the string defining the field in the code). If a refinement indicator
+     is added, either `value_greater`, `value_less`, or `gradient` must be provided.
 
    * Automatic problem parameter configuration is now available to every
      problem by placing a _prob_params file in your problem directory.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # 20.10
 
    * A new refinement scheme using the inputs file rather than the Fortran
-     tagging namelist has been added. (#1243, #1245) As an example, consider:
+     tagging namelist has been added. (#1243, #1246) As an example, consider:
 
      ```
      amr.refinement_indicators = dens temp

--- a/Docs/source/AMR.rst
+++ b/Docs/source/AMR.rst
@@ -188,7 +188,7 @@ schemes from the inputs file; for example,
 
    amr.refine.dens.max_level = 1
    amr.refine.dens.value_greater = 2.0
-   amr.refine.dens.field_name = Density
+   amr.refine.dens.field_name = density
 
    amr.refine.temp.max_level = 2
    amr.refine.temp.value_less = 1.0
@@ -199,9 +199,10 @@ schemes. For each defined name, ``amr.refine.<name>`` accepts predefined fields
 describing when to tag. These are ``max_level`` (maximum level to refine to),
 ``start_time`` (when to start tagging), ``end_time`` (when to stop tagging),
 ``value_greater`` (value above which we refine), ``value_less`` (value below
-which to refine), and ``field_name`` (name of the string defining the field
-in the code). If a refinement indicator is added, either ``value_greater`` or
-``value_less`` must be provided.
+which to refine), ``gradient`` (absolute value of the difference between
+adjacent cells above which we refine), and ``field_name`` (name of the string
+defining the field in the code). If a refinement indicator is added, either
+``value_greater``, ``value_less``, or ``gradient`` must be provided.
 
 .. _sec:amr_synchronization:
 

--- a/Exec/hydro_tests/Sedov/inputs.1d.cyl
+++ b/Exec/hydro_tests/Sedov/inputs.1d.cyl
@@ -39,6 +39,24 @@ amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 256
 
+amr.refinement_indicators = denerr dengrad presserr pressgrad
+
+amr.refine.denerr.max_level = 3
+amr.refine.denerr.value_greater = 3
+amr.refine.denerr.field_name = density
+
+amr.refine.dengrad.max_level = 3
+amr.refine.dengrad.gradient = 0.01
+amr.refine.dengrad.field_name = density
+
+amr.refine.presserr.max_level = 3
+amr.refine.presserr.value_greater = 3
+amr.refine.presserr.field_name = pressure
+
+amr.refine.pressgrad.max_level = 3
+amr.refine.pressgrad.gradient = 0.01
+amr.refine.pressgrad.field_name = pressure
+
 # CHECKPOINT FILES
 amr.check_file      = chk     # root name of checkpoint file
 amr.check_int       = 1000     # number of timesteps between checkpoints

--- a/Exec/hydro_tests/Sedov/inputs.1d.sph
+++ b/Exec/hydro_tests/Sedov/inputs.1d.sph
@@ -40,6 +40,24 @@ amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 256
 
+amr.refinement_indicators = denerr dengrad presserr pressgrad
+
+amr.refine.denerr.max_level = 3
+amr.refine.denerr.value_greater = 3
+amr.refine.denerr.field_name = density
+
+amr.refine.dengrad.max_level = 3
+amr.refine.dengrad.gradient = 0.01
+amr.refine.dengrad.field_name = density
+
+amr.refine.presserr.max_level = 3
+amr.refine.presserr.value_greater = 3
+amr.refine.presserr.field_name = pressure
+
+amr.refine.pressgrad.max_level = 3
+amr.refine.pressgrad.gradient = 0.01
+amr.refine.pressgrad.field_name = pressure
+
 # CHECKPOINT FILES
 amr.check_file      = sedov_1d_sph_chk     # root name of checkpoint file
 amr.check_int       = 1000    # number of timesteps between checkpoints

--- a/Exec/hydro_tests/Sedov/inputs.2d.cyl_in_cartcoords
+++ b/Exec/hydro_tests/Sedov/inputs.2d.cyl_in_cartcoords
@@ -39,6 +39,24 @@ amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 256
 
+amr.refinement_indicators = denerr dengrad presserr pressgrad
+
+amr.refine.denerr.max_level = 3
+amr.refine.denerr.value_greater = 3
+amr.refine.denerr.field_name = density
+
+amr.refine.dengrad.max_level = 3
+amr.refine.dengrad.gradient = 0.01
+amr.refine.dengrad.field_name = density
+
+amr.refine.presserr.max_level = 3
+amr.refine.presserr.value_greater = 3
+amr.refine.presserr.field_name = pressure
+
+amr.refine.pressgrad.max_level = 3
+amr.refine.pressgrad.gradient = 0.01
+amr.refine.pressgrad.field_name = pressure
+
 # CHECKPOINT FILES
 amr.check_file      = sedov_2d_cyl_in_cart_chk   # root name of checkpoint file
 amr.check_int       = 20       # number of timesteps between checkpoints

--- a/Exec/hydro_tests/Sedov/inputs.2d.cyl_in_cartcoords.testsuite
+++ b/Exec/hydro_tests/Sedov/inputs.2d.cyl_in_cartcoords.testsuite
@@ -39,6 +39,24 @@ amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 256
 
+amr.refinement_indicators = denerr dengrad presserr pressgrad
+
+amr.refine.denerr.max_level = 3
+amr.refine.denerr.value_greater = 3
+amr.refine.denerr.field_name = density
+
+amr.refine.dengrad.max_level = 3
+amr.refine.dengrad.gradient = 0.01
+amr.refine.dengrad.field_name = density
+
+amr.refine.presserr.max_level = 3
+amr.refine.presserr.value_greater = 3
+amr.refine.presserr.field_name = pressure
+
+amr.refine.pressgrad.max_level = 3
+amr.refine.pressgrad.gradient = 0.01
+amr.refine.pressgrad.field_name = pressure
+
 # CHECKPOINT FILES
 amr.check_file      = sedov_2d_cyl_in_cart_chk   # root name of checkpoint file
 amr.check_int       = 20       # number of timesteps between checkpoints

--- a/Exec/hydro_tests/Sedov/inputs.2d.sph_in_cylcoords
+++ b/Exec/hydro_tests/Sedov/inputs.2d.sph_in_cylcoords
@@ -50,6 +50,24 @@ amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 32
 
+amr.refinement_indicators = denerr dengrad presserr pressgrad
+
+amr.refine.denerr.max_level = 3
+amr.refine.denerr.value_greater = 3
+amr.refine.denerr.field_name = density
+
+amr.refine.dengrad.max_level = 3
+amr.refine.dengrad.gradient = 0.01
+amr.refine.dengrad.field_name = density
+
+amr.refine.presserr.max_level = 3
+amr.refine.presserr.value_greater = 3
+amr.refine.presserr.field_name = pressure
+
+amr.refine.pressgrad.max_level = 3
+amr.refine.pressgrad.gradient = 0.01
+amr.refine.pressgrad.field_name = pressure
+
 # CHECKPOINT FILES
 amr.check_file      = sedov_2d_sph_in_cyl_chk     # root name of checkpoint file
 amr.check_int       = 1000     # number of timesteps between checkpoints

--- a/Exec/hydro_tests/Sedov/inputs.2d.sph_in_cylcoords.testsuite
+++ b/Exec/hydro_tests/Sedov/inputs.2d.sph_in_cylcoords.testsuite
@@ -50,6 +50,24 @@ amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 32
 
+amr.refinement_indicators = denerr dengrad presserr pressgrad
+
+amr.refine.denerr.max_level = 3
+amr.refine.denerr.value_greater = 3
+amr.refine.denerr.field_name = density
+
+amr.refine.dengrad.max_level = 3
+amr.refine.dengrad.gradient = 0.01
+amr.refine.dengrad.field_name = density
+
+amr.refine.presserr.max_level = 3
+amr.refine.presserr.value_greater = 3
+amr.refine.presserr.field_name = pressure
+
+amr.refine.pressgrad.max_level = 3
+amr.refine.pressgrad.gradient = 0.01
+amr.refine.pressgrad.field_name = pressure
+
 # CHECKPOINT FILES
 amr.check_file      = sedov_2d_sph_in_cyl_chk     # root name of checkpoint file
 amr.check_int       = 1000     # number of timesteps between checkpoints

--- a/Exec/hydro_tests/Sedov/inputs.3d.mhd
+++ b/Exec/hydro_tests/Sedov/inputs.3d.mhd
@@ -45,6 +45,24 @@ amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 4       # block factor in grid generation
 amr.max_grid_size   = 32
 
+amr.refinement_indicators = denerr dengrad presserr pressgrad
+
+amr.refine.denerr.max_level = 3
+amr.refine.denerr.value_greater = 3
+amr.refine.denerr.field_name = density
+
+amr.refine.dengrad.max_level = 3
+amr.refine.dengrad.gradient = 0.01
+amr.refine.dengrad.field_name = density
+
+amr.refine.presserr.max_level = 3
+amr.refine.presserr.value_greater = 3
+amr.refine.presserr.field_name = pressure
+
+amr.refine.pressgrad.max_level = 3
+amr.refine.pressgrad.gradient = 0.01
+amr.refine.pressgrad.field_name = pressure
+
 # CHECKPOINT FILES
 amr.check_file      = sedov_3d_chk     # root name of checkpoint file
 amr.check_int       = 200       # number of timesteps between checkpoints

--- a/Exec/hydro_tests/Sedov/inputs.3d.sph
+++ b/Exec/hydro_tests/Sedov/inputs.3d.sph
@@ -40,6 +40,24 @@ amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 32
 
+amr.refinement_indicators = denerr dengrad presserr pressgrad
+
+amr.refine.denerr.max_level = 3
+amr.refine.denerr.value_greater = 3
+amr.refine.denerr.field_name = Density
+
+amr.refine.dengrad.max_level = 3
+amr.refine.dengrad.value_greater = 0.01
+amr.refine.dengrad.field_name = Density
+
+amr.refine.presserr.max_level = 3
+amr.refine.presserr.value_greater = 3
+amr.refine.presserr.field_name = pressure
+
+amr.refine.pressgrad.max_level = 3
+amr.refine.pressgrad.value_greater = 0.01
+amr.refine.pressgrad.field_name = pressure
+
 # CHECKPOINT FILES
 amr.check_file      = sedov_3d_chk     # root name of checkpoint file
 amr.check_int       = 200       # number of timesteps between checkpoints

--- a/Exec/hydro_tests/Sedov/inputs.3d.sph.testsuite
+++ b/Exec/hydro_tests/Sedov/inputs.3d.sph.testsuite
@@ -40,6 +40,24 @@ amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 32
 
+amr.refinement_indicators = denerr dengrad presserr pressgrad
+
+amr.refine.denerr.max_level = 3
+amr.refine.denerr.value_greater = 3
+amr.refine.denerr.field_name = density
+
+amr.refine.dengrad.max_level = 3
+amr.refine.dengrad.gradient = 0.01
+amr.refine.dengrad.field_name = density
+
+amr.refine.presserr.max_level = 3
+amr.refine.presserr.value_greater = 3
+amr.refine.presserr.field_name = pressure
+
+amr.refine.pressgrad.max_level = 3
+amr.refine.pressgrad.gradient = 0.01
+amr.refine.pressgrad.field_name = pressure
+
 # CHECKPOINT FILES
 amr.check_file      = sedov_3d_chk     # root name of checkpoint file
 amr.check_int       = 200       # number of timesteps between checkpoints

--- a/Exec/hydro_tests/Sedov/probin.1d.cyl
+++ b/Exec/hydro_tests/Sedov/probin.1d.cyl
@@ -8,20 +8,6 @@
 
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
 
   eos_assume_neutral = T

--- a/Exec/hydro_tests/Sedov/probin.1d.sph
+++ b/Exec/hydro_tests/Sedov/probin.1d.sph
@@ -8,20 +8,6 @@
 
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
 
   eos_assume_neutral = T

--- a/Exec/hydro_tests/Sedov/probin.2d.cyl_in_cartcoords
+++ b/Exec/hydro_tests/Sedov/probin.2d.cyl_in_cartcoords
@@ -8,20 +8,6 @@
 
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
 
   eos_assume_neutral = T

--- a/Exec/hydro_tests/Sedov/probin.2d.cyl_in_cartcoords.gammae
+++ b/Exec/hydro_tests/Sedov/probin.2d.cyl_in_cartcoords.gammae
@@ -8,20 +8,6 @@
 
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
   eos_gamma = 1.4
   eos_assume_neutral = T

--- a/Exec/hydro_tests/Sedov/probin.2d.cyl_in_cartcoords.testsuite
+++ b/Exec/hydro_tests/Sedov/probin.2d.cyl_in_cartcoords.testsuite
@@ -8,20 +8,6 @@
 
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
   eos_gamma = 1.4
   eos_assume_neutral = T

--- a/Exec/hydro_tests/Sedov/probin.2d.sph_in_cylcoords
+++ b/Exec/hydro_tests/Sedov/probin.2d.sph_in_cylcoords
@@ -8,20 +8,6 @@
 
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
 
   eos_assume_neutral = T

--- a/Exec/hydro_tests/Sedov/probin.2d.sph_in_cylcoords.testsuite
+++ b/Exec/hydro_tests/Sedov/probin.2d.sph_in_cylcoords.testsuite
@@ -8,20 +8,6 @@
 
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
 
   eos_gamma = 1.4

--- a/Exec/hydro_tests/Sedov/probin.3d.mhd
+++ b/Exec/hydro_tests/Sedov/probin.3d.mhd
@@ -7,20 +7,6 @@
   nsub = 10
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
   eos_gamma = 1.4d0
   eos_assume_neutral = T

--- a/Exec/hydro_tests/Sedov/probin.3d.sph
+++ b/Exec/hydro_tests/Sedov/probin.3d.sph
@@ -8,20 +8,6 @@
 
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
 
   eos_assume_neutral = T

--- a/Exec/hydro_tests/Sedov/probin.3d.sph.testsuite
+++ b/Exec/hydro_tests/Sedov/probin.3d.sph.testsuite
@@ -8,20 +8,6 @@
 
 /
 
-&tagging
-
-  denerr = 3
-  dengrad = 0.01
-  max_denerr_lev = 3
-  max_dengrad_lev = 3
-
-  presserr = 3
-  pressgrad = 0.01
-  max_presserr_lev = 3
-  max_pressgrad_lev = 3
-
-/
-
 &extern
 
   eos_gamma = 1.4d0

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -514,6 +514,13 @@ Castro::read_params ()
             ppr.get("field_name", field);
             custom_error_tags.push_back(AMRErrorTag(value, AMRErrorTag::LESS, field, info));
         }
+        else if (ppr.countval("gradient") > 0) {
+            Real value;
+            ppr.get("gradient", value);
+            std::string field;
+            ppr.get("field_name", field);
+            custom_error_tags.push_back(AMRErrorTag(value, AMRErrorTag::GRAD, field, info));
+        }
         else {
             amrex::Abort("Unrecognized refinement indicator for " + refinement_indicators[i]);
         }


### PR DESCRIPTION

## PR summary

Sedov is converted to the new scheme as a demonstration.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
