### PR TITLE
Convert compute_temp_from_rhoe to C++

### DIFF
--- a/Source/radiation/MGFLD.cpp
+++ b/Source/radiation/MGFLD.cpp
@@ -650,7 +650,10 @@ void Radiation::update_matter(MultiFab& rhoe_new, MultiFab& temp_new,
 #pragma omp parallel
 #endif
     for (MFIter mfi(rhoe_new,true); mfi.isValid(); ++mfi) {
-        const Box& bx = mfi.tilebox(); 
+        const Box& bx = mfi.tilebox();
+
+        auto temp_new_arr = temp_new[mfi].array();
+        auto S_new_arr = S_new[mfi].array();
 
         if (conservative_update) {
 #pragma gpu box(bx) sync
@@ -669,12 +672,38 @@ void Radiation::update_matter(MultiFab& rhoe_new, MultiFab& temp_new,
             temp_new[mfi].copy<RunOn::Device>(rhoe_new[mfi],bx);
             Gpu::synchronize();
 
-#pragma gpu box(bx) sync
-            ca_compute_temp_given_rhoe
-                (AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()), 
-                 BL_TO_FORTRAN_ANYD(temp_new[mfi]), 
-                 BL_TO_FORTRAN_ANYD(S_new[mfi]),
-                 0);
+            amrex::ParallelFor(bx,
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            {
+                // Get T from rhoe (temp_new comes in with rhoe)
+
+                if (temp_new_arr(i,j,k) <= 0.e0_rt)
+                {
+                    temp_new_arr(i,j,k) = small_temp;
+                }
+                else
+                {
+                    Real rhoInv = 1.e0_rt / S_new_arr(i,j,k,URHO);
+
+                    eos_t eos_state;
+                    eos_state.rho = S_new_arr(i,j,k,URHO);
+                    eos_state.T   = S_new_arr(i,j,k,UTEMP);
+                    eos_state.e   = temp_new_arr(i,j,k) * rhoInv;
+                    for (int n = 0; n < NumSpec; ++n) {
+                        eos_state.xn[n] = S_new_arr(i,j,k,UFS+n) * rhoInv;
+                    }
+#if NAUX_NET > 0
+                    for (int n = 0; n < NumAux; ++n) {
+                        eos_state.aux[n] = S_new_arr(i,j,k,UFX+n) * rhoInv;
+                    }
+#endif
+
+                    eos(eos_input_re, eos_state);
+
+                    temp_new_arr(i,j,k) = eos_state.T;
+                }
+            });
+            Gpu::synchronize();
         }
         else {
             BL_FORT_PROC_CALL(CA_NCUPDATE_MATTER, ca_ncupdate_matter)

--- a/Source/radiation/RAD_F.H
+++ b/Source/radiation/RAD_F.H
@@ -320,12 +320,6 @@ extern "C"
      const BL_FORT_FAB_ARG_3D(temp),
      const BL_FORT_FAB_ARG_3D(state));
 
-  void ca_compute_temp_given_rhoe
-    (const int* lo, const int* hi,
-     BL_FORT_FAB_ARG_3D(temp),
-     const BL_FORT_FAB_ARG_3D(state),
-     int update_state);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## PR summary

Note: in some of these cases we come in with an array called "temp" which actually contains (rho*e), and then overwrite it with the actual temperature. So the code can look a little confusing. In some cases I was able to merge this with a previous loop so the result is clearer. I chose to write each loop out explicitly rather than keep this in a separate function because I suspect that we will be able to fuse even more loops as time goes on, and in some cases we should eventually be able to use the main compute_temp function.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
