### PR TITLE
Fix access to radiation member xnu

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1425,7 +1425,7 @@ Castro::initData ()
           GpuArray<Real, NGROUPS+1> xnu_pass = {0.0};
 #if NGROUPS > 1
           for (int g = 0; g <= NGROUPS; g++) {
-            xnu_pass[g] = Radiation::xnu[g];
+              xnu_pass[g] = radiation->xnu[g];
           }
 #endif
 


### PR DESCRIPTION

## PR summary

xnu is not a static class member.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
