### PR TITLE
Limit amount of info in the wdmerger initial_model

### DIFF
--- a/Exec/science/wdmerger/_prob_params
+++ b/Exec/science/wdmerger/_prob_params
@@ -7,11 +7,15 @@ mass_P                          real                  1.0e0_rt                 y
 mass_S                          real                  1.0e0_rt                 y
 central_density_P               real                 -1.0e0_rt                 y
 central_density_S               real                 -1.0e0_rt                 y
+radius_P                        real                 -1.0e0_rt                 n
+radius_S                        real                 -1.0e0_rt                 n
 stellar_temp                    real                  1.0e7_rt                 y
-primary_envelope_mass           real                  0.0e0_rt                 n
-secondary_envelope_mass         real                  0.0e0_rt                 n
-primary_envelope_comp           real                  0.0e0_rt                 n                      (nspec, network)
-secondary_envelope_comp         real                  0.0e0_rt                 n                      (nspec, network)
+core_comp_P                     real                  0.0e0_rt                 n                      (nspec, network)
+core_comp_S                     real                  0.0e0_rt                 n                      (nspec, network)
+envelope_mass_P                 real                  0.0e0_rt                 n
+envelope_mass_S                 real                  0.0e0_rt                 n
+envelope_comp_P                 real                  0.0e0_rt                 n                      (nspec, network)
+envelope_comp_S                 real                  0.0e0_rt                 n                      (nspec, network)
 
 
 

--- a/Exec/science/wdmerger/initial_model.H
+++ b/Exec/science/wdmerger/initial_model.H
@@ -4,39 +4,18 @@
 #include <AMReX.H>
 
 #include <network_properties.H>
-
 #include <eos.H>
-
 #include <interpolate.H>
