### PR TITLE
If using arrays sized nspec, allow them in C++

### DIFF
--- a/Exec/science/Detonation/problem_bc_fill.H
+++ b/Exec/science/Detonation/problem_bc_fill.H
@@ -16,16 +16,8 @@ void problem_fill_ambient(int i, int j, int k,
 
     state(i,j,k,URHO) = problem::ambient_dens;
 
-    // This should be problem::ambient_comp but we currently don't have
-    // arrays working in C++. This should be synced when we do.
-
-    Real ambient_xn[NumSpec] = { problem::smallx };
-    ambient_xn[problem::ic12-1] = amrex::max(problem::cfrac, problem::smallx);
-    ambient_xn[problem::io16-1] = amrex::max(problem::ofrac, problem::smallx);
-    ambient_xn[problem::ihe4-1] = 1.e0_rt - problem::cfrac - problem::ofrac - (NumSpec - 2) * problem::smallx;
-
     for (int n = 0; n < NumSpec; ++n) {
-        state(i,j,k,UFS+n) = problem::ambient_dens * ambient_xn[n];
+        state(i,j,k,UFS+n) = problem::ambient_dens * problem::ambient_comp[n];
     }
 
     if (x < c_T) {

--- a/Util/scripts/write_probdata.py
+++ b/Util/scripts/write_probdata.py
@@ -73,6 +73,8 @@ CXX_HEADER = """
 #define problem_parameters_H
 #include <AMReX_BLFort.H>
 
+#include <network_properties.H>
+
 """
 
 CXX_FOOTER = """
@@ -394,7 +396,9 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
                 for p in params:
                     # We don't currently support the case where a module
                     # is required since we have no C++ equivalent for the module.
-                    if p.is_array() and p.has_module():
+                    # The exception is specific cases where we know how to do the
+                    # translation from Fortran to C++.
+                    if p.is_array() and p.has_module() and not (p.size == "nspec" and p.module == "network"):
                         continue
                     if p.dtype == "logical":
                         continue
@@ -421,6 +425,8 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
                         fout.write("{}subroutine get_f90_{}({}_in) bind(C, name=\"get_f90_{}\")\n".format(
                             indent, p.var, p.var, p.var))
                         if p.is_array():
+                            if p.has_module():
+                                fout.write("{}   use {}, only: {}\n".format(indent, p.module, p.size))
                             fout.write("{}   {}, intent(inout) :: {}_in({})\n".format(
                                 indent, p.get_f90_decl(), p.var, p.size))
                         else:
@@ -436,7 +442,7 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
                 # to set the value of the parameters.
 
                 for p in params:
-                    if p.is_array() and p.has_module():
+                    if p.is_array() and p.has_module() and not (p.size == "nspec" and p.module == "network"):
                         continue
                     if p.dtype == "logical" or p.dtype == "character":
                         continue
@@ -444,6 +450,8 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
                     fout.write("{}subroutine set_f90_{}({}_in) bind(C, name=\"set_f90_{}\")\n".format(
                         indent, p.var, p.var, p.var))
                     if p.is_array():
+                        if p.has_module():
+                            fout.write("{}   use {}, only: {}\n".format(indent, p.module, p.size))
                         fout.write("{}   {}, intent(in) :: {}_in({})\n".format(
                             indent, p.get_f90_decl(), p.var, p.size))
                     else:
@@ -469,7 +477,7 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
         fout.write(CXX_F_HEADER)
 
         for p in params:
-            if p.is_array() and p.has_module():
+            if p.is_array() and p.has_module() and not (p.size == "nspec" and p.module == "network"):
                 continue
 
             if p.dtype == "character":
@@ -498,14 +506,17 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
         fout.write("  namespace problem {\n\n")
 
         for p in params:
-            if p.is_array() and p.has_module():
+            if p.is_array() and p.has_module() and not (p.size == "nspec" and p.module == "network"):
                 continue
 
             if p.dtype == "character":
                 fout.write("  extern std::string {};\n\n".format(p.var))
             else:
                 if p.is_array():
-                    fout.write("  extern AMREX_GPU_MANAGED {} {}[{}];\n\n".format(p.get_cxx_decl(), p.var, p.size))
+                    if p.size == "nspec" and p.module == "network":
+                        fout.write("  extern AMREX_GPU_MANAGED {} {}[NumSpec];\n\n".format(p.get_cxx_decl(), p.var))
+                    else:
+                        fout.write("  extern AMREX_GPU_MANAGED {} {}[{}];\n\n".format(p.get_cxx_decl(), p.var, p.size))
                 else:
                     fout.write("  extern AMREX_GPU_MANAGED {} {};\n\n".format(p.get_cxx_decl(), p.var))
 
@@ -520,7 +531,7 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
         fout.write("#include <{}_parameters_F.H>\n\n".format(os.path.basename(cxx_prefix)))
 
         for p in params:
-            if p.is_array() and p.has_module():
+            if p.is_array() and p.has_module() and not (p.size == "nspec" and p.module == "network"):
                 continue
             if p.dtype == "logical":
                 continue
@@ -529,7 +540,10 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
                 fout.write("  std::string problem::{};\n\n".format(p.var))
             else:
                 if p.is_array():
-                    fout.write("  AMREX_GPU_MANAGED {} problem::{}[{}];\n\n".format(p.get_cxx_decl(), p.var, p.size))
+                    if p.size == "nspec" and p.module == "network":
+                        fout.write("  AMREX_GPU_MANAGED {} problem::{}[NumSpec];\n\n".format(p.get_cxx_decl(), p.var))
+                    else:
+                        fout.write("  AMREX_GPU_MANAGED {} problem::{}[{}];\n\n".format(p.get_cxx_decl(), p.var, p.size))
                 else:
                     fout.write("  AMREX_GPU_MANAGED {} problem::{};\n\n".format(p.get_cxx_decl(), p.var))
 
@@ -538,7 +552,7 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
         fout.write("    int slen = 0;\n\n")
 
         for p in params:
-            if p.is_array() and p.has_module():
+            if p.is_array() and p.has_module() and not (p.size == "nspec" and p.module == "network"):
                 continue
             if p.dtype == "logical":
                 continue
@@ -561,7 +575,7 @@ def write_probin(probin_template, default_prob_param_file, prob_param_file, out_
         fout.write("    int slen = 0;\n\n")
 
         for p in params:
-            if p.is_array() and p.has_module():
+            if p.is_array() and p.has_module() and not (p.size == "nspec" and p.module == "network"):
                 continue
             if p.dtype == "logical" or p.dtype == "character":
                 continue


### PR DESCRIPTION

## PR summary

This allows arrays sized with (nspec, network) in _prob_params to be used in C++ by manually rewriting them as size NumSpec in C++.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
