### PR TITLE
Rework diagnostic sums to be more customizable

### DIFF
--- a/Exec/hydro_tests/test_convect/inputs_2d
+++ b/Exec/hydro_tests/test_convect/inputs_2d
@@ -68,6 +68,3 @@ amr.derive_plot_vars = ALL
 
 #PROBIN FILENAME
 amr.probin_file = probin
-
-# DATA LOG
-amr.data_log = log

--- a/Exec/hydro_tests/test_convect/problem_diagnostics.H
+++ b/Exec/hydro_tests/test_convect/problem_diagnostics.H
@@ -1,14 +1,10 @@
-#include <iomanip>
+#ifndef problem_diagnostics_H
+#define problem_diagnostics_H
 
-#include <Castro.H>
-#include <Castro_F.H>
-
-using namespace amrex;
-
+AMREX_INLINE
 void
-Castro::sum_integrated_quantities ()
+Castro::problem_diagnostics ()
 {
-
     int finest_level = parent->finestLevel();
     Real time        = state[State_Type].curTime();
     Real mass        = 0.0;
@@ -26,13 +22,15 @@ Castro::sum_integrated_quantities ()
 	
 	rho_E    += ca_lev.volWgtSum("rho_E", time);
 
-	Tmax_level = ca_lev.maxVal("Temp", time);
+        auto temp_mf = ca_lev.derive("Temp", time, 0);
+	Tmax_level = temp_mf->max(0, 0);
 	if (Tmax_level > Tmax)
 	  {
 	    Tmax = Tmax_level;
 	  }
 
-	MachMax_level = ca_lev.maxVal("MachNumber", time);
+        auto mach_mf = ca_lev.derive("MachNumber", time, 0);
+	MachMax_level = mach_mf->max(0, 0);
 	if (MachMax_level > MachMax)
 	  {
 	    MachMax = MachMax_level;
@@ -48,7 +46,7 @@ Castro::sum_integrated_quantities ()
         std::cout << "TIME= " << time << " RHO*E = "   << rho_E     << '\n';
 
 	// get output files
-	std::ostream& data_log1 = parent->DataLog(0);
+	std::ostream& data_log1 = *Castro::problem_data_logs[0];
 
         if (time == 0.0) {
            data_log1 << std::setw(14) <<  "#     time    ";
@@ -69,18 +67,4 @@ Castro::sum_integrated_quantities ()
     }
 }
 
-
-Real
-Castro::maxVal (const std::string& name,
-                Real               time)
-{
-  Real        maxval  = 0.0;
-  const Real* dx      = geom.CellSize();
-  auto        mf      = derive(name,time,0);
-  BL_ASSERT(mf);
-
-  maxval = (*mf).max(0,0);
-
-  return maxval;
-}
-
+#endif

--- a/Exec/hydro_tests/test_convect/problem_initialize.H
+++ b/Exec/hydro_tests/test_convect/problem_initialize.H
@@ -34,5 +34,16 @@ void problem_initialize ()
     for (int i = 0; i < problem::num_vortices; i++) {
         problem::xloc_vortices[i] = (static_cast<Real>(i) + 0.5_rt) * offset + problo[0];
     }
+
+    // Set up Castro data logs for this problem
+
+    Castro::problem_data_logs.resize(1);
+
+    Castro::problem_data_logs[0].reset(new std::fstream);
+    Castro::problem_data_logs[0]->open("problem_diag.out", std::ios::out | std::ios::app);
+    if (!Castro::problem_data_logs[0]->good()) {
+        amrex::FileOpenFailed("problem_diag.out");
+    }
+
 }
 #endif

--- a/Exec/hydro_tests/toy_convect/inputs_2d
+++ b/Exec/hydro_tests/toy_convect/inputs_2d
@@ -61,6 +61,3 @@ amr.derive_plot_vars = ALL
 
 #PROBIN FILENAME
 amr.probin_file = probin
-
-# DATA LOG
-amr.data_log = log

