### PR TITLE
Apply Poisson gravity tagging restriction to all setups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # 20.12
 
+   * For setups using Poisson gravity, tagging is now turned off in locations where
+     the fine levels would have been adjacent to a physical boundary. (This previously
+     led to an abort.) (#1302)
+
    * An interface for doing problem tagging in C++ has been added. (#1289)
 
    * Simplified SDC now only supports the C++ integrators (#1294)

--- a/Docs/source/AMR.rst
+++ b/Docs/source/AMR.rst
@@ -205,6 +205,12 @@ adjacent cells above which we refine), and ``field_name`` (name of the string
 defining the field in the code). If a refinement indicator is added, either
 ``value_greater``, ``value_less``, or ``gradient`` must be provided.
 
+.. note::
+
+   Zones adjacent to a physical boundary cannot be tagged for refinement when
+   using the Poisson gravity solver. If your tagging criteria are met in these
+   zones, they will be ignored.
+
 .. _sec:amr_synchronization:
 
 Synchronization Algorithm

--- a/Exec/science/wdmerger/problem_tagging_nd.F90
+++ b/Exec/science/wdmerger/problem_tagging_nd.F90
@@ -46,9 +46,6 @@ contains
     integer  :: i, j, k, n
     real(rt) :: loc(3), r, r_P, r_S
 
-    logical  :: outer_boundary_test(3)
-    integer  :: boundary_buf(3), idx(3)
-
     !$gpu
 
     do k = lo(3), hi(3)
@@ -140,45 +137,6 @@ contains
              ! Clear all tagging that occurs outside the radius set by max_tagging_radius.
 
              if (r .gt. max_tagging_radius * max(maxval(abs(problo-center)), maxval(abs(probhi-center)))) then
-
-                tag(i,j,k) = clear
-
-             endif
-
-             ! We must ensure that the outermost zones are untagged
-             ! due to the Poisson equation boundary conditions.
-             ! We currently do not know how to fill the boundary conditions
-             ! for fine levels that touch the physical boundary.
-             ! (Note that this does not apply for interior/symmetry boundaries.)
-             ! To do this properly we need to be aware of AMReX's strategy
-             ! for tagging, which is not cell-based, but rather chunk-based.
-             ! The size of the chunk on the coarse grid is given by
-             ! blocking_factor / ref_ratio -- the idea here being that
-             ! blocking_factor is the smallest possible group of cells on a
-             ! given level, so the smallest chunk of cells possible on the
-             ! coarse grid is given by that number divided by the refinement ratio.
-             ! So we cannot tag anything within that distance from the boundary.
-             ! Additionally we need to stay a further amount n_error_buf away,
-             ! since n_error_buf zones are always added as padding around
-             ! tagged zones.
-
-             outer_boundary_test = .false.
-             boundary_buf(1:dim) = n_error_buf(level) + blocking_factor(level+1) / ref_ratio(1:dim, level)
-             idx = [i, j, k]
-
-             do n = 1, dim
-
-                if ((physbc_lo(n) .ne. Symmetry) .and. (idx(n) .le. domlo_level(n, level) + boundary_buf(n))) then
-                   outer_boundary_test(n) = .true.
-                endif
-
-                if ((physbc_hi(n) .ne. Symmetry) .and. (idx(n) .ge. domhi_level(n, level) - boundary_buf(n))) then
-                   outer_boundary_test(n) = .true.
-                endif
-
-             enddo
-
-             if ( any(outer_boundary_test) ) then
 
                 tag(i,j,k) = clear
 

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -752,6 +752,15 @@ public:
 
 
 ///
+/// Apply any tagging restrictions that must be satisfied by all problems.
+///
+/// @param tags         TagBoxArray of tags
+/// @param time         current time
+///
+    void apply_tagging_restrictions (amrex::TagBoxArray& tags, amrex::Real time);
+
+
+///
 /// Apply a given tagging function.
 ///
 /// @param tags         TagBoxArray of tags

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3262,6 +3262,11 @@ Castro::errorEst (TagBoxArray& tags,
     // Now we'll tag any user-specified zones using the full state array.
 
     apply_problem_tags(tags, ltime);
+
+    // Finally we'll apply any tagging restrictions which must be obeyed by any setup.
+
+    apply_tagging_restrictions(tags, ltime);
+
 }
 
 
@@ -3318,6 +3323,89 @@ Castro::apply_problem_tags (TagBoxArray& tags, Real time)
         }
     }
 
