### PR TITLE
Include ghost zones when filling data on new level

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1547,7 +1547,7 @@ Castro::init ()
 
     for (int s = 0; s < num_state_type; ++s) {
         MultiFab& state_MF = get_new_data(s);
-        FillCoarsePatch(state_MF, 0, time, s, 0, state_MF.nComp());
+        FillCoarsePatch(state_MF, 0, time, s, 0, state_MF.nComp(), state_MF.nGrow());
     }
 }
 


### PR DESCRIPTION

## PR summary

This addresses the issue that was unintentionally exposed by #1342. When we're creating a new fine level and filling data from the coarse level below it, we need to include the ghost zones in the fillpatch operation, or else they will be uninitialized and cause problems during the subsequent advance.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