--- a/Exec/hydro_tests/toy_convect/problem_diagnostics.H
+++ b/Exec/hydro_tests/toy_convect/problem_diagnostics.H
@@ -1,14 +1,10 @@
-#include <iomanip>
+#ifndef problem_diagnostics_H
+#define problem_diagnostics_H
 
-#include <Castro.H>
-#include <Castro_F.H>
-
-using namespace amrex;
-
+AMREX_INLINE
 void
-Castro::sum_integrated_quantities ()
+Castro::problem_diagnostics ()
 {
-
     int finest_level = parent->finestLevel();
     Real time        = state[State_Type].curTime();
     Real mass        = 0.0;
@@ -26,13 +22,15 @@ Castro::sum_integrated_quantities ()
 	
 	rho_E    += ca_lev.volWgtSum("rho_E", time);
 
-	Tmax_level = ca_lev.maxVal("Temp", time);
+        auto temp_mf = ca_lev.derive("Temp", time, 0);
+	Tmax_level = temp_mf->max(0, 0);
 	if (Tmax_level > Tmax)
 	  {
 	    Tmax = Tmax_level;
 	  }
 
-	MachMax_level = ca_lev.maxVal("MachNumber", time);
+        auto mach_mf = ca_lev.derive("MachNumber", time, 0);
+	MachMax_level = mach_mf->max(0, 0);
 	if (MachMax_level > MachMax)
 	  {
 	    MachMax = MachMax_level;
@@ -48,7 +46,7 @@ Castro::sum_integrated_quantities ()
         std::cout << "TIME= " << time << " RHO*E = "   << rho_E     << '\n';
 
 	// get output files
-	std::ostream& data_log1 = parent->DataLog(0);
+	std::ostream& data_log1 = *Castro::problem_data_logs[0];
 
         if (time == 0.0) {
            data_log1 << std::setw(14) <<  "#     time    ";
@@ -69,18 +67,4 @@ Castro::sum_integrated_quantities ()
     }
 }
 
-
-Real
-Castro::maxVal (const std::string& name,
-                Real               time)
-{
-  Real        maxval  = 0.0;
-  const Real* dx      = geom.CellSize();
-  auto        mf      = derive(name,time,0);
-  BL_ASSERT(mf);
-
-  maxval = (*mf).max(0,0);
-
-  return maxval;
-}
-
+#endif

--- a/Exec/hydro_tests/toy_convect/problem_initialize.H
+++ b/Exec/hydro_tests/toy_convect/problem_initialize.H
@@ -34,6 +34,17 @@ void problem_initialize ()
     for (int i = 0; i < problem::num_vortices; i++) {
         problem::xloc_vortices[i] = (static_cast<Real>(i) + 0.5_rt) * offset + problo[0];
     }
+
+    // Set up Castro data logs for this problem
+
+    Castro::problem_data_logs.resize(1);
+
+    Castro::problem_data_logs[0].reset(new std::fstream);
+    Castro::problem_data_logs[0]->open("problem_diag.out", std::ios::out | std::ios::app);
+    if (!Castro::problem_data_logs[0]->good()) {
+        amrex::FileOpenFailed("problem_diag.out");
+    }
+
 }
 
 #endif

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -1152,6 +1152,11 @@ public:
 ///
     void sum_integrated_quantities ();
 
+///
+/// Problem-specific diagnostics (called by sum_integrated_quantities)
+///
+    void problem_diagnostics ();
+
     void write_info ();
 
 ///
@@ -1220,6 +1225,12 @@ public:
 ///     non-integer number.
 ///
     static amrex::Real num_zones_advanced;
+
+///
+/// diagnostics
+///
+    static Vector<std::unique_ptr<std::fstream> > data_logs;
+    static Vector<std::unique_ptr<std::fstream> > problem_data_logs;
 
 protected:
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -84,6 +84,9 @@ Vector<std::string> Castro::source_names;
 
 Vector<AMRErrorTag> Castro::custom_error_tags;
 
