### PR TITLE
Sync F90 parameters with C++ after C++ problem_initialize

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -574,6 +574,10 @@ Castro::Castro (Amr&            papa,
       // any changes are made to the problem parameters.
 
       problem_initialize();
+
+      // Sync Fortran back up with any changes we made to the problem parameters.
+      // If problem_initialize() didn't change them, this has no effect.
+      cxx_to_f90_prob_parameters();
     }
 
     initMFs();

--- a/Util/scripts/write_probdata.py
+++ b/Util/scripts/write_probdata.py
@@ -493,6 +493,8 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
 
         fout.write("  void init_{}_parameters();\n\n".format(os.path.basename(cxx_prefix)))
 
+        fout.write("  void cxx_to_f90_{}_parameters();\n\n".format(os.path.basename(cxx_prefix)))
+
         fout.write("  namespace problem {\n\n")
 
         for p in params:
@@ -553,6 +555,24 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
                     fout.write("    get_f90_{}(&problem::{});\n\n".format(p.var, p.var))
 
         fout.write("  }\n")
+
+        fout.write("\n")
+        fout.write("  void cxx_to_f90_{}_parameters() {{\n".format(os.path.basename(cxx_prefix)))
+        fout.write("    int slen = 0;\n\n")
+
+        for p in params:
+            if p.is_array() and p.has_module():
+                continue
+            if p.dtype == "logical" or p.dtype == "character":
+                continue
+
+            if p.is_array():
+                fout.write("    set_f90_{}(problem::{});\n\n".format(p.var, p.var))
+            else:
+                fout.write("    set_f90_{}(&problem::{});\n\n".format(p.var, p.var))
+
+        fout.write("  }\n")
+
 
 def main():
 


### PR DESCRIPTION

## PR summary

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
