### PR TITLE
clean up the cpp parameters python script

### DIFF
--- a/Docs/source/rp_intro.rst
+++ b/Docs/source/rp_intro.rst
@@ -29,7 +29,7 @@ C++ parameter format
 The C parameters take the form of::
 
     # comment describing the parameter
-    name   type   default   need in Fortran?   ifdef    fortran name    fortran type
+    name   type   default   need in Fortran?   ifdef
 
 Here,
 
@@ -58,12 +58,6 @@ provide "need in Fortran?" and "ifdef".
   * `ifdef` provides the name of a preprocessor name that should
     wrap this parameter definition—it will only be compiled in if that
     name is defined to the preprocessor.
-
-  * `fortran name` is the name that the parameter should use in
-    Fortran—by default it will be the same as name.
-
-  * `fortran type` is the data type of the parameter in Fortran—by
-    default it will be the Fortran-equivalent to type.
 
 Finally, any comment (starting with ``#``) immediately before the
 parameter definition will be used to generate the documentation

--- a/Exec/science/wdmerger/wdmerger_util.F90
+++ b/Exec/science/wdmerger/wdmerger_util.F90
@@ -414,7 +414,7 @@ contains
 
   subroutine binary_setup
 
-    use meth_params_module, only: rot_period, point_mass, URHO, UTEMP, UEINT, UEDEN, UFS, UFX
+    use meth_params_module, only: rotational_period, point_mass, URHO, UTEMP, UEINT, UEDEN, UFS, UFX
     use network, only: nspec, naux
     use initial_model_module
     use prob_params_module, only: center, problo, probhi, dim, max_level, dx_level, physbc_lo, Symmetry
@@ -667,21 +667,21 @@ contains
 
              a = roche_radius_factor * (model_S % radius / roche_rad_S)
 
-             rot_period = -ONE
+             rotational_period = -ONE
 
           endif
 
           call kepler_third_law(model_P % radius, model_P % mass, model_S % radius, model_S % mass, &
-                                rot_period, orbital_eccentricity, orbital_angle, &
+                                rotational_period, orbital_eccentricity, orbital_angle, &
                                 a, r_P_initial, r_S_initial, v_P_r, v_S_r, v_P_phi, v_S_phi)
 
           if (ioproc .and. init == 1) then
              write (*,1003) a, a / AU
              write (*,1004) r_P_initial, r_P_initial / AU
              write (*,1005) r_S_initial, r_S_initial / AU
-             write (*,1006) rot_period
-             write (*,1007) TWO * M_PI * r_P_initial / rot_period
-             write (*,1008) TWO * M_PI * r_S_initial / rot_period
+             write (*,1006) rotational_period
+             write (*,1007) TWO * M_PI * r_P_initial / rotational_period
+             write (*,1008) TWO * M_PI * r_S_initial / rotational_period
 1003         format ("Generated binary orbit of distance ", ES8.2, " cm = ", ES8.2, " AU.")
 1004         format ("The primary orbits the center of mass at distance ", ES9.2, " cm = ", ES9.2, " AU.")
 1005         format ("The secondary orbits the center of mass at distance ", ES9.2, " cm = ", ES9.2, " AU.")
@@ -1058,13 +1058,13 @@ contains
 
   subroutine set_period(period) bind(C,name='set_period')
 
-    use meth_params_module, only: rot_period
+    use meth_params_module, only: rotational_period
 
     implicit none
 
     real(rt) :: period
 
-    rot_period = period
+    rotational_period = period
 
   end subroutine set_period
 
@@ -1074,13 +1074,13 @@ contains
 
   subroutine get_period(period) bind(C,name='get_period')
 
-    use meth_params_module, only: rot_period
+    use meth_params_module, only: rotational_period
 
     implicit none
 
     real(rt) :: period
 
-    period = rot_period
+    period = rotational_period
 
   end subroutine get_period
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -1,4 +1,4 @@
-# name   type   default   need in Fortran?   ifdef    fortran name    fortran type
+# name   type   default   need in Fortran?   ifdef
 #
 # note, name can have two values, as (a, b).  a will be the name used
 # in the inputs file, b is the variable name in the C++ class.
@@ -428,7 +428,7 @@ grav_source_type             int           4                  y
 do_rotation                  int          -1                  y
 
 # the rotation period for the corotating frame
-rotational_period            Real         -1.e200             y        ROTATION        rot_period
+rotational_period            Real         -1.e200             y        ROTATION
 
 # permits the centrifugal terms in the rotation to be turned on and off
 rotation_include_centrifugal int           1                  y        ROTATION

--- a/Source/driver/parse_castro_params.py
+++ b/Source/driver/parse_castro_params.py
@@ -8,7 +8,7 @@ through meth_params_module.
 
 parameters have the format:
 
-  name  type  default  need-in-fortran?  ifdef fortran-name  fortran-type
+  name  type  default  need-in-fortran?  ifdef
 
 the first three (name, type, default) are mandatory:
 
@@ -26,10 +26,6 @@ the next are optional:
    need-in-fortran: if "y" then we do a pp.query() in meth_params_nd.F90
 
    ifdef: only define this parameter if the name provided is #ifdef-ed
-
-   fortran-name: if a different variable name in Fortran, specify here
-
-   fortran-type: if a different data type in Fortran, specify here
 
 Any line beginning with a "#" is ignored
 
@@ -94,7 +90,7 @@ class Param:
                  cpp_var_name=None,
                  namespace=None, cpp_class=None,
                  debug_default=None,
-                 in_fortran=0, f90_name=None, f90_dtype=None,
+                 in_fortran=0,
                  ifdef=None):
 
         self.name = name