+Vector<std::unique_ptr<std::fstream>> Castro::data_logs;
+Vector<std::unique_ptr<std::fstream>> Castro::problem_data_logs;
+
 #ifdef TRUE_SDC
 int          Castro::SDC_NODES;
 Vector<Real> Castro::dt_sdc;
@@ -460,6 +463,18 @@ Castro::read_params ()
 #endif
 
    StateDescriptor::setBndryFuncThreadSafety(bndry_func_thread_safe);
+
+   // Open up Castro data logs
+   // Note that this functionality also exists in the Amr class
+   // but we implement it on our own to have a little more control.
+
+   data_logs.resize(1);
+
+   data_logs[0].reset(new std::fstream);
+   data_logs[0]->open("grid_diag.out", std::ios::out | std::ios::app);
+   if (!data_logs[0]->good()) {
+       amrex::FileOpenFailed("grid_diag.out");
+   }
 
    ParmParse ppa("amr");
    ppa.query("probin_file",probin_file);

--- a/Source/driver/sum_integrated_quantities.cpp
+++ b/Source/driver/sum_integrated_quantities.cpp
@@ -7,6 +7,8 @@
 #include <Gravity.H>
 #endif
 
+#include <problem_diagnostics.H>
+
 using namespace amrex;
 
 void
@@ -159,60 +161,57 @@ Castro::sum_integrated_quantities ()
             std::cout << "TIME= " << time << " RHO*PHI     = "   << rho_phi   << '\n';
             std::cout << "TIME= " << time << " TOTAL ENERGY= "   << total_energy << '\n';
 #endif
-            if (parent->NumDataLogs() > 0 ) {
 
-               std::ostream& data_log1 = parent->DataLog(0);
+            std::ostream& data_log1 = *Castro::data_logs[0];
 
-               if (data_log1.good()) {
+            if (data_log1.good()) {
 
-                  if (time == 0.0) {
-                      data_log1 << std::setw(datwidth) <<  "          time";
-                      data_log1 << std::setw(datwidth) <<  "          mass";
-                      data_log1 << std::setw(datwidth) <<  "          xmom";
-                      data_log1 << std::setw(datwidth) <<  "          ymom";
-                      data_log1 << std::setw(datwidth) <<  "          zmom";
-                      data_log1 << std::setw(datwidth) <<  "     ang mom x";
-                      data_log1 << std::setw(datwidth) <<  "     ang mom y";
-                      data_log1 << std::setw(datwidth) <<  "     ang mom z";
+               if (time == 0.0) {
+                   data_log1 << std::setw(datwidth) <<  "          time";
+                   data_log1 << std::setw(datwidth) <<  "          mass";
+                   data_log1 << std::setw(datwidth) <<  "          xmom";
+                   data_log1 << std::setw(datwidth) <<  "          ymom";
+                   data_log1 << std::setw(datwidth) <<  "          zmom";
+                   data_log1 << std::setw(datwidth) <<  "     ang mom x";
+                   data_log1 << std::setw(datwidth) <<  "     ang mom y";
+                   data_log1 << std::setw(datwidth) <<  "     ang mom z";
 #ifdef HYBRID_MOMENTUM
-                      data_log1 << std::setw(datwidth) <<  "     hyb mom r";
-                      data_log1 << std::setw(datwidth) <<  "     hyb mom l";
-                      data_log1 << std::setw(datwidth) <<  "     hyb mom p";
+                   data_log1 << std::setw(datwidth) <<  "     hyb mom r";
+                   data_log1 << std::setw(datwidth) <<  "     hyb mom l";
+                   data_log1 << std::setw(datwidth) <<  "     hyb mom p";
 #endif
-                      data_log1 << std::setw(datwidth) <<  "         rho_K";
-                      data_log1 << std::setw(datwidth) <<  "         rho_e";
-                      data_log1 << std::setw(datwidth) <<  "         rho_E";
+                   data_log1 << std::setw(datwidth) <<  "         rho_K";
+                   data_log1 << std::setw(datwidth) <<  "         rho_e";
+                   data_log1 << std::setw(datwidth) <<  "         rho_E";
 #ifdef GRAVITY
-                      data_log1 << std::setw(datwidth) <<  "       rho_phi";
-                      data_log1 << std::setw(datwidth) <<  "  total energy";
+                   data_log1 << std::setw(datwidth) <<  "       rho_phi";
+                   data_log1 << std::setw(datwidth) <<  "  total energy";
 #endif
-                      data_log1 << std::endl;
-                  }
-
-                  // Write the quantities at this time
-                  data_log1 << std::setw(datwidth) <<  time;
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << mass;
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << mom[0];
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << mom[1];
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << mom[2];
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << ang_mom[0];
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << ang_mom[1];
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << ang_mom[2];
-#ifdef HYBRID_MOMENTUM
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << hyb_mom[0];
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << hyb_mom[1];
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << hyb_mom[2];
-#endif
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_K;
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_e;
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_E;
-#ifdef GRAVITY
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_phi;
-                  data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << total_energy;
-#endif
-                  data_log1 << std::endl;
-
+                   data_log1 << std::endl;
                }
+
+               // Write the quantities at this time
+               data_log1 << std::setw(datwidth) <<  time;
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << mass;
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << mom[0];
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << mom[1];
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << mom[2];
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << ang_mom[0];
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << ang_mom[1];
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << ang_mom[2];
+#ifdef HYBRID_MOMENTUM
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << hyb_mom[0];
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << hyb_mom[1];
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << hyb_mom[2];
+#endif
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_K;
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_e;
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_E;
+#ifdef GRAVITY
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << rho_phi;
+               data_log1 << std::setw(datwidth) <<  std::setprecision(datprecision) << total_energy;
+#endif
+               data_log1 << std::endl;
 
             }
 
@@ -236,4 +235,6 @@ Castro::sum_integrated_quantities ()
         });
 #endif
     }
