### PR TITLE
Move wdmerger initial profile data into struct

### DIFF
--- a/Exec/science/wdmerger/initial_model.H
+++ b/Exec/science/wdmerger/initial_model.H
@@ -35,44 +35,30 @@ namespace initial_model {
 
         amrex::Real r[initial_model_max_npts], rl[initial_model_max_npts], rr[initial_model_max_npts];
         amrex::Real M_enclosed[initial_model_max_npts], g[initial_model_max_npts];
+        amrex::Real rho[initial_model_max_npts];
+        amrex::Real T[initial_model_max_npts];
+        amrex::Real xn[NumSpec][initial_model_max_npts];
     };
 
     // 1D initial models
 
     extern AMREX_GPU_MANAGED model model_P;
     extern AMREX_GPU_MANAGED model model_S;
-    extern AMREX_GPU_MANAGED Real rho_P[initial_model_max_npts];
-    extern AMREX_GPU_MANAGED Real rho_S[initial_model_max_npts];
-    extern AMREX_GPU_MANAGED Real T_P[initial_model_max_npts];
-    extern AMREX_GPU_MANAGED Real T_S[initial_model_max_npts];
-    extern AMREX_GPU_MANAGED Real xn_P[NumSpec][initial_model_max_npts];
-    extern AMREX_GPU_MANAGED Real xn_S[NumSpec][initial_model_max_npts];
-    extern AMREX_GPU_MANAGED Real r_P[initial_model_max_npts];
-    extern AMREX_GPU_MANAGED Real r_S[initial_model_max_npts];
 }
 
 void initialize_model (initial_model::model& model,
-                       amrex::Real r[initial_model::initial_model_max_npts],
                        amrex::Real dx, int npts,
                        amrex::Real mass_tol, amrex::Real hse_tol);
 
