### PR TITLE
Add static assertion on NETWORK_HAS_CXX_IMPLEMENTATION with CUDA

### DIFF
--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -18,6 +18,12 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt)
         amrex::Error("Strang reactions are only supported for the CTU advance.");
     }
 
+    // Sanity check: cannot use CUDA without a network with a C++ implementation.
+
+#if defined(AMREX_USE_GPU) && !defined(NETWORK_HAS_CXX_IMPLEMENTATION)
+    static_assert(false, "Cannot compile for GPUs if using a network without a C++ implementation.");
+#endif
+
     const Real strt_time = ParallelDescriptor::second();
 
     // Start off by assuming a successful burn.


### PR DESCRIPTION

## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
