### PR TITLE
Remove wdmerger tagging capability based on distance from center

### DIFF
--- a/Exec/science/wdmerger/_prob_params
+++ b/Exec/science/wdmerger/_prob_params
@@ -193,10 +193,8 @@ tde_pericenter_radius           real                  0.0e0_rt                 n
 
 max_stellar_tagging_level       integer               20                       y
 max_temperature_tagging_level   integer               20                       y
-max_center_tagging_level        integer               20                       y
 stellar_density_threshold       real                  1.0e0_rt                 y
 temperature_tagging_threshold   real                  5.0e8_rt                 y
-center_tagging_radius           real                  0.0e0_rt                 y
 max_tagging_radius              real                  0.75e0_rt                y
 roche_tagging_factor            real                  2.0e0_rt                 y
 

--- a/Exec/science/wdmerger/probin
+++ b/Exec/science/wdmerger/probin
@@ -38,10 +38,8 @@
 
   max_stellar_tagging_level = 20
   max_temperature_tagging_level = 0
-  max_center_tagging_level = 0
   stellar_density_threshold = 1.0d0
   temperature_tagging_threshold = 5.0d8
-  center_tagging_radius = 0.0d0
   max_tagging_radius = 0.75d0
   roche_tagging_factor = 2.0d0
 

--- a/Exec/science/wdmerger/problem_tagging_nd.F90
+++ b/Exec/science/wdmerger/problem_tagging_nd.F90
@@ -123,6 +123,8 @@ contains
 
              ! Clear all tagging that occurs outside the radius set by max_tagging_radius.
 
+             r = ( sum((loc-center)**2) )**HALF
+
              if (r .gt. max_tagging_radius * max(maxval(abs(problo-center)), maxval(abs(probhi-center)))) then
 
                 tag(i,j,k) = clear

--- a/Exec/science/wdmerger/problem_tagging_nd.F90
+++ b/Exec/science/wdmerger/problem_tagging_nd.F90
@@ -23,11 +23,9 @@ contains
     use probdata_module, only: max_tagging_radius, &
                                max_stellar_tagging_level, &
                                max_temperature_tagging_level, &
-                               max_center_tagging_level, &
                                roche_tagging_factor, &
                                stellar_density_threshold, &
                                temperature_tagging_threshold, &
-                               center_tagging_radius, &
                                com_P, com_S, roche_rad_P, roche_rad_S, &
                                problem
 
@@ -116,20 +114,6 @@ contains
              if (level < max_temperature_tagging_level) then
 
                 if (state(i,j,k,UTEMP) > temperature_tagging_threshold) then
-
-                   tag(i,j,k) = set
-
-                endif
-
-             endif
-
-             ! Tag all zones within a specified distance from the center.
-
-             r = ( sum((loc-center)**2) )**HALF
-
-             if (level < max_center_tagging_level) then
-
-                if (r + n_error_buf(level) * minval(dx(1:dim)) <= center_tagging_radius) then
 
                    tag(i,j,k) = set
 

--- a/Exec/science/wdmerger/science/sc20/collision_ml0/probin
+++ b/Exec/science/wdmerger/science/sc20/collision_ml0/probin
@@ -11,8 +11,6 @@
   max_stellar_tagging_level = 0
   stellar_density_threshold = 1.0d0
 
-  max_center_tagging_level = 0
-
   max_temperature_tagging_level = 0
   temperature_tagging_threshold = 1.0d9
 

--- a/Exec/science/wdmerger/science/sc20/collision_ml1/probin
+++ b/Exec/science/wdmerger/science/sc20/collision_ml1/probin
@@ -11,8 +11,6 @@
   max_stellar_tagging_level = 0
   stellar_density_threshold = 1.0d0
 
-  max_center_tagging_level = 0
-
   max_temperature_tagging_level = 1
   temperature_tagging_threshold = 1.0d9
 

--- a/Exec/science/wdmerger/science/sc20/collision_ml2/probin
+++ b/Exec/science/wdmerger/science/sc20/collision_ml2/probin
@@ -11,8 +11,6 @@
   max_stellar_tagging_level = 1
   stellar_density_threshold = 1.0d0
 
-  max_center_tagging_level = 0
-
   max_temperature_tagging_level = 2
   temperature_tagging_threshold = 1.0d9
 

--- a/Exec/science/wdmerger/tests/tde/probin
+++ b/Exec/science/wdmerger/tests/tde/probin
@@ -10,7 +10,6 @@
 
   max_stellar_tagging_level = 20
   max_temperature_tagging_level = 0
-  max_center_tagging_level = 0
   stellar_density_threshold = 1.0d4
 
 /

--- a/Exec/science/wdmerger/tests/tde/probin.test
+++ b/Exec/science/wdmerger/tests/tde/probin.test
@@ -10,7 +10,6 @@
 
   max_stellar_tagging_level = 20
   max_temperature_tagging_level = 0
-  max_center_tagging_level = 0
   stellar_density_threshold = 1.0d0
 
 /

--- a/Exec/science/wdmerger/tests/wdmerger_collision/probin_2d_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/probin_2d_collision
@@ -20,10 +20,8 @@
 
   max_stellar_tagging_level = 20
   max_temperature_tagging_level = 0
-  max_center_tagging_level = 0
   stellar_density_threshold = 1.0d2
   temperature_tagging_threshold = 5.0d8
-  center_tagging_radius = 0.0d0
   max_tagging_radius = 0.75d0
   roche_tagging_factor = 2.0d0
 

--- a/Exec/science/wdmerger/tests/wdmerger_collision_1D/probin
+++ b/Exec/science/wdmerger/tests/wdmerger_collision_1D/probin
@@ -11,7 +11,6 @@
   orbital_eccentricity = 0.0d0
   orbital_angle = 0.0d0
 
-  max_center_tagging_level = 0
   max_stellar_tagging_level = 0
   max_temperature_tagging_level = 0
 

--- a/Exec/science/wdmerger/tests/wdmerger_retry/probin_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/probin_test_wdmerger_retry
@@ -32,10 +32,8 @@
 
   max_stellar_tagging_level = 0
   max_temperature_tagging_level = 0
-  max_center_tagging_level = 20
   stellar_density_threshold = 1.0d0
   temperature_tagging_threshold = 5.0d8
-  center_tagging_radius = 2.0d8
   max_tagging_radius = 0.75d0
   roche_tagging_factor = 2.0d0
 


### PR DESCRIPTION

## PR summary

This capability is not currently used in any science setup so it is no longer needed.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
