### PR TITLE
Fix namelist for ambient parameters in wdmerger_collision

### DIFF
--- a/Exec/science/wdmerger/tests/wdmerger_collision/probin_2d_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/probin_2d_collision
@@ -10,10 +10,7 @@
 
   interp_temp = T
 
-  ambient_density = 1.0d-4
-
   stellar_temp = 1.0d7
-  ambient_temp = 1.0d7
 
   orbital_eccentricity = 0.0d0
   orbital_angle = 0.0d0
@@ -38,6 +35,13 @@
   initial_model_npts = 4096
   initial_model_mass_tol = 1.d-6
   initial_model_hse_tol = 1.d-10
+
+/
+
+&ambient
+
+  ambient_density = 1.0d-4
+  ambient_temp = 1.0d7
 
 /
 


### PR DESCRIPTION

## PR summary


## PR motivation

This setup must have been missed when we converted to the ambient namelist.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