+}
+
+
+
+void
+Castro::apply_tagging_restrictions(TagBoxArray& tags, Real time)
+{
+    BL_PROFILE("Castro::apply_tagging_restrictions()");
+
+    // If we are using Poisson gravity, we must ensure that the outermost zones are untagged
+    // due to the Poisson equation boundary conditions (we currently do not know how to fill
+    // the boundary conditions for fine levels that touch the physical boundary.)
+    // To do this properly we need to be aware of AMReX's strategy for tagging, which is not
+    // cell-based, but rather chunk-based. The size of the chunk on the coarse grid is given
+    // by blocking_factor / ref_ratio -- the idea here being that blocking_factor is the
+    // smallest possible group of cells on a given level, so the smallest chunk of cells
+    // possible on the coarse grid is given by that number divided by the refinement ratio.
+    // So we cannot tag anything within that distance from the boundary. Additionally we
+    // need to stay a further amount n_error_buf away, since n_error_buf zones are always
+    // added as padding around tagged zones.
+
+#ifdef GRAVITY
+    if (gravity::gravity_type == "PoissonGrav") {
+
+        int lev = level;
+
+        int n_error_buf[3] = {0};
+        int ref_ratio[3] = {0};
+        int domlo[3] = {0};
+        int domhi[3] = {0};
+        int physbc_lo[3] = {-1};
+        int physbc_hi[3] = {-1};
+        int blocking_factor[3] = {0};
+        for (int dim = 0; dim < AMREX_SPACEDIM; ++dim) {
+            n_error_buf[dim] = parent->nErrorBuf(lev, dim);
+            ref_ratio[dim] = parent->refRatio(lev)[dim];
+            domlo[dim] = geom.Domain().loVect()[dim];
+            domhi[dim] = geom.Domain().hiVect()[dim];
+            physbc_lo[dim] = phys_bc.lo()[dim];
+            physbc_hi[dim] = phys_bc.hi()[dim];
+            blocking_factor[dim] = parent->blockingFactor(lev)[dim];
+        }
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        for (MFIter mfi(tags); mfi.isValid(); ++mfi) {
+            const Box& bx = mfi.tilebox();
+
+            auto tag = tags[mfi].array();
+
+            amrex::ParallelFor(bx,
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            {
+                bool outer_boundary_test[3] = {false};
+
+                int idx[3] = {i, j, k};
+
+                for (int dim = 0; dim < AMREX_SPACEDIM; ++dim) {
+
+                    int boundary_buf = n_error_buf[dim] + blocking_factor[dim] / ref_ratio[dim];
+
+                    if ((physbc_lo[dim] != Symmetry && physbc_lo[dim] != Interior) &&
+                        (idx[dim] <= domlo[dim] + boundary_buf)) {
+                        outer_boundary_test[dim] = true;
+                    }
+
+                    if ((physbc_hi[dim] != Symmetry && physbc_lo[dim] != Interior) &&
+                        (idx[dim] >= domhi[dim] - boundary_buf)) {
+                        outer_boundary_test[dim] = true;
+                    }
+                }
+
+                if (outer_boundary_test[0] || outer_boundary_test[1] || outer_boundary_test[2]) {
+
+                    tag(i,j,k) = TagBox::CLEAR;
+
+                }
+            });
+        }
+
+    }
+#endif
 }
 
 


### PR DESCRIPTION

## PR summary

Poisson gravity doesn't have support for fine levels that touch the physical domain boundary (that is, the boundary is not either periodic or symmetric). This is enforced as an abort in the Poisson solver, but we can also do better by just preventing this from happening directly. This was already the case in wdmerger; this PR applies this across all problems that use Poisson gravity.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [x] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
