### PR TITLE
Update to C++17 as minimum standard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # 21.01
 
+   * The minimum C++ standard supported by Castro is now C++17. Most modern compilers
+     support C++17; the notable exception is RHEL 7 and its derivatives like CentOS 7,
+     where the default compiler is gcc 4.8. In that case a newer compiler must be loaded,
+     particularly a version of gcc >= 7.0, for example by installing devtoolset-7 or (if
+     running on an HPC cluster that provides modules) using a more recent gcc module. (#1505)
+
    * There can now be multiple _prob_params files throughout the source
      tree.  We read the problem's file last and that takes precedence over
      any other _prob_params files found. (#1500)
@@ -13,8 +19,7 @@
      when using true SDC (#1493)
 
    * Compiling with the PGI compiler is no longer a requirement for the CUDA build of Castro.
-     We recommend using COMP=gnu with a version of gcc that is C++14 compliant (gcc >= 5).
-
+     We recommend using COMP=gnu with a version of gcc that is C++17 compliant (gcc >= 7).
 
 # 20.12
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
      support C++17; the notable exception is RHEL 7 and its derivatives like CentOS 7,
      where the default compiler is gcc 4.8. In that case a newer compiler must be loaded,
      particularly a version of gcc >= 7.0, for example by installing devtoolset-7 or (if
-     running on an HPC cluster that provides modules) using a more recent gcc module. (#1505)
+     running on an HPC cluster that provides modules) using a more recent gcc module. (#1506)
 
    * There can now be multiple _prob_params files throughout the source
      tree.  We read the problem's file last and that takes precedence over

--- a/Docs/source/getting_started.rst
+++ b/Docs/source/getting_started.rst
@@ -14,7 +14,7 @@ Getting Started
 The compilation process is managed by AMReX and its build system.  The
 general requirements to build Castro are:
 
- * A C++14 (or later) compiler (e.g. gcc >= 5.0)
+ * A C++17 (or later) compiler (e.g. gcc >= 7.0)
 
  * A Fortran 20xx compiler
 
@@ -26,7 +26,7 @@ GCC and the PGI compilers are the main compiler suites used by the
 developers.
 
 For running in parallel, an MPI library is required.  For running on GPUs,
-CUDA 10 or later is required.  More information on parallel builds
+CUDA 11 or later is required.  More information on parallel builds
 is given in section :ref:`ch:mpiplusx`.
 
 Downloading the Code

--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -48,8 +48,8 @@ ifeq ("$(wildcard $(AMREX_HOME)/Tools/GNUMake/Make.defs)","")
   $(error AMReX has not been downloaded. Please run "git submodule update --init" from the top level of the code)
 endif
 
-# Require C++14
-CXXSTD := c++14
+# Require C++17
+CXXSTD := c++17
 
 # default integrator
 INTEGRATOR_DIR ?= VODE


### PR DESCRIPTION

## PR summary

C++17 is now the minimum supported standard for Castro. This means that gcc >= 7 and nvcc >= 11 are now required.

## PR motivation

Among other C++17 features we want to use `inline` variables (starkiller-astro/Microphysics#482) and `if constexpr` (starkiller-astro/Microphysics#470).

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
