### PR TITLE
Fix c-linter action as set-env is no longer supported

### DIFF
--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Check header includes
         run: |
-          echo ::set-env name=HEADER_INCLUDES::$(grep -rIE --include="*.cpp" --include="*.H" --exclude-dir=external "#\s?include\s+\"\w+\.\w+\"")
+          echo 'HEADER_INCLUDES=$(grep -rIE --include="*.cpp" --include="*.H" --exclude-dir=external "#\s?include\s+\"\w+\.\w+\"")' >> $GITHUB_ENV
           echo $HEADER_INCLUDES
           if [[ -n "${HEADER_INCLUDES}" ]]; then exit 1; fi
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

As described here (https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files), the `set-env` command is no longer supported in GitHub actions. This PR replaces the command with their suggested way of doing things.

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
