### PR TITLE
Avoid roundoff issues in normalize_species_fluxes

### DIFF
--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -602,7 +602,7 @@ Castro::normalize_species_fluxes(const Box& bx,
     // terms like artificial viscosity which can cause these problems.
     // So checking that sum is sufficiently large helps avoid this.
 
-    if (std::abs(sum) > std::numeric_limits<Real>::epsilon() * flux(i,j,k,URHO)) {
+    if (std::abs(sum) > std::numeric_limits<Real>::epsilon() * std::abs(flux(i,j,k,URHO))) {
       fac = flux(i,j,k,URHO) / sum;
     }
 

--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -593,7 +593,16 @@ Castro::normalize_species_fluxes(const Box& bx,
     }
 
     Real fac = 1.0_rt;
-    if (sum != 0.0_rt) {
+
+    // We skip the normalization if the sum is zero or within epsilon.
+    // There can be numerical problems here if the density flux is
+    // approximately zero at the interface but not exactly, resulting in
+    // division by a small number and/or resulting in one of the species
+    // fluxes being negative because of roundoff error. There are also other
+    // terms like artificial viscosity which can cause these problems.
+    // So checking that sum is sufficiently large helps avoid this.
+
+    if (std::abs(sum) > std::numeric_limits<Real>::epsilon() * flux(i,j,k,URHO)) {
       fac = flux(i,j,k,URHO) / sum;
     }
 


### PR DESCRIPTION

## PR summary

The CMA procedure in normalize_species_fluxes scales the species fluxes by the ratio of the density flux to the sum of the species of the fluxes. The idea is that this scaling ensures that the sum of the (rho X) fluxes is equal to the (rho) flux.

This can go wrong if the sum of the species fluxes is very small but non-zero. In particular, there can be numerical problems if the density flux is approximately zero at the interface but not exactly, resulting in division by a small number and/or resulting in one of the species fluxes being negative because of roundoff error. There are also other terms like artificial viscosity which can cause these problems. So checking that sum is sufficiently large helps avoid this.

## PR motivation

#1299 exposed this issue for the StarGrav problem. The star starts at rest, and during the first few timesteps the velocity is either exactly zero or close enough to zero that the Riemann solver zeros them out for safety. The artificial viscosity, which comes before normalize_species_fluxes as currently written, then sets the density flux and species fluxes to very small but non-zero numbers due to roundoff error. The roundoff error results in a species flux that may be negative for one species and positive for another, so they cancel out resulting in sum < epsilon. Then the division by zero goes poorly, resulting in unphysically large species fluxes.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
