### PR TITLE
move problem_initialize() to the end of the constructor

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -552,13 +552,8 @@ Castro::Castro (Amr&            papa,
     if (do_init_probparams == 0) {
       init_prob_parameters();
       do_init_probparams = 1;
-
-      // If we're doing C++ problem initialization, do it here. We have to make
-      // sure it's done after the above call to init_prob_parameters() in case
-      // any changes are made to the problem parameters.
-
-      problem_initialize();
     }
+
 
     initMFs();
 
@@ -639,6 +634,12 @@ Castro::Castro (Amr&            papa,
       rad_solver.reset(new RadSolve(parent, level, grids, dmap));
     }
 #endif
+
+    // If we're doing C++ problem initialization, do it here. We have to make
+    // sure it's done after the above call to init_prob_parameters() in case
+    // any changes are made to the problem parameters.
+
+    problem_initialize();
 
 }
 


### PR DESCRIPTION
this way we can be sure all of the C++ ParmParse's were done before the problem starts

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
