### PR TITLE
Only calculate GW strain if user requests

### DIFF
--- a/Exec/science/wdmerger/inputs_2d
+++ b/Exec/science/wdmerger/inputs_2d
@@ -250,6 +250,9 @@ castro.sum_interval = 1
 # Simulation time between computing and printing volume averaged diagnostic quantities
 castro.sum_per = -1.0
 
+# Gravitational wave strain observation distance
+castro.gw_dist = 10.0
+
 # Name the job
 castro.job_name = wdmerger
 

--- a/Exec/science/wdmerger/inputs_3d
+++ b/Exec/science/wdmerger/inputs_3d
@@ -256,6 +256,9 @@ castro.sum_interval = 1
 # Simulation time between computing and printing volume averaged diagnostic quantities
 castro.sum_per = -1.0
 
+# Gravitational wave strain observation distance
+castro.gw_dist = 10.0
+
 # Name the job
 castro.job_name = wdmerger
 

--- a/Exec/science/wdmerger/tests/tde/inputs.test
+++ b/Exec/science/wdmerger/tests/tde/inputs.test
@@ -157,6 +157,9 @@ castro.sum_interval = 1
 # Simulation time between computing and printing volume averaged diagnostic quantities
 castro.sum_per = -1.0
 
+# Gravitational wave strain observation distance
+castro.gw_dist = 10.0
+
 # Whether or not to output plotfiles
 amr.plot_files_output = 1
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -474,8 +474,9 @@ point_mass_fix_solution      int           0                  y        GRAVITY
 
 # Distance (in kpc) used for calculation of the gravitational wave amplitude
 # (this wil be calculated along all three coordinate axes). Only relevant if
-# castro.sum_interval > 0.
-gw_dist                      Real          10.0e0             y        GRAVITY
+# castro.sum_interval > 0 and if set to a positive number. A standard value
+# in the literature is 10.0 (kpc).
+gw_dist                      Real          0.0                y        GRAVITY
 
 #-----------------------------------------------------------------------------
 # category: parallelization

--- a/Source/driver/sum_utils.cpp
+++ b/Source/driver/sum_utils.cpp
@@ -349,6 +349,12 @@ Castro::gwstrain (Real time,
 
     BL_PROFILE("Castro::gwstrain()");
 
+    // We have nothing to do if the user did not request the gravitational wave
+    // strain (inferred from whether the observation distance is positive).
+    if (castro::gw_dist <= 0.0_rt) {
+        return;
+    }
+
     GeometryData geomdata = geom.data();
 
     auto mfrho   = derive("density",time,0);


### PR DESCRIPTION

## PR summary

The user must ask for an observation distance (in kpc) greater than zero if they want the strain calculated.

Closes #1480

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
