### PR TITLE
Convert tagging routines to C++

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3331,10 +3331,10 @@ Castro::apply_tagging_func(TagBoxArray& tags, Real time, int jcomp)
     {
         const Box& bx = mfi.tilebox();
 
-        auto datfab = (*mf).array(mfi);
-        auto tagfab = tags.array(mfi);
+        const auto dat = (*mf).array(mfi);
+        auto tag = tags.array(mfi);
 
-        const int ncomp = datfab.nComp();
+        const int ncomp = dat.nComp();
 
         const int8_t tagval   = (int8_t) TagBox::SET;
         const int8_t clearval = (int8_t) TagBox::CLEAR;
@@ -3342,83 +3342,205 @@ Castro::apply_tagging_func(TagBoxArray& tags, Real time, int jcomp)
         int lev = level;
 
         if (err_list_names[jcomp] == "density") {
+            Real denerr, dengrad, dengrad_rel;
+            int max_denerr_lev, max_dengrad_lev, max_dengrad_rel_lev;
+
+            get_denerr_params(&denerr, &max_denerr_lev,
+                              &dengrad, &max_dengrad_lev,
+                              &dengrad_rel, &max_dengrad_rel_lev);
+
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
             {
-                ca_denerror(i, j, k,
-                            (int8_t*) AMREX_ARR4_TO_FORTRAN_ANYD(tagfab),
-                            AMREX_ARR4_TO_FORTRAN_ANYD(datfab), ncomp,
-                            AMREX_ZFILL(dx.data()), AMREX_ZFILL(problo.data()),
-                            tagval, clearval, time, lev);
+                // Tag on regions of high density
+                if (lev < max_denerr_lev) {
+                    if (dat(i,j,k,0) >= denerr) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
+
+                // Tag on regions of high density gradient
+                if (lev < max_dengrad_lev || lev < max_dengrad_rel_lev) {
+                    Real ax = std::abs(dat(i+1*dg0,j,k,0) - dat(i,j,k,0));
+                    Real ay = std::abs(dat(i,j+1*dg1,k,0) - dat(i,j,k,0));
+                    Real az = std::abs(dat(i,j,k+1*dg2,0) - dat(i,j,k,0));
+                    ax = amrex::max(ax, std::abs(dat(i,j,k,0) - dat(i-1*dg0,j,k,0)));
+                    ay = amrex::max(ay, std::abs(dat(i,j,k,0) - dat(i,j-1*dg1,k,0)));
+                    az = amrex::max(az, std::abs(dat(i,j,k,0) - dat(i,j,k-1*dg2,0)));
+
+                    if (amrex::max(ax, ay, az) >= dengrad || amrex::max(ax, ay, az) >= std::abs(dengrad_rel * dat(i,j,k,0))) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
             });
         }
         else if (err_list_names[jcomp] == "Temp") {
+            Real temperr, tempgrad, tempgrad_rel;
+            int max_temperr_lev, max_tempgrad_lev, max_tempgrad_rel_lev;
+
+            get_temperr_params(&temperr, &max_temperr_lev,
+                               &tempgrad, &max_tempgrad_lev,
+                               &tempgrad_rel, &max_tempgrad_rel_lev);
+
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
             {
-                ca_temperror(i, j, k,
-                             (int8_t*) AMREX_ARR4_TO_FORTRAN_ANYD(tagfab),
-                             AMREX_ARR4_TO_FORTRAN_ANYD(datfab), ncomp,
-                             AMREX_ZFILL(dx.data()), AMREX_ZFILL(problo.data()),
-                             tagval, clearval, time, lev);
+                // Tag on regions of high temperature
+                if (lev < max_temperr_lev) {
+                    if (dat(i,j,k,0) >= temperr) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
+
+                // Tag on regions of high temperature gradient
+                if (lev < max_tempgrad_lev || lev < max_tempgrad_rel_lev) {
+                    Real ax = std::abs(dat(i+1*dg0,j,k,0) - dat(i,j,k,0));
+                    Real ay = std::abs(dat(i,j+1*dg1,k,0) - dat(i,j,k,0));
+                    Real az = std::abs(dat(i,j,k+1*dg2,0) - dat(i,j,k,0));
+                    ax = amrex::max(ax,std::abs(dat(i,j,k,0) - dat(i-1*dg0,j,k,0)));
+                    ay = amrex::max(ay,std::abs(dat(i,j,k,0) - dat(i,j-1*dg1,k,0)));
+                    az = amrex::max(az,std::abs(dat(i,j,k,0) - dat(i,j,k-1*dg2,0)));
+                    if (amrex::max(ax, ay, az) >= tempgrad || amrex::max(ax, ay, az) >= std::abs(tempgrad_rel * dat(i,j,k,0))) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
             });
         }
         else if (err_list_names[jcomp] == "pressure") {
+            Real presserr, pressgrad, pressgrad_rel;
+            int max_presserr_lev, max_pressgrad_lev, max_pressgrad_rel_lev;
+
+            get_presserr_params(&presserr, &max_presserr_lev,
+                                &pressgrad, &max_pressgrad_lev,
+                                &pressgrad_rel, &max_pressgrad_rel_lev);
+
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {                
-                ca_presserror(i, j, k,
-                              (int8_t*) AMREX_ARR4_TO_FORTRAN_ANYD(tagfab),
-                              AMREX_ARR4_TO_FORTRAN_ANYD(datfab), ncomp,
-                              AMREX_ZFILL(dx.data()), AMREX_ZFILL(problo.data()),
-                              tagval, clearval, time, lev);
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            {
+                // Tag on regions of high pressure
+                if (lev < max_presserr_lev) {
+                    if (dat(i,j,k,0) >= presserr) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
+
+                // Tag on regions of high pressure gradient
+                if (lev < max_pressgrad_lev || lev < max_pressgrad_rel_lev) {
+                    Real ax = std::abs(dat(i+1*dg0,j,k,0) - dat(i,j,k,0));
+                    Real ay = std::abs(dat(i,j+1*dg1,k,0) - dat(i,j,k,0));
+                    Real az = std::abs(dat(i,j,k+1*dg2,0) - dat(i,j,k,0));
+                    ax = amrex::max(ax,std::abs(dat(i,j,k,0) - dat(i-1*dg0,j,k,0)));
+                    ay = amrex::max(ay,std::abs(dat(i,j,k,0) - dat(i,j-1*dg1,k,0)));
+                    az = amrex::max(az,std::abs(dat(i,j,k,0) - dat(i,j,k-1*dg2,0)));
+                    if (amrex::max(ax,ay,az) >= pressgrad || amrex::max(ax,ay,az) >= std::abs(pressgrad_rel * dat(i,j,k,0))) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
             });
         }
         else if (err_list_names[jcomp] == "x_velocity" || err_list_names[jcomp] == "y_velocity" || err_list_names[jcomp] == "z_velocity") {
+            Real velerr, velgrad, velgrad_rel;
+            int max_velerr_lev, max_velgrad_lev, max_velgrad_rel_lev;
+
+            get_velerr_params(&velerr, &max_velerr_lev,
+                              &velgrad, &max_velgrad_lev,
+                              &velgrad_rel, &max_velgrad_rel_lev);
+
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
             {
-                ca_velerror(i, j, k,
-                            (int8_t*) AMREX_ARR4_TO_FORTRAN_ANYD(tagfab),
-                            AMREX_ARR4_TO_FORTRAN_ANYD(datfab), ncomp,
-                            AMREX_ZFILL(dx.data()), AMREX_ZFILL(problo.data()),
-                            tagval, clearval, time, lev);
+                // Tag on regions of high velocity
+                if (lev < max_velerr_lev) {
+                    if (std::abs(dat(i,j,k,0)) >= velerr) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
+
+                // Tag on regions of high velocity gradient
+                if (lev < max_velgrad_lev || lev < max_velgrad_rel_lev) {
+                    Real ax = std::abs(dat(i+1*dg0,j,k,0) - dat(i,j,k,0));
+                    Real ay = std::abs(dat(i,j+1*dg1,k,0) - dat(i,j,k,0));
+                    Real az = std::abs(dat(i,j,k+1*dg2,0) - dat(i,j,k,0));
+                    ax = amrex::max(ax,std::abs(dat(i,j,k,0) - dat(i-1*dg0,j,k,0)));
+                    ay = amrex::max(ay,std::abs(dat(i,j,k,0) - dat(i,j-1*dg1,k,0)));
+                    az = amrex::max(az,std::abs(dat(i,j,k,0) - dat(i,j,k-1*dg2,0)));
+                    if (amrex::max(ax,ay,az) >= velgrad || amrex::max(ax,ay,az) >= std::abs(velgrad_rel * dat(i,j,k,0))) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
             });
         }
 #ifdef REACTIONS
         else if (err_list_names[jcomp] == "t_sound_t_enuc") {
+            Real dxnuc_min, dxnuc_max;
+            int max_dxnuc_lev;
+
+            get_dxnuc_params(&dxnuc_min, &dxnuc_max, &max_dxnuc_lev);
+
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
             {
-                ca_nucerror(i, j, k,
-                            (int8_t*) AMREX_ARR4_TO_FORTRAN_ANYD(tagfab),
-                            AMREX_ARR4_TO_FORTRAN_ANYD(datfab), ncomp,
-                            AMREX_ZFILL(dx.data()), AMREX_ZFILL(problo.data()),
-                            tagval, clearval, time, lev);
+                // Disable if we're not utilizing this tagging
+
+                if (dxnuc_min > 1.e199_rt) return;
+
+                if (lev < max_dxnuc_lev) {
+                    if (dat(i,j,k,0) > dxnuc_min && dat(i,j,k,0) < dxnuc_max) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
             });
         }
         else if (err_list_names[jcomp] == "enuc") {
+            Real enucerr;
+            int max_enucerr_lev;
+
+            get_enuc_params(&enucerr, &max_enucerr_lev);
+
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
             {
-                ca_enucerror(i, j, k,
-                             (int8_t*) AMREX_ARR4_TO_FORTRAN_ANYD(tagfab),
-                             AMREX_ARR4_TO_FORTRAN_ANYD(datfab), ncomp,
-                             AMREX_ZFILL(dx.data()), AMREX_ZFILL(problo.data()),
-                             tagval, clearval, time, lev);
+                // Tag on regions of high nuclear energy generation rate
+
+                if (lev < max_enucerr_lev) {
+                    if (dat(i,j,k,0) >= enucerr) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
             });
         }
 #endif
 #ifdef RADIATION
         else if (err_list_names[jcomp] == "rad") {
+            Real raderr, radgrad, radgrad_rel;
+            int max_raderr_lev, max_radgrad_lev, max_radgrad_rel_lev;
+
+            get_raderr_params(&raderr, &max_raderr_lev,
+                              &radgrad, &max_radgrad_lev,
+                              &radgrad_rel, &max_radgrad_rel_lev);
+
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
             {
-                ca_raderror(i, j, k,
-                            (int8_t*) AMREX_ARR4_TO_FORTRAN_ANYD(tagfab),
-                            AMREX_ARR4_TO_FORTRAN_ANYD(datfab), ncomp,
-                            AMREX_ZFILL(dx.data()), AMREX_ZFILL(problo.data()),
-                            tagval, clearval, time, lev);
+                // Tag on regions of high radiation
+                if (lev < max_raderr_lev) {
+                    if (dat(i,j,k,0) >= raderr) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
+
+                // Tag on regions of high radiation gradient
+                if (lev < max_radgrad_lev || lev < max_radgrad_rel_lev) {
+                    Real ax = std::abs(dat(i+1*dg0,j,k,0) - dat(i,j,k,0));
+                    Real ay = std::abs(dat(i,j+1*dg1,k,0) - dat(i,j,k,0));
+                    Real az = std::abs(dat(i,j,k+1*dg2,0) - dat(i,j,k,0));
+                    ax = amrex::max(ax,std::abs(dat(i,j,k,0) - dat(i-1*dg0,j,k,0)));
+                    ay = amrex::max(ay,std::abs(dat(i,j,k,0) - dat(i,j-1*dg1,k,0)));
+                    az = amrex::max(az,std::abs(dat(i,j,k,0) - dat(i,j,k-1*dg2,0)));
+                    if (amrex::max(ax,ay,az) >= radgrad || amrex::max(ax,ay,az) >= std::abs(radgrad_rel * dat(i,j,k,0))) {
+                        tag(i,j,k) = TagBox::SET;
+                    }
+                }
             });
         }
 #endif

--- a/Source/driver/Castro_error_F.H
+++ b/Source/driver/Castro_error_F.H
@@ -81,6 +81,37 @@ extern "C"
      const int8_t tagval, const int8_t clearval,
      const amrex::Real time, const int level);
 
+  void get_denerr_params
+    (amrex::Real* denerr, int* max_denerr_lev,
+     amrex::Real* dengrad, int* max_dengrad_lev,
+     amrex::Real* dengrad_rel, int* max_dengrad_rel_lev);
+
+  void get_temperr_params
+    (amrex::Real* temperr, int* max_temperr_lev,
+     amrex::Real* tempgrad, int* max_tempgrad_lev,
+     amrex::Real* tempgrad_rel, int* max_tempgrad_rel_lev);
+
+  void get_velerr_params
+    (amrex::Real* velerr, int* max_velerr_lev,
+     amrex::Real* velgrad, int* max_velgrad_lev,
+     amrex::Real* velgrad_rel, int* max_velgrad_rel_lev);
+
+  void get_presserr_params
+    (amrex::Real* presserr, int* max_presserr_lev,
+     amrex::Real* pressgrad, int* max_pressgrad_lev,
+     amrex::Real* pressgrad_rel, int* max_pressgrad_rel_lev);
+
+  void get_raderr_params
+    (amrex::Real* raderr, int* max_raderr_lev,
+     amrex::Real* radgrad, int* max_radgrad_lev,
+     amrex::Real* radgrad_rel, int* max_radgrad_rel_lev);
+
+  void get_dxnuc_params
+    (amrex::Real* dxnuc_min, amrex::Real* dxnuc_max, int* max_dxnuc_lev);
+
+  void get_enuc_params
+    (amrex::Real* enucerr, int* max_enucerr_lev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/driver/Tagging_nd.F90
+++ b/Source/driver/Tagging_nd.F90
@@ -1,8 +1,6 @@
 module tagging_module
 
   use amrex_fort_module, only : rt => amrex_real
-  use iso_c_binding, only : c_int8_t
-
 
   implicit none
 
@@ -38,530 +36,137 @@ module tagging_module
 
   public
 
-#ifdef AMREX_USE_CUDA
-  attributes(managed) ::    denerr,   dengrad, dengrad_rel
-  attributes(managed) ::    velerr,   velgrad, velgrad_rel
-  attributes(managed) ::   temperr,  tempgrad, tempgrad_rel
-  attributes(managed) ::  presserr, pressgrad, pressgrad_rel
-  attributes(managed) ::    raderr,   radgrad, radgrad_rel
-  attributes(managed) ::   enucerr
-
-  attributes(managed) ::  max_denerr_lev,   max_dengrad_lev, max_dengrad_rel_lev
-  attributes(managed) ::  max_velerr_lev,   max_velgrad_lev, max_velgrad_rel_lev
-  attributes(managed) ::  max_temperr_lev,  max_tempgrad_lev, max_tempgrad_rel_lev
-  attributes(managed) ::  max_presserr_lev, max_pressgrad_lev, max_pressgrad_rel_lev
-  attributes(managed) ::  max_raderr_lev,   max_radgrad_lev, max_radgrad_rel_lev
-  attributes(managed) ::  max_enucerr_lev
-
-  attributes(managed) :: dxnuc_min
-  attributes(managed) :: dxnuc_max
-  attributes(managed) :: max_dxnuc_lev
-#endif
-
 contains
 
-  AMREX_CUDA_FORT_DEVICE subroutine ca_denerror(i, j, k, &
-                                                tag, taglo, taghi, &
-                                                den, denlo, denhi, nd, &
-                                                delta, problo, &
-                                                set, clear, time, level) &
-                                                bind(C, name="ca_denerror")
-     !
-     ! This routine will tag high error cells based on the density
-     !
-
-    use prob_params_module, only: dg
+  subroutine get_denerr_params(denerr_out, max_denerr_lev_out, &
+                               dengrad_out, max_dengrad_lev_out, &
+                               dengrad_rel_out, max_dengrad_rel_lev_out) &
+                               bind(c, name='get_denerr_params')
 
     implicit none
 
-    integer,    intent(in   ), value :: i, j, k
-    integer,    intent(in   ) :: taglo(3), taghi(3)
-    integer,    intent(in   ) :: denlo(3), denhi(3)
-    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    real(rt),   intent(in   ) :: den(denlo(1):denhi(1),denlo(2):denhi(2),denlo(3):denhi(3),nd)
-    real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(kind=c_int8_t), intent(in   ), value :: set, clear
-    integer,    intent(in   ), value :: nd, level
-    real(rt),   intent(in   ), value :: time
+    real(rt), intent(out) :: denerr_out, dengrad_out, dengrad_rel_out
+    integer, intent(out) :: max_denerr_lev_out, max_dengrad_lev_out, max_dengrad_rel_lev_out
 
-    real(rt) :: ax, ay, az
+    denerr_out = denerr
+    dengrad_out = dengrad
+    dengrad_rel_out = dengrad_rel
 
-    !     Tag on regions of high density
-    if (level .lt. max_denerr_lev) then
-       if (den(i,j,k,1) .ge. denerr) then
-          tag(i,j,k) = set
-       endif
-    endif
+    max_denerr_lev_out = max_denerr_lev
+    max_dengrad_lev_out = max_dengrad_lev
+    max_dengrad_rel_lev_out = max_dengrad_rel_lev
 
-    !     Tag on regions of high density gradient
-    if (level .lt. max_dengrad_lev .or. level .lt. max_dengrad_rel_lev) then
-       ax = ABS(den(i+1*dg(1),j,k,1) - den(i,j,k,1))
-       ay = ABS(den(i,j+1*dg(2),k,1) - den(i,j,k,1))
-       az = ABS(den(i,j,k+1*dg(3),1) - den(i,j,k,1))
-       ax = MAX(ax,ABS(den(i,j,k,1) - den(i-1*dg(1),j,k,1)))
-       ay = MAX(ay,ABS(den(i,j,k,1) - den(i,j-1*dg(2),k,1)))
-       az = MAX(az,ABS(den(i,j,k,1) - den(i,j,k-1*dg(3),1)))
-       if (MAX(ax,ay,az) .ge. dengrad .or. MAX(ax,ay,az) .ge. ABS(dengrad_rel * den(i,j,k,1))) then
-          tag(i,j,k) = set
-       endif
-    endif
+  end subroutine get_denerr_params
 
-  end subroutine ca_denerror
-
-
-
-  AMREX_CUDA_FORT_DEVICE subroutine ca_temperror(i, j, k, &
-                                                 tag, taglo, taghi, &
-                                                 temp, templo, temphi, np, &
-                                                 delta, problo, &
-                                                 set, clear, time, level) &
-                                                 bind(C, name="ca_temperror")
-  !
-  ! This routine will tag high error cells based on the temperature
-  !
-
-    use prob_params_module, only: dg
+  subroutine get_velerr_params(velerr_out, max_velerr_lev_out, &
+                               velgrad_out, max_velgrad_lev_out, &
+                               velgrad_rel_out, max_velgrad_rel_lev_out) &
+                               bind(c, name='get_velerr_params')
 
     implicit none
 
-    integer,    intent(in   ), value :: i, j, k
-    integer,    intent(in   ) :: taglo(3), taghi(3)
-    integer,    intent(in   ) :: templo(3), temphi(3)
-    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    real(rt),   intent(in   ) :: temp(templo(1):temphi(1),templo(2):temphi(2),templo(3):temphi(3),np)
-    real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(kind=c_int8_t), intent(in   ), value :: set, clear
-    integer,    intent(in   ), value :: np, level
-    real(rt),   intent(in   ), value :: time
+    real(rt), intent(out) :: velerr_out, velgrad_out, velgrad_rel_out
+    integer, intent(out) :: max_velerr_lev_out, max_velgrad_lev_out, max_velgrad_rel_lev_out
 
-    real(rt) :: ax, ay, az
+    velerr_out = velerr
+    velgrad_out = velgrad
+    velgrad_rel_out = velgrad_rel
 
-    !     Tag on regions of high temperature
-    if (level .lt. max_temperr_lev) then
-       if (temp(i,j,k,1) .ge. temperr) then
-          tag(i,j,k) = set
-       endif
-    endif
+    max_velerr_lev_out = max_velerr_lev
+    max_velgrad_lev_out = max_velgrad_lev
+    max_velgrad_rel_lev_out = max_velgrad_rel_lev
 
-    !     Tag on regions of high temperature gradient
-    if (level .lt. max_tempgrad_lev .or. level .lt. max_tempgrad_rel_lev) then
-       ax = ABS(temp(i+1*dg(1),j,k,1) - temp(i,j,k,1))
-       ay = ABS(temp(i,j+1*dg(2),k,1) - temp(i,j,k,1))
-       az = ABS(temp(i,j,k+1*dg(3),1) - temp(i,j,k,1))
-       ax = MAX(ax,ABS(temp(i,j,k,1) - temp(i-1*dg(1),j,k,1)))
-       ay = MAX(ay,ABS(temp(i,j,k,1) - temp(i,j-1*dg(2),k,1)))
-       az = MAX(az,ABS(temp(i,j,k,1) - temp(i,j,k-1*dg(3),1)))
-       if (MAX(ax,ay,az) .ge. tempgrad .or. MAX(ax,ay,az) .ge. ABS(tempgrad_rel * temp(i,j,k,1))) then
-          tag(i,j,k) = set
-       endif
-    endif
+  end subroutine get_velerr_params
 
-  end subroutine ca_temperror
-
-
-
-  AMREX_CUDA_FORT_DEVICE subroutine ca_presserror(i, j, k, &
-                                                  tag, taglo, taghi, &
-                                                  press, presslo, presshi, np, &
-                                                  delta, problo, &
-                                                  set, clear, time, level) &
-                                                  bind(C, name="ca_presserror")
-   !
-   ! This routine will tag high error cells based on the pressure
-   !
-
-    use prob_params_module, only: dg
-    use amrex_fort_module, only: rt => amrex_real
+  subroutine get_temperr_params(temperr_out, max_temperr_lev_out, &
+                                tempgrad_out, max_tempgrad_lev_out, &
+                                tempgrad_rel_out, max_tempgrad_rel_lev_out) &
+                                bind(c, name='get_temperr_params')
 
     implicit none
 
-    integer,    intent(in   ), value :: i, j, k
-    integer,    intent(in   ) :: taglo(3), taghi(3)
-    integer,    intent(in   ) :: presslo(3), presshi(3)
-    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    real(rt),   intent(in   ) :: press(presslo(1):presshi(1),presslo(2):presshi(2),presslo(3):presshi(3),np)
-    real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(kind=c_int8_t), intent(in   ), value :: set, clear
-    integer,    intent(in   ), value :: np, level
-    real(rt),   intent(in   ), value :: time
+    real(rt), intent(out) :: temperr_out, tempgrad_out, tempgrad_rel_out
+    integer, intent(out) :: max_temperr_lev_out, max_tempgrad_lev_out, max_tempgrad_rel_lev_out
 
-    real(rt) :: ax, ay, az
+    temperr_out = temperr
+    tempgrad_out = tempgrad
+    tempgrad_rel_out = tempgrad_rel
 
-    !     Tag on regions of high pressure
-    if (level .lt. max_presserr_lev) then
-       if (press(i,j,k,1) .ge. presserr) then
-          tag(i,j,k) = set
-       endif
-    endif
+    max_temperr_lev_out = max_temperr_lev
+    max_tempgrad_lev_out = max_tempgrad_lev
+    max_tempgrad_rel_lev_out = max_tempgrad_rel_lev
 
-    !     Tag on regions of high pressure gradient
-    if (level .lt. max_pressgrad_lev .or. level .lt. max_pressgrad_rel_lev) then
-       ax = ABS(press(i+1*dg(1),j,k,1) - press(i,j,k,1))
-       ay = ABS(press(i,j+1*dg(2),k,1) - press(i,j,k,1))
-       az = ABS(press(i,j,k+1*dg(3),1) - press(i,j,k,1))
-       ax = MAX(ax,ABS(press(i,j,k,1) - press(i-1*dg(1),j,k,1)))
-       ay = MAX(ay,ABS(press(i,j,k,1) - press(i,j-1*dg(2),k,1)))
-       az = MAX(az,ABS(press(i,j,k,1) - press(i,j,k-1*dg(3),1)))
-       if (MAX(ax,ay,az) .ge. pressgrad .or. MAX(ax,ay,az) .ge. ABS(pressgrad_rel * press(i,j,k,1))) then
-          tag(i,j,k) = set
-       endif
-    endif
+  end subroutine get_temperr_params
 
-  end subroutine ca_presserror
-
-
-
-  AMREX_CUDA_FORT_DEVICE subroutine ca_velerror(i, j, k, &
-                                                tag, taglo, taghi, &
-                                                vel, vello, velhi, nv, &
-                                                delta, problo, &
-                                                set, clear, time, level) &
-                                                bind(C, name="ca_velerror")
-    !
-    ! This routine will tag high error cells based on the velocity
-    !
-
-    use prob_params_module, only: dg
+  subroutine get_presserr_params(presserr_out, max_presserr_lev_out, &
+                                 pressgrad_out, max_pressgrad_lev_out, &
+                                 pressgrad_rel_out, max_pressgrad_rel_lev_out) &
+                                 bind(c, name='get_presserr_params')
 
     implicit none
 
-    integer,    intent(in   ), value :: i, j, k
-    integer,    intent(in   ) :: taglo(3), taghi(3)
-    integer,    intent(in   ) :: vello(3), velhi(3)
-    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    real(rt),   intent(in   ) :: vel(vello(1):velhi(1),vello(2):velhi(2),vello(3):velhi(3),nv)
-    real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(kind=c_int8_t), intent(in   ), value :: set, clear
-    integer,    intent(in   ), value :: nv, level
-    real(rt),   intent(in   ), value :: time
+    real(rt), intent(out) :: presserr_out, pressgrad_out, pressgrad_rel_out
+    integer, intent(out) :: max_presserr_lev_out, max_pressgrad_lev_out, max_pressgrad_rel_lev_out
 
-    real(rt) :: ax, ay, az
+    presserr_out = presserr
+    pressgrad_out = pressgrad
+    pressgrad_rel_out = pressgrad_rel
 
-    !     Tag on regions of high velocity
-    if (level .lt. max_velerr_lev) then
-       if (abs(vel(i,j,k,1)) .ge. velerr) then
-          tag(i,j,k) = set
-       endif
-    endif
+    max_presserr_lev_out = max_presserr_lev
+    max_pressgrad_lev_out = max_pressgrad_lev
+    max_pressgrad_rel_lev_out = max_pressgrad_rel_lev
 
-    !     Tag on regions of high velocity gradient
-    if (level .lt. max_velgrad_lev .or. level .lt. max_velgrad_rel_lev) then
-       ax = ABS(vel(i+1*dg(1),j,k,1) - vel(i,j,k,1))
-       ay = ABS(vel(i,j+1*dg(2),k,1) - vel(i,j,k,1))
-       az = ABS(vel(i,j,k+1*dg(3),1) - vel(i,j,k,1))
-       ax = MAX(ax,ABS(vel(i,j,k,1) - vel(i-1*dg(1),j,k,1)))
-       ay = MAX(ay,ABS(vel(i,j,k,1) - vel(i,j-1*dg(2),k,1)))
-       az = MAX(az,ABS(vel(i,j,k,1) - vel(i,j,k-1*dg(3),1)))
-       if (MAX(ax,ay,az) .ge. velgrad .or. MAX(ax,ay,az) .ge. ABS(velgrad_rel * vel(i,j,k,1))) then
-          tag(i,j,k) = set
-       endif
-    endif
+  end subroutine get_presserr_params
 
-  end subroutine ca_velerror
-
-
-
-  AMREX_CUDA_FORT_DEVICE subroutine ca_raderror(i, j, k, &
-                                                tag, taglo, taghi, &
-                                                rad, radlo, radhi, nr, &
-                                                delta, problo, &
-                                                set, clear, time, level) &
-                                                bind(C, name="ca_raderror")
-    !
-    ! This routine will tag high error cells based on the radiation
-    !
-
-    use prob_params_module, only: dg
+  subroutine get_raderr_params(raderr_out, max_raderr_lev_out, &
+                               radgrad_out, max_radgrad_lev_out, &
+                               radgrad_rel_out, max_radgrad_rel_lev_out) &
+                               bind(c, name='get_raderr_params')
 
     implicit none
 
-    integer,    intent(in   ), value :: i, j, k
-    integer,    intent(in   ) :: taglo(3), taghi(3)
-    integer,    intent(in   ) :: radlo(3), radhi(3)
-    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    real(rt),   intent(in   ) :: rad(radlo(1):radhi(1),radlo(2):radhi(2),radlo(3):radhi(3),nr)
-    real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(kind=c_int8_t), intent(in   ), value :: set, clear
-    integer,    intent(in   ), value :: nr, level
-    real(rt),   intent(in   ), value :: time
+    real(rt), intent(out) :: raderr_out, radgrad_out, radgrad_rel_out
+    integer, intent(out) :: max_raderr_lev_out, max_radgrad_lev_out, max_radgrad_rel_lev_out
 
-    real(rt) :: ax, ay, az
+    raderr_out = raderr
+    radgrad_out = radgrad
+    radgrad_rel_out = radgrad_rel
 
-    !     Tag on regions of high radiation
-    if (level .lt. max_raderr_lev) then
-       if (rad(i,j,k,1) .ge. raderr) then
-          tag(i,j,k) = set
-       endif
-    endif
+    max_raderr_lev_out = max_raderr_lev
+    max_radgrad_lev_out = max_radgrad_lev
+    max_radgrad_rel_lev_out = max_radgrad_rel_lev
 
-    !     Tag on regions of high radiation gradient
-    if (level .lt. max_radgrad_lev .or. level .lt. max_radgrad_rel_lev) then
-       ax = ABS(rad(i+1*dg(1),j,k,1) - rad(i,j,k,1))
-       ay = ABS(rad(i,j+1*dg(2),k,1) - rad(i,j,k,1))
-       az = ABS(rad(i,j,k+1*dg(3),1) - rad(i,j,k,1))
-       ax = MAX(ax,ABS(rad(i,j,k,1) - rad(i-1*dg(1),j,k,1)))
-       ay = MAX(ay,ABS(rad(i,j,k,1) - rad(i,j-1*dg(2),k,1)))
-       az = MAX(az,ABS(rad(i,j,k,1) - rad(i,j,k-1*dg(3),1)))
-       if (MAX(ax,ay,az) .ge. radgrad .or. MAX(ax,ay,az) .ge. ABS(radgrad_rel * rad(i,j,k,1))) then
-          tag(i,j,k) = set
-       endif
-    endif
+  end subroutine get_raderr_params
 
-  end subroutine ca_raderror
+  subroutine get_dxnuc_params(dxnuc_min_out, dxnuc_max_out, max_dxnuc_lev_out) &
+                              bind(c, name='get_dxnuc_params')
 
-
-
-#ifdef REACTIONS
-  AMREX_CUDA_FORT_DEVICE subroutine ca_nucerror(i, j, k, &
-                                                tag, taglo, taghi, &
-                                                t, tlo, thi, nr, &
-                                                delta, problo, &
-                                                set, clear, time, level) &
-                                                bind(C, name="ca_nucerror")
-    !
-    ! This routine will tag cells based on the sound crossing time
-    ! relative to the nuclear energy injection timescale.
-    !
 
     implicit none
 
-    integer,    intent(in   ), value :: i, j, k
-    integer,    intent(in   ) :: taglo(3), taghi(3)
-    integer,    intent(in   ) :: tlo(3), thi(3)
-    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    real(rt),   intent(in   ) :: t(tlo(1):thi(1),tlo(2):thi(2),tlo(3):thi(3),nr) ! t_sound / t_e
-    real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(kind=c_int8_t), intent(in   ), value :: set, clear
-    integer,    intent(in   ), value :: nr, level
-    real(rt),   intent(in   ), value :: time
+    real(rt), intent(out) :: dxnuc_min_out, dxnuc_max_out
+    integer, intent(out) :: max_dxnuc_lev_out
 
-    ! Disable if we're not utilizing this tagging
+    dxnuc_min_out = dxnuc_min
+    dxnuc_max_out = dxnuc_max
 
-    if (dxnuc_min > 1.e199_rt) return
+    max_dxnuc_lev_out = max_dxnuc_lev
 
-    if (level .lt. max_dxnuc_lev) then
-       if (t(i,j,k,1) > dxnuc_min .and. t(i,j,k,1) < dxnuc_max) then
-          tag(i,j,k) = set
-       endif
-    end if
+  end subroutine get_dxnuc_params
 
-  end subroutine ca_nucerror
+  subroutine get_enuc_params(enucerr_out, max_enucerr_lev_out) &
+                             bind(c, name='get_enuc_params')
 
-
-
-  AMREX_CUDA_FORT_DEVICE subroutine ca_enucerror(i, j, k, &
-                                                 tag, taglo, taghi, &
-                                                 enuc,enuclo,enuchi, nd, &
-                                                 delta, problo, &
-                                                 set, clear, time, level) &
-                                                 bind(C, name="ca_enucerror")
-    !
-    ! This routine will tag high error cells based on the nuclear
-    ! energy generation rate
-    !
 
     implicit none
 
-    integer,    intent(in   ), value :: i, j, k
-    integer,    intent(in   ) :: taglo(3), taghi(3)
-    integer,    intent(in   ) :: enuclo(3), enuchi(3)
-    integer(kind=c_int8_t), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
-    real(rt),   intent(in   ) :: enuc(enuclo(1):enuchi(1),enuclo(2):enuchi(2),enuclo(3):enuchi(3),nd)
-    real(rt),   intent(in   ) :: delta(3), problo(3)
-    integer(kind=c_int8_t), intent(in   ), value :: set, clear
-    integer,    intent(in   ), value :: nd, level
-    real(rt),   intent(in   ), value :: time
+    real(rt), intent(out) :: enucerr_out
+    integer, intent(out) :: max_enucerr_lev_out
 
-    ! Tag on regions of high nuclear energy generation rate
-    if (level .lt. max_enucerr_lev) then
-       if (enuc(i,j,k,1) .ge. enucerr) then
-          tag(i,j,k) = set
-       endif
-    endif
+    enucerr_out = enucerr
 
-  end subroutine ca_enucerror
-#endif
+    max_enucerr_lev_out = max_enucerr_lev
 
-
-
-  ! Routines for retrieving the maximum tagging level.
-
-  subroutine get_max_denerr_lev(lev) bind(c, name='get_max_denerr_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_denerr_lev
-
-  end subroutine get_max_denerr_lev
-
-
-
-  subroutine get_max_dengrad_lev(lev) bind(c, name='get_max_dengrad_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_dengrad_lev
-
-  end subroutine get_max_dengrad_lev
-
-
-
-  subroutine get_max_dengrad_rel_lev(lev) bind(c, name='get_max_dengrad_rel_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_dengrad_rel_lev
-
-  end subroutine get_max_dengrad_rel_lev
-
-
-
-  subroutine get_max_velerr_lev(lev) bind(c, name='get_max_velerr_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_velerr_lev
-
-  end subroutine get_max_velerr_lev
-
-
-
-  subroutine get_max_velgrad_lev(lev) bind(c, name='get_max_velgrad_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_velgrad_lev
-
-  end subroutine get_max_velgrad_lev
-
-
-
-  subroutine get_max_velgrad_rel_lev(lev) bind(c, name='get_max_velgrad_rel_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_velgrad_rel_lev
-
-  end subroutine get_max_velgrad_rel_lev
-
-
-
-  subroutine get_max_temperr_lev(lev) bind(c, name='get_max_temperr_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_temperr_lev
-
-  end subroutine get_max_temperr_lev
-
-
-
-  subroutine get_max_tempgrad_lev(lev) bind(c, name='get_max_tempgrad_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_tempgrad_lev
-
-  end subroutine get_max_tempgrad_lev
-
-
-
-  subroutine get_max_tempgrad_rel_lev(lev) bind(c, name='get_max_tempgrad_rel_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_tempgrad_rel_lev
-
-  end subroutine get_max_tempgrad_rel_lev
-
-
-
-  subroutine get_max_presserr_lev(lev) bind(c, name='get_max_presserr_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_presserr_lev
-
-  end subroutine get_max_presserr_lev
-
-
-
-  subroutine get_max_pressgrad_lev(lev) bind(c, name='get_max_pressgrad_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_pressgrad_lev
-
-  end subroutine get_max_pressgrad_lev
-
-
-
-  subroutine get_max_pressgrad_rel_lev(lev) bind(c, name='get_max_pressgrad_rel_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_pressgrad_rel_lev
-
-  end subroutine get_max_pressgrad_rel_lev
-
-
-
-  subroutine get_max_raderr_lev(lev) bind(c, name='get_max_raderr_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_raderr_lev
-
-  end subroutine get_max_raderr_lev
-
-
-
-  subroutine get_max_radgrad_lev(lev) bind(c, name='get_max_radgrad_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_radgrad_lev
-
-  end subroutine get_max_radgrad_lev
-
-
-
-  subroutine get_max_radgrad_rel_lev(lev) bind(c, name='get_max_radgrad_rel_lev')
-
-    implicit none
-
-    integer, intent(out) :: lev
-
-    lev = max_radgrad_rel_lev
-
-  end subroutine get_max_radgrad_rel_lev
+  end subroutine get_enuc_params
 
 end module tagging_module


### PR DESCRIPTION

## PR summary

For now the parameters continue to reside in Fortran so that user code does not break, so we use helper routines to bring the values of the module parameters over to C++.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
