### PR TITLE
Permit level dependent thresholds in new tagging scheme

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -500,23 +500,23 @@ Castro::read_params ()
             info.SetMaxLevel(max_level);
         }
 
-        if (ppr.countval("value_greater") > 0) {
-            Real value;
-            ppr.get("value_greater", value);
+        if (int nval = ppr.countval("value_greater")) {
+            Vector<Real> value;
+            ppr.getarr("value_greater", value, 0, nval);
             std::string field;
             ppr.get("field_name", field);
             custom_error_tags.push_back(AMRErrorTag(value, AMRErrorTag::GREATER, field, info));
         }
-        else if (ppr.countval("value_less") > 0) {
-            Real value;
-            ppr.get("value_less", value);
+        else if (int nval = ppr.countval("value_less")) {
+            Vector<Real> value;
+            ppr.getarr("value_less", value, 0, nval);
             std::string field;
             ppr.get("field_name", field);
             custom_error_tags.push_back(AMRErrorTag(value, AMRErrorTag::LESS, field, info));
         }
-        else if (ppr.countval("gradient") > 0) {
-            Real value;
-            ppr.get("gradient", value);
+        else if (int nval = ppr.countval("gradient")) {
+            Vector<Real> value;
+            ppr.getarr("gradient", value, 0, nval);
             std::string field;
             ppr.get("field_name", field);
             custom_error_tags.push_back(AMRErrorTag(value, AMRErrorTag::GRAD, field, info));


### PR DESCRIPTION

## PR summary

We take advantage of AMReX-Codes/amrex#1441 to allow the user to specify a tagging threshold that can vary by level. If a value for every level is not provided, we assume the last value holds for all remaining levels, similar to how we treat quantities like amr.n_error_buf.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
