### PR TITLE
Catch up to latest Hypre

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # 20.12
 
+   * The minimum supported Hypre version is now 2.19.0. (#1333)
+
    * We have switched from a Fortran to a C++ implementation of VODE in Microphysics.
      As a result we have also switched the Strang and simplified SDC burners in Castro
      to use this C++ implementation. Most networks used in Castro have already been

--- a/Docs/source/radiation.rst
+++ b/Docs/source/radiation.rst
@@ -41,7 +41,7 @@ to exercise radiation. The only other requirement is a copy
 of the Hypre library. Hypre provides the algebraic multigrid
 solvers used by the implicit radiation update. You can get
 a copy at https://github.com/hypre-space/hypre (the minimum
-supported release version is 2.15.0). Their install
+supported release version is 2.19.0). Their install
 instructions describe what to do; we recommend using the autotools
 and GNU Make build. On HPC clusters, you typically want to build
 with the same compiler you're using to build Castro, and you also

--- a/Source/driver/main.cpp
+++ b/Source/driver/main.cpp
@@ -67,7 +67,7 @@ main (int   argc,
 
 #ifdef HYPRE
     // Initialize Hypre.
-    HYPRE_Init(argc, argv);
+    HYPRE_Init();
 #endif
 
     BL_PROFILE_VAR("main()", pmain);


### PR DESCRIPTION

## PR summary

HYPRE_Init() no longer accepts arguments as of 2.19. We should update the test suite to 2.20.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
