### PR TITLE
Bump up minimum C++ standard to C++14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # 20.11
 
+   * The minimum C++ standard supported by Castro is now C++14. Most modern compilers
+     support C++14; the notable exception is RHEL 7 and its derivatives like CentOS 7,
+     where the default compiler is gcc 4.8. In that case a newer compiler must be loaded,
+     particularly a version of gcc >= 5.0, for example by installing devtoolset-7 or (if
+     running on an HPC cluster that provides modules) using a more recent gcc module. (#1284)
+
    * A new option, `castro.retry_small_density_cutoff`, has been added. In some
      cases a small or negative density retry may be triggered on an update that
      moves a zone already close to small_dens just below it. This is not uncommon

--- a/Docs/source/getting_started.rst
+++ b/Docs/source/getting_started.rst
@@ -14,7 +14,7 @@ Getting Started
 The compilation process is managed by AMReX and its build system.  The
 general requirements to build Castro are:
 
- * A C++ 11 (or later) compiler
+ * A C++14 (or later) compiler (e.g. gcc >= 5.0)
 
  * A Fortran 20xx compiler
 

--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -51,6 +51,26 @@ endif
 # Require C++14
 CXXSTD := c++14
 
+# Implement any machine-specific workarounds.
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.machines
+
+# On Summit if we have the PGI module loaded then we cannot simultaneously
+# have the gcc module loaded, which means we are stuck with the system
+# default (gcc 4.8.5). Since CUDA builds use gcc as the host compiler,
+# we would be prevented from using C++14. To work around this, if we're
+# using CUDA, then we reset the C++ host compiler to a known good
+# version of gcc on the system.
+
+ifeq ($(which_computer),summit)
+  ifeq ($(USE_CUDA),TRUE)
+    SUMMIT_GCC_OVERRIDE_DIR := /sw/summit/gcc/7.4.0
+    NVCC_CCBIN := $(SUMMIT_GCC_OVERRIDE_DIR)/bin/g++
+    LIBRARY_LOCATIONS += $(SUMMIT_GCC_OVERRIDE_DIR)/lib64
+    LIBRARIES += -Wl,-rpath,$(SUMMIT_GCC_OVERRIDE_DIR)/lib64
+  endif
+endif
+
 # default integrator
 INTEGRATOR_DIR ?= VODE
 

--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -48,6 +48,9 @@ ifeq ("$(wildcard $(AMREX_HOME)/Tools/GNUMake/Make.defs)","")
   $(error AMReX has not been downloaded. Please run "git submodule update --init" from the top level of the code)
 endif
 
+# Require C++14
+CXXSTD := c++14
+
 # default integrator
 INTEGRATOR_DIR ?= VODE
 


### PR DESCRIPTION

## PR summary

C++14 is now required as the minimum C++ standard. This should cause no changes except for RHEL 7/CentOS 7 systems where users will be required to use a more recent gcc than the system default.

## PR motivation

This will support some C++14 constructs we want to add to Microphysics.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
