### PR TITLE
Fix rotating_star compilation for non-NSE

### DIFF
--- a/Exec/science/rotating_star/Prob_nd.F90
+++ b/Exec/science/rotating_star/Prob_nd.F90
@@ -69,8 +69,8 @@ subroutine ca_initdata(level, time, lo, hi, nscal, &
   use eos_type_module
   use amrex_constants_module, only : ZERO, HALF, ONE, TWO
   use amrex_fort_module, only : rt => amrex_real
-#ifdef NSE_THERMO
   use burn_type_module
+#ifdef NSE_THERMO
   use nse_check_module
   use nse_module, only: nse_interp
 #endif


### PR DESCRIPTION
## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