@@ -113,16 +109,6 @@ class Param:
         else:
             self.ifdef = ifdef
 
-        if f90_name is None:
-            self.f90_name = name
-        else:
-            self.f90_name = f90_name
-
-        if f90_dtype is None:
-            self.f90_dtype = dtype
-        else:
-            self.f90_dtype = f90_dtype
-
     def get_declare_string(self):
         # this is the line that goes into castro_declares.H included
         # into Castro.cpp
@@ -131,7 +117,7 @@ class Param:
             tstr = "AMREX_GPU_MANAGED int         {}::{}".format(self.namespace, self.cpp_var_name)
         elif self.dtype == "bool":
             tstr = "AMREX_GPU_MANAGED bool        {}::{}".format(self.namespace, self.cpp_var_name)
-        elif self.dtype == "Real":
+        elif self.dtype == "real":
             tstr = "AMREX_GPU_MANAGED amrex::Real {}::{}".format(self.namespace, self.cpp_var_name)
         elif self.dtype == "string":
             tstr = "std::string {}::{}".format(self.namespace, self.cpp_var_name)
@@ -172,18 +158,18 @@ class Param:
 
         if self.debug_default is not None:
             debug_default = self.debug_default
-            if self.dtype == "Real":
+            if self.dtype == "real":
                 if "d" in debug_default:
                     debug_default = debug_default.replace("d", "e")
                 debug_default += "_rt"
 
         default = self.default
-        if self.dtype == "Real":
+        if self.dtype == "real":
             if "d" in default:
                 default = default.replace("d", "e")
             default += "_rt"
 
-        name = self.f90_name
+        name = self.name
 
         # for a character, we need to allocate its length.  We allocate
         # to 1, and the Fortran parmparse will resize
@@ -205,14 +191,14 @@ class Param:
 
     def get_cuda_managed_string(self):
         """this is the string that sets the variable as managed for CUDA"""
-        if self.f90_dtype == "string":
+        if self.dtype == "string":
             return "\n"
 
         cstr = ""
         if self.ifdef is not None:
             cstr += "#ifdef {}\n".format(self.ifdef)
         cstr += "#ifdef AMREX_USE_GPU_PRAGMA\n"
-        cstr += "attributes(managed) :: {}\n".format(self.f90_name)
+        cstr += "attributes(managed) :: {}\n".format(self.name)
         cstr += "#endif\n"
         if self.ifdef is not None:
             cstr += "#endif\n"
@@ -227,7 +213,7 @@ class Param:
         if language == "C++":
             ostr += "pp.query(\"{}\", {}::{});\n".format(self.name, self.namespace, self.cpp_var_name)
         elif language == "F90":
-            ostr += "    call pp%query(\"{}\", {})\n".format(self.name, self.f90_name)
+            ostr += "    call pp%query(\"{}\", {})\n".format(self.name, self.name)
         else:
             sys.exit("invalid language choice in get_query_string")
 
@@ -259,7 +245,7 @@ class Param:
             tstr = "extern AMREX_GPU_MANAGED int {};\n".format(self.cpp_var_name)
         elif self.dtype == "bool":
             tstr = "extern AMREX_GPU_MANAGED bool {};\n".format(self.cpp_var_name)
-        elif self.dtype == "Real":
+        elif self.dtype == "real":
             tstr = "extern AMREX_GPU_MANAGED amrex::Real {};\n".format(self.cpp_var_name)
         elif self.dtype == "string":
             tstr = "extern std::string {};\n".format(self.cpp_var_name)
@@ -277,16 +263,16 @@ class Param:
         if not self.in_fortran:
             return None
 
-        if self.f90_dtype == "int":
-            tstr = "integer,  allocatable, save :: {}\n".format(self.f90_name)
-        elif self.f90_dtype == "Real":
-            tstr = "real(rt), allocatable, save :: {}\n".format(self.f90_name)
-        elif self.f90_dtype == "logical":
-            tstr = "logical,  allocatable, save :: {}\n".format(self.f90_name)
-        elif self.f90_dtype == "string":
-            tstr = "character (len=:), allocatable, save :: {}\n".format(self.f90_name)
+        if self.dtype == "int":
+            tstr = "integer,  allocatable, save :: {}\n".format(self.name)
+        elif self.dtype == "real":
+            tstr = "real(rt), allocatable, save :: {}\n".format(self.name)
+        elif self.dtype == "logical":
+            tstr = "logical,  allocatable, save :: {}\n".format(self.name)
+        elif self.dtype == "string":
+            tstr = "character (len=:), allocatable, save :: {}\n".format(self.name)
             print("warning: string parameter {} will not be available on the GPU".format(
-                self.f90_name))
+                self.name))
         else:
             sys.exit("unsupported datatype for Fortran: {}".format(self.name))
 