+
+    problem_diagnostics();
 }

--- a/Source/problems/Make.package
+++ b/Source/problems/Make.package
@@ -13,6 +13,7 @@ CEXE_headers += problem_restart.H
 CEXE_headers += problem_bc_fill.H
 CEXE_headers += problem_source.H
 CEXE_headers += problem_emissivity.H
+CEXE_headers += problem_diagnostics.H
 
 ca_F90EXE_sources += bc_fill_nd.F90
 ca_F90EXE_sources += Prob_nd.F90

--- a/Source/problems/problem_diagnostics.H
+++ b/Source/problems/problem_diagnostics.H
@@ -1,0 +1,8 @@
+#ifndef problem_diagnostics_H
+#define problem_diagnostics_H
+
+AMREX_INLINE
+void
+Castro::problem_diagnostics () {}
+
+#endif


### PR DESCRIPTION

## PR summary

The current diagnostic sums functionality (`castro.sum_interval = 1`) has two limitations. First, customizing it for a problem setup currently means that the whole sum_integrated_quantities.cpp file has to be copied, which means that if the functionality from the main sum_integrated_quantities routine is desired, the problem has to duplicate that code. Second, even if you did customize it, the Amr class ownership of the data logs means that customizing the number and name of the logs is brittle. One unfortunate way that brittleness plays out is that you must specify `amr.data_log` in the inputs file with the exact ordering of the diagnostic names.

The intent of this change is that problems should have not have to override sum_integrated_quantities.cpp to get custom diagnostics. A new hook is provided, `problem_diagnostics.H`, which is called at the end of `sum_integrated_quantities()` for problem-specific diagnostics. To support this change, we stop depending on the Amr ownership of the data logs. Two new Castro class members are added, `data_logs` and `problem_data_logs`. The former is managed by Castro and can be changed over time if we want to add more diagnostic routines, with initialization done in `Castro::read_params()`. The latter is managed by the problem itself, with initialization done in `problem_initialize()`. The log names are coded directly into the source, which means that you don't need to remember to put those names in your inputs file.

test_convect and toy_convect are converted to the new scheme.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
