### PR TITLE
the "interp" external BC option was removed long ago

### DIFF
--- a/Exec/gravity_tests/hse_convergence_general/inputs_1d.128.hse_test
+++ b/Exec/gravity_tests/hse_convergence_general/inputs_1d.128.hse_test
@@ -21,7 +21,7 @@ castro.xl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
 
-castro.xr_ext_bc_type = "interp"
+castro.xr_ext_bc_type = "hse"
 
 # WHICH PHYSICS
 castro.do_hydro = 1

--- a/Exec/gravity_tests/hse_convergence_general/inputs_1d.256.hse_test
+++ b/Exec/gravity_tests/hse_convergence_general/inputs_1d.256.hse_test
@@ -21,7 +21,7 @@ castro.xl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
 
-castro.xr_ext_bc_type = "interp"
+castro.xr_ext_bc_type = "hse"
 
 # WHICH PHYSICS
 castro.do_hydro = 1

--- a/Exec/gravity_tests/hse_convergence_general/inputs_1d.512.hse_test
+++ b/Exec/gravity_tests/hse_convergence_general/inputs_1d.512.hse_test
@@ -21,7 +21,7 @@ castro.xl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
 
-castro.xr_ext_bc_type = "interp"
+castro.xr_ext_bc_type = "hse"
 
 # WHICH PHYSICS
 castro.do_hydro = 1

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.128
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.128
@@ -17,9 +17,6 @@ amr.n_cell           = 128     128
 castro.lo_bc       =  0   3
 castro.hi_bc       =  0   3
 
-castro.yl_ext_bc_type = "interp"
-castro.yr_ext_bc_type = "interp"
-
 # WHICH PHYSICS
 castro.do_hydro = 1
 castro.do_react = 1

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.256
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.256
@@ -17,9 +17,6 @@ amr.n_cell           = 256     256
 castro.lo_bc       =  0   3
 castro.hi_bc       =  0   3
 
-castro.yl_ext_bc_type = "interp"
-castro.yr_ext_bc_type = "interp"
-
 # WHICH PHYSICS
 castro.do_hydro = 1
 castro.do_react = 1

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.512
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.512
@@ -17,9 +17,6 @@ amr.n_cell           = 512     512
 castro.lo_bc       =  0   3
 castro.hi_bc       =  0   3
 
-castro.yl_ext_bc_type = "interp"
-castro.yr_ext_bc_type = "interp"
-
 # WHICH PHYSICS
 castro.do_hydro = 1
 castro.do_react = 1

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.64
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.64
@@ -17,9 +17,6 @@ amr.n_cell           = 64      64
 castro.lo_bc       =  0   3
 castro.hi_bc       =  0   3
 
-castro.yl_ext_bc_type = "interp"
-castro.yr_ext_bc_type = "interp"
-
 # WHICH PHYSICS
 castro.do_hydro = 1
 castro.do_react = 1

--- a/Exec/science/flame_wave/job_scripts/aprox13/inputs_2d.boost.aprox13
+++ b/Exec/science/flame_wave/job_scripts/aprox13/inputs_2d.boost.aprox13
@@ -15,13 +15,12 @@ amr.n_cell           = 384         96
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 castro.lo_bc       =  3   1
-castro.hi_bc       =  2   1
+castro.hi_bc       =  2   2
 
 castro.yl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
 
-castro.yr_ext_bc_type = "interp"
 
 # WHICH PHYSICS
 castro.do_hydro = 1

--- a/Exec/science/flame_wave/job_scripts/aprox13_test/inputs_2d.boost.aprox13
+++ b/Exec/science/flame_wave/job_scripts/aprox13_test/inputs_2d.boost.aprox13
@@ -15,13 +15,11 @@ amr.n_cell           = 128         64
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 castro.lo_bc       =  3   1
-castro.hi_bc       =  2   1
+castro.hi_bc       =  2   2
 
 castro.yl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
-
-castro.yr_ext_bc_type = "interp"
 
 # WHICH PHYSICS
 castro.do_hydro = 1

--- a/Exec/science/flame_wave/scaling/inputs.scaling.3d
+++ b/Exec/science/flame_wave/scaling/inputs.scaling.3d
@@ -15,13 +15,11 @@ amr.n_cell           = 768       768        192
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 castro.lo_bc       =  3   3   1
-castro.hi_bc       =  2   2   1
+castro.hi_bc       =  2   2   2
 
 castro.zl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
-
-castro.zr_ext_bc_type = "interp"
 
 # WHICH PHYSICS
 castro.do_hydro = 1

--- a/Exec/science/flame_wave/scaling/inputs.scaling_384.3d
+++ b/Exec/science/flame_wave/scaling/inputs.scaling_384.3d
@@ -16,13 +16,11 @@ amr.n_cell = 384 384 96
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 castro.lo_bc       =  3   3   1
-castro.hi_bc       =  2   2   1
+castro.hi_bc       =  2   2   2
 
 castro.zl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
-
-castro.zr_ext_bc_type = "interp"
 
 # WHICH PHYSICS
 castro.do_hydro = 1

--- a/Exec/science/flame_wave/scaling/inputs.scaling_576.3d
+++ b/Exec/science/flame_wave/scaling/inputs.scaling_576.3d
@@ -16,13 +16,11 @@ amr.n_cell = 576 576 144
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 castro.lo_bc       =  3   3   1
-castro.hi_bc       =  2   2   1
+castro.hi_bc       =  2   2   2
 
 castro.zl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
-
-castro.zr_ext_bc_type = "interp"
 
 # WHICH PHYSICS
 castro.do_hydro = 1

--- a/Exec/science/planet/inputs_2d
+++ b/Exec/science/planet/inputs_2d
@@ -16,15 +16,13 @@ amr.n_cell           = 8      256
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 castro.lo_bc       =  0    1
-castro.hi_bc       =  0    1
+castro.hi_bc       =  0    2
 
 
 castro.yl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
 #castro.hse_zero_vels=0
-
-castro.yr_ext_bc_type = "interp"
 
 fab.format=NATIVE_32
 

--- a/Exec/science/planet/inputs_3d
+++ b/Exec/science/planet/inputs_3d
@@ -15,14 +15,12 @@ amr.n_cell           = 64 64 256
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 castro.lo_bc       =  0    0    1
-castro.hi_bc       =  0    0    1
+castro.hi_bc       =  0    0    2
 
 
 castro.zl_ext_bc_type = "hse"
 castro.hse_interp_temp = 1
 castro.hse_reflect_vels = 1
-
-castro.zr_ext_bc_type = "interp"
 
 castro.hse_zero_vels=0
 fab.format=NATIVE_32

--- a/Exec/science/xrb_mixed/inputs_2d
+++ b/Exec/science/xrb_mixed/inputs_2d
@@ -15,10 +15,9 @@ amr.n_cell           = 256     768
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 castro.lo_bc       =  0   1
-castro.hi_bc       =  0   1
+castro.hi_bc       =  0   2
 
 castro.yl_ext_bc_type = "hse"
-castro.yr_ext_bc_type = "interp"
 
 # WHICH PHYSICS
 castro.do_hydro = 1


### PR DESCRIPTION
Running with these inputs would immediately hit an abort complaining about an unsupported BC type.
Many of these instances were not actually used, but a few were changed to
outflow.  

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
