### PR TITLE
Remove the dtnuc_T timestep limiter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # 21.01
 
+   * The timestep limiter dtnuc_T has been removed. dtnuc_e and dtnuc_X
+     are still available for controlling the burning timestep. (#1501)
+
    * A bug was fixed in the 2nd order true SDC (with reactions) that
      was giving the wrong solution and convergence (#1494).  A second
      bug was fixed in defining the weights for the Radau quadrature

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -357,11 +357,6 @@ sdc_iters                    int           2
 # ``dtnuc``  :math:`\cdot\,(e / \dot{e})`.
 dtnuc_e                      Real          1.e200             y
 
-# Limit the timestep based on how much the burning can change the temperature
-# of a zone. The timestep is equal to
-# ``dtnuc``  :math:`\cdot\,(T / \dot{T})`.
-dtnuc_T                      Real          1.e200             y
-
 # Limit the timestep based on how much the burning can change the species
 # mass fractions of a zone. The timestep is equal to
 # ``dtnuc``  :math:`\cdot\,(X / \dot{X})`.


### PR DESCRIPTION
## PR summary

This was added as an experiment but was never used in production and is mostly redundant with the dtnuc_e limiter.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
