### PR TITLE
Remove some old uses of dt_cutoff

### DIFF
--- a/Docs/source/timestepping.rst
+++ b/Docs/source/timestepping.rst
@@ -75,15 +75,15 @@ The following parameters affect the timestep choice:
   * ``castro.initial_dt``: initial level 0 time
     step regardless of other settings (Real :math:`> 0`; unused if not set)
 
-  * ``castro.dt_cutoff``: time step below which calculation
-    will abort (Real :math:`> 0`; default: 0.0)
+  * ``castro.dt_cutoff``: as a fraction of the current simulation time,
+    the time step below which the calculation will abort (Real
+    :math:`> 0`; default: 1.e-12); typically not user-defined
 
 As an example, consider::
 
     castro.cfl = 0.9
     castro.init_shrink = 0.01
     castro.change_max = 1.1
-    castro.dt_cutoff = 1.e-20
 
 This defines the :math:`\mathtt{cfl}` parameter in :eq:`eq:cfl` to be
 0.9, but sets (via ``init_shrink``) the first timestep we take to
@@ -93,7 +93,7 @@ the hydrodynamic timestep at the start of a simulation. The
 more than 10% over a coarse timestep. Note that the time step can
 shrink by any factor; this only controls the extent to which it can
 grow. The ``dt_cutoff`` parameter will force the code to abort if
-the timestep ever drops below :math:`10^{-20}`. This is a safety
+the timestep ever drops below :math:`10^{-12}` of the current time. This is a safety
 feature—if the code hits such a small value, then something likely
 went wrong in the simulation, and by aborting, you won’t burn through
 your entire allocation before noticing that there is an issue.

--- a/Exec/science/rotating_star/inputs_2d.sdc_test
+++ b/Exec/science/rotating_star/inputs_2d.sdc_test
@@ -40,7 +40,6 @@ castro.riemann_solver = 1
 gravity.gravity_type = MonopoleGrav
 gravity.drdxfac = 2
 
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.7     # cfl number for hyperbolic system
 castro.init_shrink    = 0.001     # scale back initial timestep by this factor
 castro.change_max     = 1.5    # factor by which dt is allowed to change each timestep

--- a/Exec/science/wdmerger/tests/wdmerger_mhd/inputs_test_wdmerger_3D
+++ b/Exec/science/wdmerger/tests/wdmerger_mhd/inputs_test_wdmerger_3D
@@ -17,7 +17,6 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-#castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Util/scaling/sedov/summit_201905/CPU_runs/inputs.3d.sph
+++ b/Util/scaling/sedov/summit_201905/CPU_runs/inputs.3d.sph
@@ -23,7 +23,6 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Util/scaling/sedov/summit_201905/CPU_runs/inputs.3d.sph_1level
+++ b/Util/scaling/sedov/summit_201905/CPU_runs/inputs.3d.sph_1level
@@ -23,7 +23,6 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Util/scaling/sedov/summit_201905/GPU_runs/inputs.3d.sph
+++ b/Util/scaling/sedov/summit_201905/GPU_runs/inputs.3d.sph
@@ -23,7 +23,6 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Util/scaling/sedov/summit_201905/GPU_runs/inputs.3d.sph_1level
+++ b/Util/scaling/sedov/summit_201905/GPU_runs/inputs.3d.sph_1level
@@ -23,7 +23,6 @@ castro.do_react = 0
 castro.ppm_type = 1
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Util/scaling/sedov/titan_20171011/1level/inputs.starlord
+++ b/Util/scaling/sedov/titan_20171011/1level/inputs.starlord
@@ -25,7 +25,6 @@ castro.do_ctu = 0
 castro.allow_negative_energy = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Util/scaling/sedov/titan_20171011/1level_4x/inputs.starlord
+++ b/Util/scaling/sedov/titan_20171011/1level_4x/inputs.starlord
@@ -25,7 +25,6 @@ castro.do_ctu = 0
 castro.allow_negative_energy = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Util/scaling/sedov/titan_20171011/64_1024/inputs.starlord
+++ b/Util/scaling/sedov/titan_20171011/64_1024/inputs.starlord
@@ -25,7 +25,6 @@ castro.do_ctu = 0
 castro.allow_negative_energy = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Util/scaling/sedov/titan_20171011/64_1536/inputs.starlord
+++ b/Util/scaling/sedov/titan_20171011/64_1536/inputs.starlord
@@ -25,7 +25,6 @@ castro.do_ctu = 0
 castro.allow_negative_energy = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Util/scaling/sedov/titan_20171011/64_512/inputs.starlord
+++ b/Util/scaling/sedov/titan_20171011/64_512/inputs.starlord
@@ -25,7 +25,6 @@ castro.do_ctu = 0
 castro.allow_negative_energy = 0
 
 # TIME STEP CONTROL
-castro.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.01    # scale back initial timestep
 castro.change_max     = 1.1     # maximum increase in dt over successive steps

--- a/Util/scaling/wdmerger/cori_201710/inputs_test_wdmerger_3D
+++ b/Util/scaling/wdmerger/cori_201710/inputs_test_wdmerger_3D
@@ -17,7 +17,6 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Util/scaling/wdmerger/summitdev_201806/inputs_test_wdmerger_3D
+++ b/Util/scaling/wdmerger/summitdev_201806/inputs_test_wdmerger_3D
@@ -16,7 +16,6 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Util/scaling/wdmerger/titan_20171011/256_0amr/inputs_test_wdmerger_3D
+++ b/Util/scaling/wdmerger/titan_20171011/256_0amr/inputs_test_wdmerger_3D
@@ -17,7 +17,6 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Util/scaling/wdmerger/titan_20171011/256_1amr/inputs_test_wdmerger_3D
+++ b/Util/scaling/wdmerger/titan_20171011/256_1amr/inputs_test_wdmerger_3D
@@ -17,7 +17,6 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Util/scaling/wdmerger/titan_20171011/256_2amr/inputs_test_wdmerger_3D
+++ b/Util/scaling/wdmerger/titan_20171011/256_2amr/inputs_test_wdmerger_3D
@@ -17,7 +17,6 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Util/scaling/wdmerger/titan_20171011/512_0amr/inputs_test_wdmerger_3D
+++ b/Util/scaling/wdmerger/titan_20171011/512_0amr/inputs_test_wdmerger_3D
@@ -17,7 +17,6 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep

--- a/Util/scaling/wdmerger/titan_20171011/512_1amr/inputs_test_wdmerger_3D
+++ b/Util/scaling/wdmerger/titan_20171011/512_1amr/inputs_test_wdmerger_3D
@@ -17,7 +17,6 @@ geometry.prob_lo = -5.12e9 -5.12e9 -5.12e9         # Lower boundary limits in ph
 geometry.prob_hi =  5.12e9  5.12e9  5.12e9         # Upper boundary limits in physical space
 castro.center =      0.0e0   0.0e0   0.0e0         # System center of mass
 
-castro.dt_cutoff = 1.e-8                           # Level 0 timestep below which we halt
 castro.cfl = 0.5                                   # CFL number for hyperbolic system
 castro.init_shrink = 0.1                           # Scale back initial timestep by this factor
 castro.change_max = 1.1                            # Factor by which dt is allowed to change each timestep


### PR DESCRIPTION

## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