-void establish_hse (initial_model::model& model,
-                    amrex::Real rho[initial_model::initial_model_max_npts],
-                    amrex::Real T[initial_model::initial_model_max_npts],
-                    amrex::Real xn[NumSpec][initial_model::initial_model_max_npts],
-                    amrex::Real r[initial_model::initial_model_max_npts]);
+void establish_hse (initial_model::model& model);
 
 // Takes a one-dimensional stellar model and interpolates it to a point in
 // 3D Cartesian grid space. Optionally does a sub-grid-scale interpolation
 // if nsub > 1 (set in the probin file).
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void interpolate_3d_from_1d (amrex::Real rho[initial_model::initial_model_max_npts],
-                             amrex::Real T[initial_model::initial_model_max_npts],
-                             amrex::Real xn[NumSpec][initial_model::initial_model_max_npts],
-                             amrex::Real r[initial_model::initial_model_max_npts],
-                             int npts, const Real* loc, Real star_radius,
-                             const Real* dx, eos_t& state, int nsub = 1)
+void interpolate_3d_from_1d (initial_model::model& model,
+                             const Real* loc, const Real* dx, eos_t& state, int nsub = 1)
 {
     state.rho = 0.0_rt;
     state.p   = 0.0_rt;
@@ -93,12 +79,12 @@ void interpolate_3d_from_1d (amrex::Real rho[initial_model::initial_model_max_np
         max_dx = amrex::max(max_dx, dx[2]);
     }
 
-    if (star_radius <= max_dx && dist < max_dx) {
+    if (model.radius <= max_dx && dist < max_dx) {
 
-        state.rho = rho[0];
-        state.T   = T[0];
+        state.rho = model.rho[0];
+        state.T   = model.T[0];
         for (int n = 0; n < NumSpec; ++n) {
-            state.xn[n]  = xn[n][0];
+            state.xn[n]  = model.xn[n][0];
         }
 
     }
@@ -123,11 +109,11 @@ void interpolate_3d_from_1d (amrex::Real rho[initial_model::initial_model_max_np
 
                     Real dist = std::sqrt(x * x + y * y + z * z);
 
-                    state.rho = state.rho + interpolate::interpolate(dist, npts, r, rho);
-                    state.T   = state.T   + interpolate::interpolate(dist, npts, r, T);
+                    state.rho = state.rho + interpolate::interpolate(dist, model.npts, model.r, model.rho);
+                    state.T   = state.T   + interpolate::interpolate(dist, model.npts, model.r, model.T);
 
                     for (int n = 0; n < NumSpec; ++n) {
-                        state.xn[n] += interpolate::interpolate(dist, npts, r, xn[n]);
+                        state.xn[n] += interpolate::interpolate(dist, model.npts, model.r, model.xn[n]);
                     }
                 }
             }

--- a/Exec/science/wdmerger/problem_initialize_state_data.H
+++ b/Exec/science/wdmerger/problem_initialize_state_data.H
@@ -87,8 +87,7 @@ void problem_initialize_state_data (int i, int j, int k,
                        loc[1] - problem::center_P_initial[1],
                        loc[2] - problem::center_P_initial[2]};
 
-        interpolate_3d_from_1d(initial_model::rho_P, initial_model::T_P, initial_model::xn_P, initial_model::r_P,
-                               initial_model::model_P.npts, pos, initial_model::model_P.radius, dx, zone_state, problem::nsub);
+        interpolate_3d_from_1d(initial_model::model_P, pos, dx, zone_state, problem::nsub);
 
     }
     else if (problem::mass_S > 0.0_rt && (dist_S < initial_model::model_S.radius ||
@@ -98,8 +97,7 @@ void problem_initialize_state_data (int i, int j, int k,
                        loc[1] - problem::center_S_initial[1],
                        loc[2] - problem::center_S_initial[2]};
 
-        interpolate_3d_from_1d(initial_model::rho_S, initial_model::T_S, initial_model::xn_S, initial_model::r_S,
-                               initial_model::model_S.npts, pos, initial_model::model_S.radius, dx, zone_state, problem::nsub);
+        interpolate_3d_from_1d(initial_model::model_S, pos, dx, zone_state, problem::nsub);
 
     }
     else {

--- a/Exec/science/wdmerger/wdmerger_util.cpp
+++ b/Exec/science/wdmerger/wdmerger_util.cpp
@@ -459,11 +459,11 @@ void binary_setup ()
 
     // Allocate arrays to hold the stellar models.
 
-    initialize_model(initial_model::model_P, initial_model::r_P,
+    initialize_model(initial_model::model_P,
                      problem::initial_model_dx, problem::initial_model_npts,
                      problem::initial_model_mass_tol, problem::initial_model_hse_tol);
 
-    initialize_model(initial_model::model_S, initial_model::r_S,
+    initialize_model(initial_model::model_S,
                      problem::initial_model_dx, problem::initial_model_npts,
                      problem::initial_model_mass_tol, problem::initial_model_hse_tol);
 
@@ -496,8 +496,7 @@ void binary_setup ()
 
         initial_model::model_P.central_density = problem::central_density_P;
 
-        establish_hse(initial_model::model_P, initial_model::rho_P, initial_model::T_P,
-                      initial_model::xn_P, initial_model::r_P);
+        establish_hse(initial_model::model_P);
 
         set_wd_composition(initial_model::model_P);
 
@@ -527,8 +526,7 @@ void binary_setup ()
 
             initial_model::model_S.central_density = problem::central_density_S;
 
-            establish_hse(initial_model::model_S, initial_model::rho_S, initial_model::T_S,
-                          initial_model::xn_S, initial_model::r_S);
+            establish_hse(initial_model::model_S);
 
             set_wd_composition(initial_model::model_S);
 
@@ -579,8 +577,7 @@ void binary_setup ()
 
     // Generate primary and secondary WD models.
 
-    establish_hse(initial_model::model_P, initial_model::rho_P, initial_model::T_P,
-                  initial_model::xn_P, initial_model::r_P);
+    establish_hse(initial_model::model_P);
 
     amrex::Print() << std::endl;
 
@@ -594,8 +591,7 @@ void binary_setup ()
 
     if (!problem::single_star) {
 
-        establish_hse(initial_model::model_S, initial_model::rho_S, initial_model::T_S,
-                      initial_model::xn_S, initial_model::r_S);
+        establish_hse(initial_model::model_S);
 
         amrex::Print() << "Generated initial model for secondary WD of mass " << std::setprecision(3) << initial_model::model_S.mass / C::M_solar
                        << " solar masses, central density " << std::setprecision(3) << std::scientific << initial_model::model_S.central_density


### PR DESCRIPTION

## PR summary

The reason they currently weren't in the struct was due to an ancient OpenACC limitation.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