@@ -342,14 +328,14 @@ def write_meth_module(plist, meth_template, out_directory):
             mo.write("\n")
             mo.write("  !$acc declare &\n")
             for n, p in enumerate(params):
-                if p.f90_dtype == "string":
+                if p.dtype == "string":
                     print("warning: string parameter {} will not be on the GPU".format(p.name),
                           file=sys.stderr)
                     continue
 
                 if p.ifdef is not None:
                     mo.write("#ifdef {}\n".format(p.ifdef))
-                mo.write("  !$acc create({})".format(p.f90_name))
+                mo.write("  !$acc create({})".format(p.name))
 
                 if n != len(params)-1:
                     mo.write(" &\n")
@@ -402,13 +388,13 @@ def write_meth_module(plist, meth_template, out_directory):
             mo.write("\n")
 
             for n, p in enumerate(params):
-                if p.f90_dtype == "string":
+                if p.dtype == "string":
                     continue
 
                 if p.ifdef is not None:
                     mo.write("#ifdef {}\n".format(p.ifdef))
 
-                mo.write("    !$acc update device({})\n".format(p.f90_name))
+                mo.write("    !$acc update device({})\n".format(p.name))
 
                 if p.ifdef is not None:
                     mo.write("#endif\n")
@@ -418,8 +404,8 @@ def write_meth_module(plist, meth_template, out_directory):
             params_free = [q for q in params if q.in_fortran == 1]
 
             for p in params_free:
-                mo.write("    if (allocated({})) then\n".format(p.f90_name))
-                mo.write("        deallocate({})\n".format(p.f90_name))
+                mo.write("    if (allocated({})) then\n".format(p.name))
+                mo.write("        deallocate({})\n".format(p.name))
                 mo.write("    end if\n")
 
             mo.write("\n\n")
@@ -475,7 +461,7 @@ def parse_params(infile, meth_template, out_directory):
         else:
             cpp_var_name = name
 
-        dtype = fields[1]
+        dtype = fields[1].lower()
 
         default = fields[2]
         if default[0] == "(":
@@ -498,16 +484,6 @@ def parse_params(infile, meth_template, out_directory):
         except IndexError:
             ifdef = None
 
-        try:
-            f90_name = fields[5]
-        except IndexError:
-            f90_name = None
-
-        try:
-            f90_dtype = fields[6]
-        except IndexError:
-            f90_dtype = None
-
         if namespace is None:
             sys.exit("namespace not set")
 
@@ -516,7 +492,7 @@ def parse_params(infile, meth_template, out_directory):
                             namespace=namespace,
                             cpp_class=cpp_class,
                             debug_default=debug_default,
-                            in_fortran=in_fortran, f90_name=f90_name, f90_dtype=f90_dtype,
+                            in_fortran=in_fortran,
                             ifdef=ifdef))
 
 

--- a/Source/rotation/Rotation_frequency.F90
+++ b/Source/rotation/Rotation_frequency.F90
@@ -9,7 +9,7 @@ contains
   subroutine get_omega(omega) bind(C, name="get_omega")
 
     use prob_params_module, only: coord_type
-    use meth_params_module, only: rot_period, rot_axis
+    use meth_params_module, only: rotational_period, rot_axis
     use amrex_constants_module, only: ZERO, TWO, M_PI
     use amrex_fort_module, only : rt => amrex_real
 
@@ -17,7 +17,7 @@ contains
 
     real(rt), intent(inout) :: omega(3)
 
-    ! If rot_period is less than zero, that means rotation is disabled, and so we should effectively
+    ! If rotational_period is less than zero, that means rotation is disabled, and so we should effectively
     ! shut off the source term by setting omega = 0. Note that by default rot_axis == 3 for Cartesian
     ! coordinates and rot_axis == 2 for cylindrical coordinates.
 
@@ -27,9 +27,9 @@ contains
 
     if (coord_type == 0 .or. coord_type == 1) then
 
-       if (rot_period > ZERO) then
+       if (rotational_period > ZERO) then
 
-          omega(rot_axis) = TWO * M_PI / rot_period
+          omega(rot_axis) = TWO * M_PI / rotational_period
 
        endif
 
@@ -43,13 +43,13 @@ contains
 
   subroutine set_rot_period(period) bind(C, name='set_rot_period')
 
-    use meth_params_module, only: rot_period
+    use meth_params_module, only: rotational_period
 
     implicit none
 
     real(rt), intent(in) :: period
 
-    rot_period = period
+    rotational_period = period
 
   end subroutine set_rot_period
   


### PR DESCRIPTION
we now ignore case in the _cpp_parameters file for the data type.
we also remove the option for the Fortran version of a parameter to
use a different name or data type.  One Fortran runtime parameter
was changed as a result (rot_periond -> rotational_period).

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
