### PR TITLE
Allow retry to be skipped if starting density is too small 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+# 20.11
+
+   * A new option, `castro.retry_small_density_cutoff`, has been added. In some
+     cases a small or negative density retry may be triggered on an update that
+     moves a zone already close to small_dens just below it. This is not uncommon
+     for "ambient"/"fluff" material outside a star. Since these zones are not
+     dynamically important anyway, triggering a retry is unnecessary (and possibly
+     counterproductive, since it may require a very small timestep to avoid). By
+     setting this cutoff value appropriately, the retry will be skipped if the
+     density of the zone prior to the update was below the cutoff. (#1273)
+
 # 20.10
 
    * A new refinement scheme using the inputs file rather than the Fortran

--- a/Exec/science/wdmerger/inputs_2d
+++ b/Exec/science/wdmerger/inputs_2d
@@ -64,6 +64,9 @@ amr.compute_new_dt_on_regrid = 1
 # Use a retry if an advance violated our stability criteria
 castro.use_retry = 1
 
+# Skip retries for small density if the starting density was less than this threshold
+castro.retry_small_density_cutoff = 1.0e0
+
 ############################################################################################ 
 # Resolution, gridding and AMR
 ############################################################################################

--- a/Exec/science/wdmerger/inputs_3d
+++ b/Exec/science/wdmerger/inputs_3d
@@ -64,6 +64,9 @@ amr.compute_new_dt_on_regrid = 1
 # Use a retry if an advance violated our stability criteria
 castro.use_retry = 1
 
+# Skip retries for small density if the starting density was less than this threshold
+castro.retry_small_density_cutoff = 1.0e0
+
 ############################################################################################ 
 # Resolution, gridding and AMR
 ############################################################################################

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -328,6 +328,10 @@ use_retry                    int           1
 # timestep by when trying again.
 retry_subcycle_factor        Real          0.5
 
+# Skip retries for small (or negative) density if the zone's density prior
+# to the update was below this threshold.
+retry_small_density_cutoff   Real         -1.e200
+
 # Regrid after every timestep.
 use_post_step_regrid         int           0
 


### PR DESCRIPTION

## PR summary

A new option, `castro.retry_small_density_cutoff`, has been added. In some cases a small or negative density retry may be triggered on an update that moves a zone already close to small_dens just below it. This is not uncommon for "ambient"/"fluff" material outside a star. Since these zones are not dynamically important anyway, triggering a retry is unnecessary (and possibly counterproductive, since it may require a very small timestep to avoid). By setting this cutoff value appropriately, the retry will be skipped if the density of the zone prior to the update was below the cutoff. The zone will be reset using the standard approach in enforce_min_dens.

## PR motivation

This is done in conjunction with #1272, which provides us the necessary data for making this determination. I have observed that the WD collision problem can get into situations where densities just above small_dens get pushed just below it. It's very hard to fix this problem with a smaller dt, since the difference between the starting and ending densities may be very small already in absolute terms. So the problem setup can crash after hitting too many retry subcycles. Since we don't care about zones near small_dens anyway, it is more efficient to just skip the retry in that case and let clean_state handle it.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
