### PR TITLE
Reorder header includes to fix EOS compilation

### DIFF
--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -2,7 +2,6 @@
 
 #include <AMReX_LevelBld.H>
 #include <AMReX_ParmParse.H>
-#include <eos.H>
 #include <Castro.H>
 #include <Castro_F.H>
 #include <Castro_bc_fill_nd_F.H>
@@ -18,6 +17,7 @@
 
 #include <AMReX_buildInfo.H>
 #include <microphysics_F.H>
+#include <eos.H>
 #include <prob_parameters_F.H>
 
 using std::string;


### PR DESCRIPTION

## PR summary

starkiller-astro/Microphysics#454 unintentionally broke compilation because it's depending on small_temp and small_dens being available global parameters.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
