### PR TITLE
Turn off GPU pragma for everything but radiation

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -119,7 +119,11 @@ ifeq ($(USE_SYSTEM_BLAS), TRUE)
 endif
 
 ifeq ($(USE_CUDA),TRUE)
-  USE_GPU_PRAGMA ?= TRUE
+  ifeq ($(USE_RAD),TRUE)
+    USE_GPU_PRAGMA ?= TRUE
+  else
+    USE_GPU_PRAGMA ?= FALSE
+  endif
   DEFINES += -DCUDA
   CUDA_VERBOSE = FALSE
 

--- a/Exec/hydro_tests/Sedov/GNUmakefile
+++ b/Exec/hydro_tests/Sedov/GNUmakefile
@@ -14,8 +14,6 @@ USE_MHD    = FALSE
 
 GPU_COMPATIBLE_PROBLEM = TRUE
 
-USE_GPU_PRAGMA = FALSE
-
 # define the location of the CASTRO top directory
 CASTRO_HOME  := ../../..
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1119,10 +1119,9 @@ Castro::initData ()
 
 #ifdef GPU_COMPATIBLE_PROBLEM
 
-#pragma gpu box(box)
-          ca_initdata(AMREX_INT_ANYD(lo), AMREX_INT_ANYD(hi),
+          ca_initdata(AMREX_ARLIM_ANYD(lo), AMREX_ARLIM_ANYD(hi),
                       BL_TO_FORTRAN_ANYD(S_new[mfi]),
-                      AMREX_REAL_ANYD(dx), AMREX_REAL_ANYD(prob_lo));
+                      AMREX_ZFILL(dx), AMREX_ZFILL(prob_lo));
 
 #else
           RealBox gridloc = RealBox(grids[mfi.index()],geom.CellSize(),geom.ProbLo());
@@ -1403,11 +1402,10 @@ Castro::initData ()
 
 #ifdef GPU_COMPATIBLE_PROBLEM
 
-#pragma gpu box(box)
           ca_initrad
-              (AMREX_INT_ANYD(lo), AMREX_INT_ANYD(hi),
+              (AMREX_ARLIM_ANYD(lo), AMREX_ARLIM_ANYD(hi),
                BL_TO_FORTRAN_ANYD(Rad_new[mfi]),
-               AMREX_REAL_ANYD(dx), AMREX_REAL_ANYD(prob_lo));
+               AMREX_ZFILL(dx), AMREX_ZFILL(prob_lo));
 
 #else
           RealBox gridloc(grids[mfi.index()], geom.CellSize(), geom.ProbLo());
@@ -3326,11 +3324,10 @@ Castro::apply_problem_tags (TagBoxArray& tags, Real time)
             });
 
 #ifdef GPU_COMPATIBLE_PROBLEM
-#pragma gpu box(bx)
-            set_problem_tags(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
+            set_problem_tags(AMREX_ARLIM_ANYD(bx.loVect()), AMREX_ARLIM_ANYD(bx.hiVect()),
                              (int8_t*) BL_TO_FORTRAN_ANYD(tagfab),
                              BL_TO_FORTRAN_ANYD(S_new[mfi]),
-                             AMREX_REAL_ANYD(dx), AMREX_REAL_ANYD(prob_lo),
+                             AMREX_ZFILL(dx), AMREX_ZFILL(prob_lo),
                              tagval, clearval, time, level);
 #else
             set_problem_tags(AMREX_ARLIM_ANYD(bx.loVect()), AMREX_ARLIM_ANYD(bx.hiVect()),

--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -286,10 +286,9 @@ Castro::restart (Amr&     papa,
 
 #ifdef GPU_COMPATIBLE_PROBLEM
 
-#pragma gpu box(bx)
-              ca_initdata(AMREX_INT_ANYD(lo), AMREX_INT_ANYD(hi),
+              ca_initdata(AMREX_ARLIM_ANYD(lo), AMREX_ARLIM_ANYD(hi),
                           BL_TO_FORTRAN_ANYD(S_new[mfi]),
-                          AMREX_REAL_ANYD(dx), AMREX_REAL_ANYD(prob_lo));
+                          AMREX_ZFILL(dx), AMREX_ZFILL(prob_lo));
 
 #else
 

--- a/Source/problems/Castro_problem_source.cpp
+++ b/Source/problems/Castro_problem_source.cpp
@@ -135,12 +135,11 @@ Castro::fill_ext_source (const Real time, const Real dt, const MultiFab& state_o
             problem_source(i, j, k, geomdata, snew, src, dt, time);
         });
 
-#pragma gpu box(bx)
         ca_ext_src
-          (AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
+          (AMREX_ARLIM_ANYD(bx.loVect()), AMREX_ARLIM_ANYD(bx.hiVect()),
            BL_TO_FORTRAN_ANYD(state_old[mfi]),
            BL_TO_FORTRAN_ANYD(state_new[mfi]),
            BL_TO_FORTRAN_ANYD(ext_src[mfi]),
-           AMREX_REAL_ANYD(prob_lo), AMREX_REAL_ANYD(dx), time, dt);
+           AMREX_ZFILL(prob_lo), AMREX_ZFILL(dx), time, dt);
     }
 }

--- a/Source/sdc/Castro_sdc.cpp
+++ b/Source/sdc/Castro_sdc.cpp
@@ -199,7 +199,7 @@ Castro::do_sdc_update(int m_start, int m_end, Real dt)
             make_cell_center(bx1, Sborder.array(mfi), U_center_arr, domain_lo, domain_hi);
 
             // sometimes the Laplacian can make the species go negative near discontinuities
-            ca_normalize_species(AMREX_INT_ANYD(bx1.loVect()), AMREX_INT_ANYD(bx1.hiVect()),
+            ca_normalize_species(AMREX_ARLIM_ANYD(bx1.loVect()), AMREX_ARLIM_ANYD(bx1.hiVect()),
                                  BL_TO_FORTRAN_ANYD(U_center));
 
             // convert the C source to cell-centers


### PR DESCRIPTION

## PR summary

Radiation is the only code that substantively uses it at this point. The exception is a few problem-related routines -- problems that want to benefit from GPUs on these should migrate to the new C++ interfaces.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