+#include <prob_parameters.H>
 
 namespace initial_model {
     const int initial_model_max_npts = 10000;
 
     struct model {
-        // Physical characteristics
-
-        amrex::Real mass;
-        amrex::Real envelope_mass;
-        amrex::Real central_density;
-        amrex::Real central_temp;
-        amrex::Real min_density;
-        amrex::Real radius;
-
-        // Composition
-
-        amrex::Real core_comp[NumSpec];
-        amrex::Real envelope_comp[NumSpec];
-
-        // Model storage
-
-        amrex::Real dx;
-        int npts;
-        amrex::Real mass_tol, hse_tol;
-
-        amrex::Real r[initial_model_max_npts], rl[initial_model_max_npts], rr[initial_model_max_npts];
-        amrex::Real M_enclosed[initial_model_max_npts], g[initial_model_max_npts];
+        amrex::Real r[initial_model_max_npts];
         amrex::Real rho[initial_model_max_npts];
         amrex::Real T[initial_model_max_npts];
+        amrex::Real p[initial_model_max_npts];
         amrex::Real xn[NumSpec][initial_model_max_npts];
     };
 
@@ -46,18 +25,17 @@ namespace initial_model {
     extern AMREX_GPU_MANAGED model model_S;
 }
 
-void initialize_model (initial_model::model& model,
-                       amrex::Real dx, int npts,
-                       amrex::Real mass_tol, amrex::Real hse_tol);
-
-void establish_hse (initial_model::model& model);
+void establish_hse (initial_model::model& model,
+                    Real& mass, Real& central_density,
+                    Real envelope_mass, Real& radius,
+                    const Real core_comp[NumSpec], const Real envelope_comp[NumSpec]);
 
 // Takes a one-dimensional stellar model and interpolates it to a point in
 // 3D Cartesian grid space. Optionally does a sub-grid-scale interpolation
 // if nsub > 1 (set in the probin file).
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void interpolate_3d_from_1d (initial_model::model& model,
+void interpolate_3d_from_1d (initial_model::model& model, Real radius,
                              const Real* loc, const Real* dx, eos_t& state, int nsub = 1)
 {
     state.rho = 0.0_rt;
@@ -79,7 +57,7 @@ void interpolate_3d_from_1d (initial_model::model& model,
         max_dx = amrex::max(max_dx, dx[2]);
     }
 
-    if (model.radius <= max_dx && dist < max_dx) {
+    if (radius <= max_dx && dist < max_dx) {
 
         state.rho = model.rho[0];
         state.T   = model.T[0];
@@ -109,11 +87,11 @@ void interpolate_3d_from_1d (initial_model::model& model,
 
                     Real dist = std::sqrt(x * x + y * y + z * z);
 
-                    state.rho = state.rho + interpolate::interpolate(dist, model.npts, model.r, model.rho);
-                    state.T   = state.T   + interpolate::interpolate(dist, model.npts, model.r, model.T);
+                    state.rho = state.rho + interpolate::interpolate(dist, problem::initial_model_npts, model.r, model.rho);
+                    state.T   = state.T   + interpolate::interpolate(dist, problem::initial_model_npts, model.r, model.T);
 
                     for (int n = 0; n < NumSpec; ++n) {
-                        state.xn[n] += interpolate::interpolate(dist, model.npts, model.r, model.xn[n]);
+                        state.xn[n] += interpolate::interpolate(dist, problem::initial_model_npts, model.r, model.xn[n]);
                     }
                 }
             }

--- a/Exec/science/wdmerger/problem_initialize_state_data.H
+++ b/Exec/science/wdmerger/problem_initialize_state_data.H
@@ -81,23 +81,23 @@ void problem_initialize_state_data (int i, int j, int k,
 
     eos_t zone_state;
 
-    if (problem::mass_P > 0.0_rt && (dist_P < initial_model::model_P.radius ||
-                                     (initial_model::model_P.radius <= max_dx && dist_P < max_dx))) {
+    if (problem::mass_P > 0.0_rt && (dist_P < problem::radius_P ||
+                                     (problem::radius_P <= max_dx && dist_P < max_dx))) {
         Real pos[3] = {loc[0] - problem::center_P_initial[0],
                        loc[1] - problem::center_P_initial[1],
                        loc[2] - problem::center_P_initial[2]};
 
-        interpolate_3d_from_1d(initial_model::model_P, pos, dx, zone_state, problem::nsub);
+        interpolate_3d_from_1d(initial_model::model_P, problem::radius_P, pos, dx, zone_state, problem::nsub);
 
     }
-    else if (problem::mass_S > 0.0_rt && (dist_S < initial_model::model_S.radius ||
-                                          (initial_model::model_S.radius <= max_dx && dist_S < max_dx))) {
+    else if (problem::mass_S > 0.0_rt && (dist_S < problem::radius_S ||
+                                          (problem::radius_S <= max_dx && dist_S < max_dx))) {
 
         Real pos[3] = {loc[0] - problem::center_S_initial[0],
                        loc[1] - problem::center_S_initial[1],
                        loc[2] - problem::center_S_initial[2]};
 
-        interpolate_3d_from_1d(initial_model::model_S, pos, dx, zone_state, problem::nsub);
+        interpolate_3d_from_1d(initial_model::model_S, problem::radius_S, pos, dx, zone_state, problem::nsub);
 
     }
     else {
@@ -136,12 +136,12 @@ void problem_initialize_state_data (int i, int j, int k,
 
     if (problem::problem != 1) {
 
-        if (dist_P < initial_model::model_P.radius) {
+        if (dist_P < problem::radius_P) {
             state(i,j,k,UMX) += problem::vel_P[0] * state(i,j,k,URHO);
             state(i,j,k,UMY) += problem::vel_P[1] * state(i,j,k,URHO);
             state(i,j,k,UMZ) += problem::vel_P[2] * state(i,j,k,URHO);
         }
-        else if (dist_S < initial_model::model_S.radius) {
+        else if (dist_S < problem::radius_S) {
             state(i,j,k,UMX) += problem::vel_S[0] * state(i,j,k,URHO);
             state(i,j,k,UMY) += problem::vel_S[1] * state(i,j,k,URHO);
             state(i,j,k,UMZ) += problem::vel_S[2] * state(i,j,k,URHO);
@@ -167,8 +167,8 @@ void problem_initialize_state_data (int i, int j, int k,
 
         if (state(i,j,k,URHO) <= castro::ambient_safety_factor * ambient::ambient_state[URHO]) {
 
-            Real cap_radius = 1.25e0_rt * amrex::max(initial_model::model_P.radius + std::abs(problem::center_P_initial[problem::axis_1-1]),
-                                                     initial_model::model_S.radius + std::abs(problem::center_S_initial[problem::axis_1-1]));
+            Real cap_radius = 1.25e0_rt * amrex::max(problem::radius_P + std::abs(problem::center_P_initial[problem::axis_1-1]),
+                                                     problem::radius_S + std::abs(problem::center_S_initial[problem::axis_1-1]));
 
             for (int n = 0; n < 3; ++n) {
                 rot_loc[n] = amrex::min(cap_radius, std::abs(rot_loc[n])) * std::copysign(1.0_rt, rot_loc[n]);
@@ -199,7 +199,7 @@ void problem_initialize_state_data (int i, int j, int k,
 
     if (problem::problem == 1 && problem::initial_radial_velocity_factor > 0.0_rt) {
 
-        if (dist_P < initial_model::model_P.radius || dist_P < initial_model::model_S.radius) {
+        if (dist_P < problem::radius_P || dist_P < problem::radius_S) {
 
             Real R_prp    = std::sqrt(std::pow(loc[problem::axis_1-1], 2) + std::pow(loc[problem::axis_2-1], 2));
             Real cosTheta = loc[problem::axis_1-1] / R_prp;

--- a/Exec/science/wdmerger/wdmerger_util.cpp
+++ b/Exec/science/wdmerger/wdmerger_util.cpp
@@ -71,7 +71,7 @@ void kepler_third_law (Real radius_1, Real mass_1, Real radius_2, Real mass_2,
 
 // Given a WD mass, set its core and envelope composition.
 
-void set_wd_composition (initial_model::model& model)
+void set_wd_composition (initial_model::model& model, Real mass, Real& envelope_mass, Real core_comp[NumSpec], Real envelope_comp[NumSpec])
 {
     int iHe4 = network_spec_index("helium-4");
     int iC12 = network_spec_index("carbon-12");
@@ -80,28 +80,28 @@ void set_wd_composition (initial_model::model& model)
     int iMg24 = network_spec_index("magnesium-24");
 
     for (int n = 0; n < NumSpec; ++n) {
-        model.core_comp[n] = small_x;
-        model.envelope_comp[n] = small_x;
+        core_comp[n] = small_x;
+        envelope_comp[n] = small_x;
     }
 
-    model.envelope_mass = 0.0_rt;
+    envelope_mass = 0.0_rt;
 
     // Here we follow the prescription of Dan et al. 2012.
 
-    if (model.mass > 0.0_rt && model.mass < problem::max_he_wd_mass) {
+    if (mass > 0.0_rt && mass < problem::max_he_wd_mass) {
 
         if (iHe4 < 0) {
             amrex::Error("Must have He4 in the nuclear network.");
         }
 
-        model.core_comp[iHe4] = 1.0_rt;
+        core_comp[iHe4] = 1.0_rt;
 
         for (int n = 0; n < NumSpec; ++n) {
-            model.envelope_comp[n] = model.core_comp[n];
+            envelope_comp[n] = core_comp[n];
         }
 
     }
-    else if (model.mass >= problem::max_he_wd_mass && model.mass < problem::max_hybrid_wd_mass) {
+    else if (mass >= problem::max_he_wd_mass && mass < problem::max_hybrid_wd_mass) {
 
         if (iC12 < 0) {
             amrex::Error("Must have C12 in the nuclear network.");
@@ -110,25 +110,25 @@ void set_wd_composition (initial_model::model& model)
             amrex::Error("Must have O16 in the nuclear network.");
         }
 
-        model.core_comp[iC12] = problem::hybrid_wd_c_frac;
-        model.core_comp[iO16] = problem::hybrid_wd_o_frac;
+        core_comp[iC12] = problem::hybrid_wd_c_frac;
+        core_comp[iO16] = problem::hybrid_wd_o_frac;
 
-        model.envelope_mass = problem::hybrid_wd_he_shell_mass;
+        envelope_mass = problem::hybrid_wd_he_shell_mass;
 
-        if (model.envelope_mass > 0.0_rt) {
+        if (envelope_mass > 0.0_rt) {
             if (iHe4 < 0) {
                 amrex::Error("Must have He4 in the nuclear network.");
             }
-            model.envelope_comp[iHe4] = 1.0_rt;
+            envelope_comp[iHe4] = 1.0_rt;
         }
         else {
             for (int n = 0; n < NumSpec; ++n) {
-                model.envelope_comp[n] = model.core_comp[n];
+                envelope_comp[n] = core_comp[n];
             }
         }
 
     }
-    else if (model.mass >= problem::max_hybrid_wd_mass && model.mass < problem::max_co_wd_mass) {
+    else if (mass >= problem::max_hybrid_wd_mass && mass < problem::max_co_wd_mass) {
 
         if (iC12 < 0) {
             amrex::Error("Must have C12 in the nuclear network.");
@@ -137,25 +137,25 @@ void set_wd_composition (initial_model::model& model)
             amrex::Error("Must have O16 in the nuclear network.");
         }
 
-        model.core_comp[iC12] = problem::co_wd_c_frac;
-        model.core_comp[iO16] = problem::co_wd_o_frac;
+        core_comp[iC12] = problem::co_wd_c_frac;
+        core_comp[iO16] = problem::co_wd_o_frac;
 
-        model.envelope_mass = problem::co_wd_he_shell_mass;
+        envelope_mass = problem::co_wd_he_shell_mass;
 
-        if (model.envelope_mass > 0.0_rt) {
+        if (envelope_mass > 0.0_rt) {
             if (iHe4 < 0) {
                 amrex::Error("Must have He4 in the nuclear network.");
             }
-            model.envelope_comp[iHe4] = 1.0_rt;
+            envelope_comp[iHe4] = 1.0_rt;
         }
         else {
             for (int n = 0; n < NumSpec; ++n) {
-                model.envelope_comp[n] = model.core_comp[n];
+                envelope_comp[n] = core_comp[n];
             }
         }
 
     }
-    else if (model.mass > problem::max_co_wd_mass) {
+    else if (mass > problem::max_co_wd_mass) {
 
         if (iO16 < 0) {
             amrex::Error("Must have O16 in the nuclear network.");
@@ -167,12 +167,12 @@ void set_wd_composition (initial_model::model& model)
             amrex::Error("Must have Mg24 in the nuclear network.");
         }
 
-        model.core_comp[iO16]  = problem::onemg_wd_o_frac;
-        model.core_comp[iNe20] = problem::onemg_wd_ne_frac;
-        model.core_comp[iMg24] = problem::onemg_wd_mg_frac;
+        core_comp[iO16]  = problem::onemg_wd_o_frac;
+        core_comp[iNe20] = problem::onemg_wd_ne_frac;
+        core_comp[iMg24] = problem::onemg_wd_mg_frac;
 
         for (int n = 0; n < NumSpec; ++n) {
-            model.envelope_comp[n] = model.core_comp[n];
+            envelope_comp[n] = core_comp[n];
         }
 
     }
@@ -183,13 +183,13 @@ void set_wd_composition (initial_model::model& model)
     Real envelope_sum = 0.0_rt;
 
     for (int n = 0; n < NumSpec; ++n) {
-        core_sum += model.core_comp[n];
-        envelope_sum += model.envelope_comp[n];
+        core_sum += core_comp[n];
+        envelope_sum += envelope_comp[n];
     }
 
     for (int n = 0; n < NumSpec; ++n) {
-        model.core_comp[n] /= core_sum;
-        model.envelope_comp[n] /= envelope_sum;
+        core_comp[n] /= core_sum;
+        envelope_comp[n] /= envelope_sum;
     }
 }
 
@@ -457,96 +457,45 @@ void binary_setup ()
         problem::vel_S[n] = 0.0_rt;
     }
 
-    // Allocate arrays to hold the stellar models.
-
-    initialize_model(initial_model::model_P,
-                     problem::initial_model_dx, problem::initial_model_npts,
-                     problem::initial_model_mass_tol, problem::initial_model_hse_tol);
-
-    initialize_model(initial_model::model_S,
-                     problem::initial_model_dx, problem::initial_model_npts,
-                     problem::initial_model_mass_tol, problem::initial_model_hse_tol);
-
-    initial_model::model_P.min_density = ambient::ambient_state[URHO];
-    initial_model::model_S.min_density = ambient::ambient_state[URHO];
-
-    initial_model::model_P.central_temp = problem::stellar_temp;
-    initial_model::model_S.central_temp = problem::stellar_temp;
-
-
-
     // Fill in the model's physical details.
     // If we're integrating to reach a desired mass, set the composition accordingly.
     // If instead we're fixing the central density, then first we'll assume the composition is
     // that of a solar mass WD as a initial guess, and get the corresponding mass. 
     // Then we set the composition to match this preliminary mass, and we'll get a final mass later.
 
-    if (problem::mass_P > 0.0_rt) {
-
-        initial_model::model_P.mass = problem::mass_P;
-
-        set_wd_composition(initial_model::model_P);
-
+    if (problem::central_density_P > 0.0_rt) {
+        // Initial guess for the mass
+        problem::mass_P = C::M_solar;
     }
-    else if (problem::central_density_P > 0.0_rt) {
-
-        initial_model::model_P.mass = C::M_solar;
-
-        set_wd_composition(initial_model::model_P);
-
-        initial_model::model_P.central_density = problem::central_density_P;
-
-        establish_hse(initial_model::model_P);
-
-        set_wd_composition(initial_model::model_P);
-
-    }
-    else {
-
+    else if (problem::mass_P <= 0.0_rt) {
         amrex::Error("Must specify either a positive primary mass or a positive primary central density.");
-
     }
+
+    set_wd_composition(initial_model::model_P, problem::mass_P, problem::envelope_mass_P, problem::core_comp_P, problem::envelope_comp_P);
 
 
 
     if (!problem::single_star) {
 
-        if (problem::mass_S > 0.0_rt) {
-
-            initial_model::model_S.mass = problem::mass_S;
-
-            set_wd_composition(initial_model::model_S);
-
+        if (problem::central_density_S > 0.0_rt) {
+            // Initial guess for the mass
+            problem::mass_S = C::M_solar;
         }
-        else if (problem::central_density_S > 0.0_rt) {
-
-            initial_model::model_S.mass = C::M_solar;
-
-            set_wd_composition(initial_model::model_S);
-
-            initial_model::model_S.central_density = problem::central_density_S;
-
-            establish_hse(initial_model::model_S);
-
-            set_wd_composition(initial_model::model_S);
-
-        }
-        else {
-
+        else if (problem::mass_S <= 0.0_rt) {
             amrex::Error("If we are doing a binary calculation, we must specify either a positive secondary mass or a positive secondary central density");
-
         }
+
+        set_wd_composition(initial_model::model_S, problem::mass_S, problem::envelope_mass_S, problem::core_comp_S, problem::envelope_comp_S);
 
         for (int n = 0; n < NumSpec; ++n) {
-            ambient::ambient_state[UFS+n] = ambient::ambient_state[URHO] * (initial_model::model_P.envelope_comp[n] +
-                                                                            initial_model::model_S.envelope_comp[n]) / 2;
+            ambient::ambient_state[UFS+n] = ambient::ambient_state[URHO] * (problem::envelope_comp_P[n] + problem::envelope_comp_S[n]) / 2;
         }
 
     }
     else {
 
         for (int n = 0; n < NumSpec; ++n) {
-            ambient::ambient_state[UFS+n] = ambient::ambient_state[URHO] * initial_model::model_P.envelope_comp[n];
+            ambient::ambient_state[UFS+n] = ambient::ambient_state[URHO] * problem::envelope_comp_P[n];
         }
 
     }
@@ -577,29 +526,29 @@ void binary_setup ()
 
     // Generate primary and secondary WD models.
 
-    establish_hse(initial_model::model_P);
+    establish_hse(initial_model::model_P, problem::mass_P, problem::central_density_P, problem::envelope_mass_P,
+                  problem::radius_P, problem::core_comp_P, problem::envelope_comp_P);
 
     amrex::Print() << std::endl;
 
-    amrex::Print() << "Generated initial model for primary WD of mass " << std::setprecision(3) << initial_model::model_P.mass / C::M_solar
-                   << " solar masses, central density " << std::setprecision(3) << std::scientific << initial_model::model_P.central_density
-                   << " g cm**-3, and radius " << std::setprecision(3) << std::scientific << initial_model::model_P.radius << " cm."
+    amrex::Print() << "Generated initial model for primary WD of mass " << std::setprecision(3) << problem::mass_P / C::M_solar
+                   << " solar masses, central density " << std::setprecision(3) << std::scientific << problem::central_density_P
+                   << " g cm**-3, and radius " << std::setprecision(3) << std::scientific << problem::radius_P << " cm."
                    << std::endl << std::endl;
 
-    problem::mass_P = initial_model::model_P.mass;
-    problem::roche_rad_P = initial_model::model_P.radius;
+    problem::roche_rad_P = problem::radius_P;
 
     if (!problem::single_star) {
 
-        establish_hse(initial_model::model_S);
+        establish_hse(initial_model::model_S, problem::mass_S, problem::central_density_S, problem::envelope_mass_S,
+                      problem::radius_S, problem::core_comp_S, problem::envelope_comp_S);
 
-        amrex::Print() << "Generated initial model for secondary WD of mass " << std::setprecision(3) << initial_model::model_S.mass / C::M_solar
-                       << " solar masses, central density " << std::setprecision(3) << std::scientific << initial_model::model_S.central_density
-                       << " g cm**-3, and radius " << std::setprecision(3) << std::scientific << initial_model::model_S.radius << " cm."
+        amrex::Print() << "Generated initial model for secondary WD of mass " << std::setprecision(3) << problem::mass_S / C::M_solar
+                       << " solar masses, central density " << std::setprecision(3) << std::scientific << problem::central_density_S
+                       << " g cm**-3, and radius " << std::setprecision(3) << std::scientific << problem::radius_S << " cm."
                        << std::endl << std::endl;
 
-        problem::mass_S = initial_model::model_S.mass;
-        problem::roche_rad_S = initial_model::model_S.radius;
+        problem::roche_rad_S = problem::radius_S;
 
         // Compute initial Roche radii
 
@@ -609,7 +558,7 @@ void binary_setup ()
 
         if (problem::problem == 0) {
 
-            problem::collision_separation *= initial_model::model_S.radius;
+            problem::collision_separation *= problem::radius_S;
 
             if (problem::collision_velocity < 0.0e0_rt) {
 
@@ -641,7 +590,7 @@ void binary_setup ()
             // Since the secondary's radius is greater than the primary's, measuring in the
             // units of the primary's radius will guarantee contact.
 
-            Real collision_offset = problem::collision_impact_parameter * initial_model::model_P.radius;
+            Real collision_offset = problem::collision_impact_parameter * problem::radius_P;
 
             problem::center_P_initial[problem::axis_2-1] -= collision_offset;
             problem::center_S_initial[problem::axis_2-1] += collision_offset;
@@ -660,7 +609,7 @@ void binary_setup ()
 
                 // Set the orbital distance, then calculate the rotational period.
 
-                problem::a = problem::roche_radius_factor * (initial_model::model_S.radius / problem::roche_rad_S);
+                problem::a = problem::roche_radius_factor * (problem::radius_S / problem::roche_rad_S);
 
                 castro::rotational_period = -1.0_rt;
 
@@ -668,7 +617,7 @@ void binary_setup ()
 
             Real v_P_r, v_S_r, v_P_phi, v_S_phi;
 
-            kepler_third_law(initial_model::model_P.radius, initial_model::model_P.mass, initial_model::model_S.radius, initial_model::model_S.mass,
+            kepler_third_law(problem::radius_P, problem::mass_P, problem::radius_S, problem::mass_S,
                              castro::rotational_period, problem::orbital_eccentricity, problem::orbital_angle,
                              problem::a, problem::r_P_initial, problem::r_S_initial, v_P_r, v_S_r, v_P_phi, v_S_phi);
 
@@ -679,12 +628,12 @@ void binary_setup ()
             if (Castro::physbc().lo(problem::axis_1-1) == Symmetry) {
 
                 // In this case we're only modelling the secondary.
-                length = problem::r_P_initial + initial_model::model_P.radius;
+                length = problem::r_P_initial + problem::radius_P;
 
             }
             else {
 
-                length = (problem::r_S_initial - problem::r_P_initial) + initial_model::model_P.radius + initial_model::model_S.radius;
+                length = (problem::r_S_initial - problem::r_P_initial) + problem::radius_P + problem::radius_S;
 
             }
 
@@ -694,7 +643,7 @@ void binary_setup ()
 
             // Make sure the stars are not touching.
 
-            if (initial_model::model_P.radius + initial_model::model_S.radius > problem::a) {
+            if (problem::radius_P + problem::radius_S > problem::a) {
                 amrex::Error("ERROR: Stars are touching!");
             }
 
@@ -748,7 +697,7 @@ void binary_setup ()
             // The tidal radius is given by (M_BH / M_WD)^(1/3) * R_WD.
 
             problem::tde_tidal_radius = std::pow(castro::point_mass / problem::mass_P, 1.0_rt / 3.0_rt) *
-                                        initial_model::model_P.radius;
+                                        problem::radius_P;
 
             // The usual definition for the Schwarzschild radius.
 
@@ -809,23 +758,23 @@ void binary_setup ()
 
     if (!(AMREX_SPACEDIM == 2 && Castro::physbc().lo(1) == Symmetry)) {
 
-        if ((0.5_rt * (probhi[0] - problo[0]) < initial_model::model_P.radius) ||
-            (0.5_rt * (probhi[1] - problo[1]) < initial_model::model_P.radius) ||
-            (0.5_rt * (probhi[2] - problo[2]) < initial_model::model_P.radius && AMREX_SPACEDIM == 3)) {
+        if ((0.5_rt * (probhi[0] - problo[0]) < problem::radius_P) ||
+            (0.5_rt * (probhi[1] - problo[1]) < problem::radius_P) ||
+            (0.5_rt * (probhi[2] - problo[2]) < problem::radius_P && AMREX_SPACEDIM == 3)) {
             amrex::Error("Primary does not fit inside the domain.");
         }
 
-        if ((0.5_rt * (probhi[0] - problo[0]) < initial_model::model_S.radius) ||
-            (0.5_rt * (probhi[1] - problo[1]) < initial_model::model_S.radius) ||
-            (0.5_rt * (probhi[2] - problo[2]) < initial_model::model_S.radius && AMREX_SPACEDIM == 3) ) {
+        if ((0.5_rt * (probhi[0] - problo[0]) < problem::radius_S) ||
+            (0.5_rt * (probhi[1] - problo[1]) < problem::radius_S) ||
+            (0.5_rt * (probhi[2] - problo[2]) < problem::radius_S && AMREX_SPACEDIM == 3) ) {
             amrex::Error("Secondary does not fit inside the domain.");
         }
 
     }
     else {
 
-        if ((probhi[0] - problo[0] < initial_model::model_S.radius) ||
-            (probhi[1] - problo[1] < 2.0_rt * initial_model::model_S.radius)) {
+        if ((probhi[0] - problo[0] < problem::radius_S) ||
+            (probhi[1] - problo[1] < 2.0_rt * problem::radius_S)) {
             amrex::Error("Secondary does not fit inside the domain.");
         }
 


### PR DESCRIPTION

## PR summary

All data other than the radius, density, temperature, pressure, and composition is moved out of the initial_model struct (mostly into _prob_params data).

## PR motivation

This sets up, as a following change, storing the remaining model data in the main Castro initial model functionality.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
