### PR TITLE
Remove noexcept from ParallelFor lambda

### DIFF
--- a/Exec/gravity_tests/hydrostatic_adjust/Problem_Derive.cpp
+++ b/Exec/gravity_tests/hydrostatic_adjust/Problem_Derive.cpp
@@ -23,7 +23,7 @@ void ca_derpi(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         Real x = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt) - problem::center[0];
@@ -100,7 +100,7 @@ void ca_derpioverp0(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         Real x = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt) - problem::center[0];

--- a/Exec/gravity_tests/uniform_cube_sphere/Prob.cpp
+++ b/Exec/gravity_tests/uniform_cube_sphere/Prob.cpp
@@ -71,7 +71,7 @@ void Castro::problem_post_init()
                 // mass on the domain is what we intend it to be.
 
                 amrex::ParallelFor(box,
-                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                 {
                     if (problem::problem != 2) return;
 
@@ -156,7 +156,7 @@ void Castro::problem_post_init()
             // and the analytical solution.
 
             reduce_op.eval(box, reduce_data,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
             {
                 Real radius = 0.5_rt * problem::diameter;
                 Real mass = (4.0_rt / 3.0_rt) * M_PI * radius * radius * radius * problem::density;

--- a/Exec/hydro_tests/gamma_law_bubble/Problem_Derive.cpp
+++ b/Exec/hydro_tests/gamma_law_bubble/Problem_Derive.cpp
@@ -41,7 +41,7 @@ void ca_derpi(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
   // Compute pressure from the EOS
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real rhoInv = 1.0_rt / dat(i,j,k,URHO);
@@ -105,7 +105,7 @@ void ca_derpioverp0(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
   gamma_law_initial_model(pressure, density, temp, eint, npts_1d, dx);
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real rhoInv = 1.0_rt/dat(i,j,k,URHO);
@@ -188,7 +188,7 @@ void ca_derrhopert(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
   }
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
     der(i,j,k,0) = dat(i,j,k,URHO) - density[AMREX_D_PICK(i,j,k)];
   });
@@ -224,7 +224,7 @@ void ca_dertpert(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
   gamma_law_initial_model(pressure, density, temp, eint, npts_1d, dx);
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
     der(i,j,k,0) = dat(i,j,k,UTEMP) - temp[AMREX_D_PICK(i,j,k)];
   });

--- a/Exec/radiation_tests/RadSphere/Problem_Derive.cpp
+++ b/Exec/radiation_tests/RadSphere/Problem_Derive.cpp
@@ -30,7 +30,7 @@ void deranalytic(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
   ca_get_dnugroup(dnugroup.begin());
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real loc[3] = {0.0};

--- a/Exec/radiation_tests/RadThermalWave/Problem_Derive.cpp
+++ b/Exec/radiation_tests/RadThermalWave/Problem_Derive.cpp
@@ -23,7 +23,7 @@ void dertexact(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
   auto const der = derfab.array();
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real loc[3] = {0.0};
@@ -81,7 +81,7 @@ void derterror(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
   auto const der = derfab.array();
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real loc[3] = {0.0};

--- a/Exec/reacting_tests/reacting_bubble/Problem_Derive.cpp
+++ b/Exec/reacting_tests/reacting_bubble/Problem_Derive.cpp
@@ -22,7 +22,7 @@ void ca_derpi(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         Real x = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
@@ -81,7 +81,7 @@ void ca_derpioverp0(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         Real x = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
@@ -140,7 +140,7 @@ void ca_derrhopert(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         Real x = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
@@ -184,7 +184,7 @@ void ca_dertpert(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         Real x = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);

--- a/Exec/reacting_tests/toy_flame/Prob.cpp
+++ b/Exec/reacting_tests/toy_flame/Prob.cpp
@@ -30,7 +30,7 @@ Castro::flame_width_properties (Real time, Real& T_max, Real& T_min, Real& grad_
         const auto temp = (*mf)[mfi].array();
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             // Assumes 1D simulation, right now. Also assumes that
             // we have at least one ghost cell in the x dimension.
@@ -82,7 +82,7 @@ Castro::flame_speed_properties (Real time, Real& rho_fuel_dot)
         const auto omegadot = (*mf)[mfi].array();
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             return {omegadot(i,j,k) * dx[0]};
         });

--- a/Exec/science/Detonation/Prob.cpp
+++ b/Exec/science/Detonation/Prob.cpp
@@ -59,7 +59,7 @@ Castro::problem_post_timestep()
                 // Note that this stopping criterion only makes sense for the collision problem.
 
                 reduce_op.eval(bx, reduce_data,
-                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
                 {
                     int stop = 0;
 

--- a/Exec/science/flame/Prob.cpp
+++ b/Exec/science/flame/Prob.cpp
@@ -30,7 +30,7 @@ Castro::flame_width_properties (Real time, Real& T_max, Real& T_min, Real& grad_
         const auto temp = (*mf)[mfi].array();
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             // Assumes 1D simulation, right now. Also assumes that
             // we have at least one ghost cell in the x dimension.
@@ -100,7 +100,7 @@ Castro::flame_speed_properties (Real time, Real& rho_fuel_dot)
         const auto omegadot = (*mf)[mfi].array();
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             return {omegadot(i,j,k) * dx[0]};
         });

--- a/Exec/science/wdmerger/Prob.cpp
+++ b/Exec/science/wdmerger/Prob.cpp
@@ -174,7 +174,7 @@ Castro::wd_update (Real time, Real dt)
           // and secondary to generate a new estimate.
 
           reduce_op.eval(box, reduce_data,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
           {
               // Add to the COM locations and velocities of the primary and secondary
               // depending on which potential dominates, ignoring unbound material.
@@ -467,7 +467,7 @@ void Castro::volInBoundary (Real time, Real& vol_P, Real& vol_S, Real rho_cutoff
           // at zones within the Roche lobe of the white dwarf.
 
           reduce_op.eval(box, reduce_data,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
           {
               Real primary_factor = 0.0_rt;
               Real secondary_factor = 0.0_rt;
@@ -941,7 +941,7 @@ Castro::update_relaxation(Real time, Real dt) {
             Array4<Real const> const smask_arr = (*smask).array(mfi);
 
             reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
             {
                 GpuArray<Real, 3> dF;
                 for (int n = 0; n < 3; ++n) {
@@ -1148,7 +1148,7 @@ Castro::update_relaxation(Real time, Real dt) {
             // turn off the external source terms.
 
             reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
             {
                 Real done = 0.0_rt;
 

--- a/Exec/science/wdmerger/Problem_Derive.cpp
+++ b/Exec/science/wdmerger/Problem_Derive.cpp
@@ -28,7 +28,7 @@ void ca_derinertialmomentumx(const Box& bx, FArrayBox& derfab, int dcomp, int /*
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -70,7 +70,7 @@ void ca_derinertialmomentumy(const Box& bx, FArrayBox& derfab, int dcomp, int /*
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -112,7 +112,7 @@ void ca_derinertialmomentumz(const Box& bx, FArrayBox& derfab, int dcomp, int /*
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -154,7 +154,7 @@ void ca_derinertialangmomx(const Box& bx, FArrayBox& derfab, int dcomp, int /*nc
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -200,7 +200,7 @@ void ca_derinertialangmomy(const Box& bx, FArrayBox& derfab, int dcomp, int /*nc
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -246,7 +246,7 @@ void ca_derinertialangmomz(const Box& bx, FArrayBox& derfab, int dcomp, int /*nc
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -292,7 +292,7 @@ void ca_derinertialradmomx(const Box& bx, FArrayBox& derfab, int dcomp, int /*nc
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -336,7 +336,7 @@ void ca_derinertialradmomy(const Box& bx, FArrayBox& derfab, int dcomp, int /*nc
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -380,7 +380,7 @@ void ca_derinertialradmomz(const Box& bx, FArrayBox& derfab, int dcomp, int /*nc
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         GpuArray<Real, 3> loc;
         loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -419,7 +419,7 @@ void ca_derphieff(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         der(i,j,k,0) = dat(i,j,k,0) + dat(i,j,k,1);
     });
@@ -441,7 +441,7 @@ void ca_derphieffpm_p(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/
     const auto problo = geom.ProbLoArray();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         der(i,j,k,0) = 0.0_rt;
 
@@ -486,7 +486,7 @@ void ca_derphieffpm_s(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/
     const auto problo = geom.ProbLoArray();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         der(i,j,k,0) = 0.0_rt;
 
@@ -526,7 +526,7 @@ void ca_derrhophiGrav(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         der(i,j,k,0) = dat(i,j,k,0) * dat(i,j,k,1);
     });
@@ -540,7 +540,7 @@ void ca_derrhophiRot(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         der(i,j,k,0) = dat(i,j,k,0) * dat(i,j,k,1);
     });
@@ -564,7 +564,7 @@ void ca_derprimarymask(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*
     const auto problo = geom.ProbLoArray();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         // By default, assume we're not inside the star.
 
@@ -624,7 +624,7 @@ void ca_dersecondarymask(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncom
     const auto problo = geom.ProbLoArray();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         // By default, assume we're not inside the star.
 

--- a/Exec/unit_tests/diffusion_test/Problem_Derive.cpp
+++ b/Exec/unit_tests/diffusion_test/Problem_Derive.cpp
@@ -23,7 +23,7 @@ void deranalytic(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         Real r[3] = {0.0};

--- a/Source/diffusion/diffusion_util.cpp
+++ b/Source/diffusion/diffusion_util.cpp
@@ -15,7 +15,7 @@ fill_temp_cond(const Box& bx,
                Array4<Real> const& coeff_arr) {
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_DEVICE (int i, int j, int k)
   {
 
     eos_t eos_state;
@@ -64,7 +64,7 @@ fill_temp_diff_coeff(const Box& bx,
                      Array4<Real> const& coeff_arr) {
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_DEVICE (int i, int j, int k)
   {
 
     eos_t eos_state;

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1079,7 +1079,7 @@ Castro::initData ()
           const Box& box_x = mfi.nodaltilebox(0);
 
           amrex::ParallelFor(box_x,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
               // C++ MHD problem initialization; has no effect if not
               // implemented by a problem setup (defaults to an empty
@@ -1090,7 +1090,7 @@ Castro::initData ()
           const Box& box_y = mfi.nodaltilebox(1);
 
           amrex::ParallelFor(box_y,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
               // C++ MHD problem initialization; has no effect if not
               // implemented by a problem setup (defaults to an empty
@@ -1101,7 +1101,7 @@ Castro::initData ()
           const Box& box_z = mfi.nodaltilebox(2);
 
           amrex::ParallelFor(box_z,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
               // C++ MHD problem initialization; has no effect if not
               // implemented by a problem setup (defaults to an empty
@@ -1150,7 +1150,7 @@ Castro::initData ()
           auto geomdata = geom.data();
 
           amrex::ParallelFor(box,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
               // C++ problem initialization; has no effect if not implemented
               // by a problem setup (defaults to an empty routine).
@@ -1211,7 +1211,7 @@ Castro::initData ()
            Real lsmall_dens = small_dens;
 
            reduce_op.eval(bx, reduce_data,
-           [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+           [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
            {
                // if the problem tried to initialize a thermodynamic
                // state that is at or below small_temp, then we abort.
@@ -1266,7 +1266,7 @@ Castro::initData ()
          auto S_arr = S_new.array(mfi);
 
          amrex::ParallelFor(bx,
-         [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+         [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
          {
            Real spec_sum = 0.0_rt;
            for (int n = 0; n < NumSpec; n++) {
@@ -1354,7 +1354,7 @@ Castro::initData ()
              auto S_arr = Sborder.array(mfi);
 
              amrex::ParallelFor(box,
-             [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+             [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
              {
 
                Real rhoInv = 1.0_rt / S_arr(i,j,k,URHO);
@@ -1451,7 +1451,7 @@ Castro::initData ()
 #endif
 
           amrex::ParallelFor(box,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
               // C++ problem initialization; has no effect if not implemented
               // by a problem setup (defaults to an empty routine).
@@ -3100,7 +3100,7 @@ Castro::normalize_species (MultiFab& S_new, int ng)
         // then normalize them so that they sum to 1.
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real rhoX_sum = 0.0_rt;
 
@@ -3146,7 +3146,7 @@ Castro::enforce_consistent_e (
 #endif
 
         ParallelFor(box,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
           Real rhoInv = 1.0_rt / S_arr(i,j,k,URHO);
           Real u = S_arr(i,j,k,UMX) * rhoInv;
@@ -3236,7 +3236,7 @@ Castro::enforce_speed_limit (MultiFab& state_in, int ng)
         auto u = state_in[mfi].array();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real rho = u(i,j,k,URHO);
             Real rhoInv = 1.0_rt / rho;
@@ -3379,7 +3379,7 @@ Castro::apply_problem_tags (TagBoxArray& tags, Real time)
             const GeometryData& geomdata = geom.data();
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 problem_tagging(i, j, k, tag_arr, state_arr, lev, geomdata);
             });
@@ -3452,7 +3452,7 @@ Castro::apply_tagging_restrictions(TagBoxArray& tags, Real time)
             auto tag = tags[mfi].array();
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 bool outer_boundary_test[3] = {false};
 
@@ -3523,7 +3523,7 @@ Castro::apply_tagging_func(TagBoxArray& tags, Real time, int jcomp)
                               &dengrad_rel, &max_dengrad_rel_lev);
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 // Tag on regions of high density
                 if (lev < max_denerr_lev) {
@@ -3556,7 +3556,7 @@ Castro::apply_tagging_func(TagBoxArray& tags, Real time, int jcomp)
                                &tempgrad_rel, &max_tempgrad_rel_lev);
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 // Tag on regions of high temperature
                 if (lev < max_temperr_lev) {
@@ -3588,7 +3588,7 @@ Castro::apply_tagging_func(TagBoxArray& tags, Real time, int jcomp)
                                 &pressgrad_rel, &max_pressgrad_rel_lev);
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 // Tag on regions of high pressure
                 if (lev < max_presserr_lev) {
@@ -3620,7 +3620,7 @@ Castro::apply_tagging_func(TagBoxArray& tags, Real time, int jcomp)
                               &velgrad_rel, &max_velgrad_rel_lev);
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 // Tag on regions of high velocity
                 if (lev < max_velerr_lev) {
@@ -3651,7 +3651,7 @@ Castro::apply_tagging_func(TagBoxArray& tags, Real time, int jcomp)
             get_dxnuc_params(&dxnuc_min, &dxnuc_max, &max_dxnuc_lev);
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 // Disable if we're not utilizing this tagging
 
@@ -3671,7 +3671,7 @@ Castro::apply_tagging_func(TagBoxArray& tags, Real time, int jcomp)
             get_enuc_params(&enucerr, &max_enucerr_lev);
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 // Tag on regions of high nuclear energy generation rate
 
@@ -3693,7 +3693,7 @@ Castro::apply_tagging_func(TagBoxArray& tags, Real time, int jcomp)
                               &radgrad_rel, &max_radgrad_rel_lev);
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 // Tag on regions of high radiation
                 if (lev < max_raderr_lev) {
@@ -3797,7 +3797,7 @@ Castro::reset_internal_energy(const Box& bx,
     Real ldual_energy_eta2 = dual_energy_eta2;
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         Real rhoInv = 1.0_rt / u(i,j,k,URHO);
         Real Up = u(i,j,k,UMX) * rhoInv;
@@ -3924,7 +3924,7 @@ Castro::add_magnetic_e( MultiFab& Bx,
 
 
       ParallelFor(box,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
           Real bx_cell_c = 0.5_rt * (Bx_arr(i,j,k) + Bx_arr(i+1,j,k));
@@ -3969,7 +3969,7 @@ Castro::check_div_B( MultiFab& Bx,
       const auto dx = geom.CellSizeArray();
 
       reduce_op.eval(box, reduce_data,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
       {
           
           Real divB = (Bx_arr(i+1,j,k) - Bx_arr(i,j,k))/dx[0] +
@@ -4117,7 +4117,7 @@ Castro::computeTemp(
       Array4<Real> const u = u_fab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
           Real rhoInv = 1.0_rt / u(i,j,k,URHO);
@@ -4144,7 +4144,7 @@ Castro::computeTemp(
 
       if (clamp_ambient_temp == 1) {
           amrex::ParallelFor(bx,
-          [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_DEVICE (int i, int j, int k)
           {
               Real rhoInv = 1.0_rt / u(i,j,k,URHO);
 

--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -277,7 +277,7 @@ Castro::restart (Amr&     papa,
                auto geomdata = geom.data();
 
                amrex::ParallelFor(bx,
-               [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+               [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                {
                    // C++ problem initialization; has no effect if not implemented
                    // by a problem setup (defaults to an empty routine).

--- a/Source/driver/Derive.cpp
+++ b/Source/driver/Derive.cpp
@@ -30,7 +30,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         Real rhoInv = 1.0_rt / dat(i,j,k,URHO);
@@ -63,7 +63,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         Real rhoInv = 1.0_rt/dat(i,j,k,URHO);
@@ -85,7 +85,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         der(i,j,k,0) = dat(i,j,k,UEINT) / dat(i,j,k,URHO);
@@ -101,7 +101,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
         der(i,j,k,0) = std::log10(dat(i,j,k,0));
       });
@@ -116,7 +116,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
 
@@ -151,7 +151,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
 
@@ -186,7 +186,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
 
@@ -222,7 +222,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
 
@@ -257,7 +257,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
 
@@ -295,7 +295,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
 
@@ -367,7 +367,7 @@ extern "C"
       const int coord_type = geomdata.Coord();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         // (k grad T)_{i+1/2}
@@ -455,7 +455,7 @@ extern "C"
       int enuc_comp = datfab.nComp()-1;
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         // the nuclear energy (rho H_nuc) is tacked onto the end of
@@ -503,7 +503,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_DEVICE (int i, int j, int k)
       {
           // The derive data is (rho, rho_enuc)
           Real enuc = dat(i,j,k,1) / dat(i,j,k,0);
@@ -522,7 +522,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
              der(i,j,k,0) = dat(i,j,k,1) / dat(i,j,k,0);
       });
@@ -538,7 +538,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         Real deninv = 1.0_rt/dat(i,j,k,0);
@@ -559,7 +559,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         der(i,j,k,0) = std::sqrt(dat(i,j,k,0)*dat(i,j,k,0) +
@@ -583,7 +583,7 @@ extern "C"
       auto problo = geomdata.ProbLoArray();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         Real x = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -638,7 +638,7 @@ extern "C"
       auto problo = geomdata.ProbLoArray();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         Real x = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
@@ -698,7 +698,7 @@ extern "C"
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                        {
 
                          der(i,j,k,0) = std::sqrt(dat(i,j,k,0)*dat(i,j,k,0) +
@@ -721,7 +721,7 @@ extern "C"
     auto const L = derfab.array();
 
     amrex::ParallelFor(bx,
-                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                        {
                          Real loc[3];
 
@@ -773,7 +773,7 @@ extern "C"
     auto const L = derfab.array();
 
     amrex::ParallelFor(bx,
-                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                        {
                          Real loc[3];
 
@@ -821,7 +821,7 @@ extern "C"
     auto const L = derfab.array();
 
     amrex::ParallelFor(bx,
-                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                        {
                          Real loc[3];
 
@@ -866,7 +866,7 @@ extern "C"
     auto const kineng = derfab.array();
 
     amrex::ParallelFor(bx,
-                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                        {
                          kineng(i,j,k,0) = 0.5_rt / dat(i,j,k,0) * ( dat(i,j,k,1)*dat(i,j,k,1) +
                                                                      dat(i,j,k,2)*dat(i,j,k,2) +
@@ -897,7 +897,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
              der(i,j,k,0) = dat(i,j,k,1) / dat(i,j,k,0);
       });
@@ -913,7 +913,7 @@ extern "C"
       auto const der = derfab.array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         Real sum = 0.0_rt;
@@ -941,7 +941,7 @@ extern "C"
       auto problo = geomdata.ProbLoArray();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         // Calculate vorticity.
@@ -1033,7 +1033,7 @@ extern "C"
       const int coord_type = geomdata.Coord();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         Real uhi = dat(i+1,j,k,1) / dat(i+1,j,k,0);
@@ -1093,7 +1093,7 @@ extern "C"
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
       // density
@@ -1119,7 +1119,7 @@ extern "C"
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
       der(i,j,k,0) = 0.5_rt * (dat(i,j,k,0) + dat(i+1,j,k,0));
     });
@@ -1135,7 +1135,7 @@ extern "C"
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
       der(i,j,k,0) = 0.5_rt * (dat(i,j,k,0) + dat(i,j+1,k,0));
     });
@@ -1151,7 +1151,7 @@ extern "C"
     auto const der = derfab.array();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
       der(i,j,k,0) = 0.5_rt * (dat(i,j,k,0) + dat(i,j,k+1,0));
     });
@@ -1171,7 +1171,7 @@ extern "C"
     // here dat contains (mag_y,mag_z,density,ymom,zmom)
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
       Real vy = dat(i,j,k,3) / dat(i,j,k,2);
       Real vz = dat(i,j,k,4) / dat(i,j,k,2);
@@ -1194,7 +1194,7 @@ extern "C"
     // here dat contains (mag_x,mag_z,density,xmom,zmom)
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
       Real vx = dat(i,j,k,3) / dat(i,j,k,2);
       Real vz = dat(i,j,k,4) / dat(i,j,k,2);
@@ -1217,7 +1217,7 @@ extern "C"
     // here dat contains (mag_x,mag_y,density,xmom,ymom)
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
       Real vx = dat(i,j,k,3) / dat(i,j,k,2);
       Real vy = dat(i,j,k,4) / dat(i,j,k,2);
@@ -1238,7 +1238,7 @@ extern "C"
     auto dx = geomdata.CellSizeArray();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
       Real dBx = dat(i+1,j,k,0) - dat(i,j,k,0);
       der(i,j,k,0) = dBx / dx[0];

--- a/Source/driver/MGutils.cpp
+++ b/Source/driver/MGutils.cpp
@@ -17,7 +17,7 @@ apply_metric(const Box& bx,
     if (coord_type == 1) {
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
 
             IntVect idx(D_DECL(i, j, k));
@@ -62,7 +62,7 @@ do_weight_cc(const Box& bx,
 
         // At centers
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
             cc(i,j,k) *= r;
@@ -86,7 +86,7 @@ do_unweight_cc(const Box& bx,
 
         // At centers
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
             cc(i,j,k) /= r;
@@ -113,7 +113,7 @@ do_unweight_edges(const Box& bx,
 
             // On x-edges
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 if (i != 0) {
                     Real r = static_cast<Real>(i) * dx[0];
@@ -125,7 +125,7 @@ do_unweight_edges(const Box& bx,
 
             // On y-edges
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 Real r = (static_cast<Real>(i) + 0.5_rt) * dx[0];
                 ec(i,j,k) /= r;

--- a/Source/driver/sum_utils.cpp
+++ b/Source/driver/sum_utils.cpp
@@ -53,7 +53,7 @@ Castro::volWgtSum (const std::string& name,
         //
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             return {fab(i,j,k) * vol(i,j,k)};
         });
@@ -106,7 +106,7 @@ Castro::volWgtSquaredSum (const std::string& name,
         //
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             return {fab(i,j,k) * fab(i,j,k) * vol(i,j,k)};
         });
@@ -162,7 +162,7 @@ Castro::locWgtSum (const std::string& name,
         //
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             Real loc[3];
 
@@ -241,7 +241,7 @@ Castro::volProductSum (const std::string& name1,
         const Box& box = mfi.tilebox();
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             return {fab1(i,j,k) * fab2(i,j,k) * vol(i,j,k)};
         });
@@ -291,7 +291,7 @@ Castro::locSquaredSum (const std::string& name,
         const Box& box = mfi.tilebox();
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             Real loc[3];
 
@@ -440,7 +440,7 @@ Castro::gwstrain (Real time,
 #endif
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 Array2D<Real, 0, 2, 0, 2> dQtt{};
 

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -42,7 +42,7 @@ Castro::estdt_cfl(const Real time)
     auto u = stateMF.array(mfi);
 
     reduce_op.eval(box, reduce_data,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
     {
 
       Real rhoInv = 1.0_rt / u(i,j,k,URHO);
@@ -162,7 +162,7 @@ Castro::estdt_mhd()
     auto bz_arr = bz.array(mfi);
 
     reduce_op.eval(box, reduce_data,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
     {
 
       Real rhoInv = 1.0_rt / u_arr(i,j,k,URHO);
@@ -276,7 +276,7 @@ Castro::estdt_temp_diffusion(void)
     auto ustate = stateMF.array(mfi);
 
     reduce_op.eval(box, reduce_data,
-                   [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+                   [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
                    {
 
                      if (ustate(i,j,k,URHO) > ldiffuse_cutoff_density) {
@@ -391,7 +391,7 @@ Castro::estdt_burning()
         // But we will call in (rho, T) mode, which is inexpensive.
 
         reduce_op.eval(box, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             Real rhoInv = 1.0_rt / S(i,j,k,URHO);
 

--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -261,7 +261,7 @@ void Castro::construct_old_gravity_source(MultiFab& source, MultiFab& state_in, 
         Array4<Real> const source_arr = source.array(mfi);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             // Temporary array for seeing what the new state would be if the update were applied here.
 
@@ -424,7 +424,7 @@ void Castro::construct_new_gravity_source(MultiFab& source, MultiFab& state_old,
             Array4<Real> const source_arr  = source.array(mfi);
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 GpuArray<Real, NSRC> src{};
 

--- a/Source/gravity/Castro_pointmass.cpp
+++ b/Source/gravity/Castro_pointmass.cpp
@@ -33,7 +33,7 @@ Castro::pointmass_update(Real time, Real dt)
             Array4<Real const> const vol  = volume.array(mfi);
 
             reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
             {
                 // This is just a small number to keep precision issues from making
                 // icen, jcen, kcen one cell too low.
@@ -108,7 +108,7 @@ Castro::pointmass_update(Real time, Real dt)
                 Array4<Real> const uout = S_new.array(mfi);
 
                 amrex::ParallelFor(bx,
-                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                 {
                     // This is just a small number to keep precision issues from making
                     // icen, jcen, kcen one cell too low.

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -1013,7 +1013,7 @@ Gravity::test_residual (const Box& bx,
     AMREX_ALWAYS_ASSERT(coord_type >= 0 && coord_type <= 2);
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         // Cartesian
         if (coord_type == 0) {
@@ -1382,7 +1382,7 @@ Gravity::interpolate_monopole_grav(int level, RealVector& radial_grav, MultiFab&
         // including the ghost cells.
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             GpuArray<Real, 3> loc;
 
@@ -1522,7 +1522,7 @@ Gravity::compute_radial_mass(const Box& bx,
     Real* const radial_vol_ptr = radial_vol.dataPtr();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         Real xc = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
         Real lo_i = problo[0] + static_cast<Real>(i) * dx[0] - problem::center[0];
@@ -1899,7 +1899,7 @@ Gravity::fill_multipole_BCs(int crse_level, int fine_level, const Vector<MultiFa
                 auto vol = (*volume[lev])[mfi].array();
 
                 amrex::ParallelFor(bx,
-                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                 {
                     // If we're using this to construct boundary values, then only fill
                     // the outermost bin.
@@ -2098,7 +2098,7 @@ Gravity::fill_multipole_BCs(int crse_level, int fine_level, const Vector<MultiFa
         auto phi_arr = phi[mfi].array();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             const int* domlo = domain.loVect();
             const int* domhi = domain.hiVect();
@@ -2438,7 +2438,7 @@ Gravity::fill_direct_sum_BCs(int crse_level, int fine_level, const Vector<MultiF
 #endif
 
                 amrex::ParallelFor(bx,
-                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                 {
                     GpuArray<Real, 3> loc, locb;
                     loc[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0];
@@ -2727,7 +2727,7 @@ Gravity::fill_direct_sum_BCs(int crse_level, int fine_level, const Vector<MultiF
         auto bcYZHi_arr = bcYZHi.array();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             if (i == bc_lo[0]) {
                 p(i,j,k) = bcYZLo_arr(0,j,k);
@@ -2941,7 +2941,7 @@ Gravity::add_pointmass_to_gravity (int level, MultiFab& phi, MultiFab& grav_vect
         Array4<Real> const phi_arr = phi.array(mfi);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             // Compute radial gravity due to a point mass at center[:].
 

--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -41,7 +41,7 @@ Castro::consup_hydro(const Box& bx,
   int coord = geom.Coord();
 
   amrex::ParallelFor(bx, NUM_STATE,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
 
     Real volinv = 1.0 / vol(i,j,k);
@@ -310,7 +310,7 @@ Castro::ctu_plm_states(const Box& bx, const Box& vbx,
       if (lo_bc_test) {
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
 
           // reset the left state at domlo(0) if needed -- it is outside the domain
@@ -331,7 +331,7 @@ Castro::ctu_plm_states(const Box& bx, const Box& vbx,
       if (hi_bc_test) {
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
 
           // reset the right state at domhi(0)+1 if needed -- it is outside the domain
@@ -354,7 +354,7 @@ Castro::ctu_plm_states(const Box& bx, const Box& vbx,
       if (lo_bc_test) {
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
 
           // reset the left state at domlo(0) if needed -- it is outside the domain
@@ -375,7 +375,7 @@ Castro::ctu_plm_states(const Box& bx, const Box& vbx,
       if (hi_bc_test) {
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
 
           // reset the right state at domhi(0)+1 if needed -- it is outside the domain
@@ -399,7 +399,7 @@ Castro::ctu_plm_states(const Box& bx, const Box& vbx,
       if (lo_bc_test) {
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
 
           // reset the left state at domlo(0) if needed -- it is outside the domain
@@ -420,7 +420,7 @@ Castro::ctu_plm_states(const Box& bx, const Box& vbx,
       if (hi_bc_test) {
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
 
           // reset the right state at domhi(0)+1 if needed -- it is outside the domain
@@ -451,7 +451,7 @@ Castro::src_to_prim(const Box& bx,
 {
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
 

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -228,7 +228,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
       if (first_order_hydro == 1) {
         amrex::ParallelFor(obx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
           flatn_arr(i,j,k) = 0.0;
         });
@@ -242,7 +242,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
         Real flatten_pp_thresh = radiation::flatten_pp_threshold;
 
         amrex::ParallelFor(obx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
           flatn_arr(i,j,k) = flatn_arr(i,j,k) * flatg_arr(i,j,k);
 
@@ -260,7 +260,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
       } else {
         amrex::ParallelFor(obx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
           flatn_arr(i,j,k) = 1.0;
         });
@@ -297,7 +297,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
       }
       else {
         amrex::ParallelFor(obx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
           shk_arr(i,j,k) = 0.0;
         });
@@ -1168,7 +1168,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
           // Zero out shock and temp fluxes -- these are physically meaningless here
           amrex::ParallelFor(nbx,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
               flux_arr(i,j,k,UTEMP) = 0.e0;
 #ifdef SHOCK_VAR
@@ -1328,7 +1328,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
             if (!mom_flux_has_p(0, 0, coord)) {
 #endif
                 amrex::ParallelFor(nbx,
-                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                 {
                     pradial_fab(i,j,k) = qex_arr(i,j,k,GDPRES) * dt;
                 });

--- a/Source/hydro/Castro_ctu_rad.cpp
+++ b/Source/hydro/Castro_ctu_rad.cpp
@@ -71,7 +71,7 @@ Castro::ctu_rad_consup(const Box& bx,
   // radiation energy update.  For the moment, we actually update things
   // fully here, instead of creating a source term for the update
   amrex::ParallelFor(bx, NGROUPS,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int g) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int g)
   {
 
     Erout(i,j,k,g) = Erin(i,j,k,g) + dt *
@@ -89,7 +89,7 @@ Castro::ctu_rad_consup(const Box& bx,
   // (and only for the radial flux);  also add the radiation pressure gradient
   // to the momentum for all directions
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // pgdnv from the Riemann solver is only the gas contribution,
@@ -187,7 +187,7 @@ Castro::ctu_rad_consup(const Box& bx,
     using ReduceTuple = typename decltype(reduce_data)::Type;
 
     reduce_op.eval(bx, reduce_data,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
     {
 
       Real ux = 0.5_rt * (qx(i,j,k,GDU) + qx(i+1,j,k,GDU));

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -262,7 +262,7 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
         auto U = State.array(mfi);
 
         reduce_op.eval(bx, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
             // Compute running max of Courant number over grids
 

--- a/Source/hydro/Castro_mol.cpp
+++ b/Source/hydro/Castro_mol.cpp
@@ -37,7 +37,7 @@ Castro::mol_plm_reconstruct(const Box& bx,
 
   // piecewise linear slopes
   amrex::ParallelFor(bx, NQ,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
 
     bool lo_bc_test = lo_symm && ((idir == 0 && i == domlo[0]) ||
@@ -82,7 +82,7 @@ Castro::mol_plm_reconstruct(const Box& bx,
   if (use_pslope == 1) {
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
       Real s[5];
@@ -165,7 +165,7 @@ Castro::mol_plm_reconstruct(const Box& bx,
   }
 
   amrex::ParallelFor(bx, NQ,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
 
 
@@ -216,7 +216,7 @@ Castro::mol_plm_reconstruct(const Box& bx,
     if (lo_symm) {
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
        // reset the left state at domlo(0) if needed -- it is outside the domain
@@ -237,7 +237,7 @@ Castro::mol_plm_reconstruct(const Box& bx,
     if (hi_symm) {
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
        // reset the right state at domhi(0)+1 if needed -- it is outside the domain
@@ -260,7 +260,7 @@ Castro::mol_plm_reconstruct(const Box& bx,
     if (lo_symm) {
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
        // reset the left state at domlo(0) if needed -- it is outside the domain
@@ -281,7 +281,7 @@ Castro::mol_plm_reconstruct(const Box& bx,
     if (hi_symm) {
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
        // reset the right state at domhi(0)+1 if needed -- it is outside the domain
@@ -305,7 +305,7 @@ Castro::mol_plm_reconstruct(const Box& bx,
     if (lo_symm) {
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
        // reset the left state at domlo(0) if needed -- it is outside the domain
@@ -326,7 +326,7 @@ Castro::mol_plm_reconstruct(const Box& bx,
     if (hi_symm) {
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
        // reset the right state at domhi(0)+1 if needed -- it is outside the domain
@@ -358,7 +358,7 @@ Castro::mol_ppm_reconstruct(const Box& bx,
                             Array4<Real> const& qp) {
 
   amrex::ParallelFor(bx, NQ,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
 
     Real s[5];
@@ -460,7 +460,7 @@ Castro::mol_consup(const Box& bx,
 #endif
 
   amrex::ParallelFor(bx, NUM_STATE,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
 
 #if AMREX_SPACEDIM == 1
@@ -509,7 +509,7 @@ Castro::mol_consup(const Box& bx,
   // we'll be multiplying that for the update calculation.
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
     update(i,j,k,USHK) = shk(i,j,k) / dt;
   });
@@ -528,7 +528,7 @@ Castro::mol_diffusive_flux(const Box& bx,
   const auto dx = geom.CellSizeArray();
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real cond_int;

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -112,7 +112,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 
         if (first_order_hydro == 1) {
           amrex::ParallelFor(obx,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
             flatn_arr(i,j,k) = 0.0;
           });
@@ -120,7 +120,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
           uflatten(obx, q_arr, flatn_arr, QPRES);
         } else {
           amrex::ParallelFor(obx,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
             flatn_arr(i,j,k) = 1.0;
           });
@@ -147,7 +147,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
         }
         else {
           amrex::ParallelFor(obx,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
             shk_arr(i,j,k) = 0.0;
           });
@@ -266,7 +266,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 
             if (do_hydro == 0) {
               amrex::ParallelFor(nbx, NUM_STATE,
-              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
               {
                 f_avg_arr(i,j,k,n) = 0.0;
               });
@@ -295,7 +295,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
             Array4<Real> const flux_arr = (flux[0]).array();
 
             amrex::ParallelFor(nbx, NUM_STATE,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
             {
               flux_arr(i,j,k,n) = f_avg_arr(i,j,k,n);
             });
@@ -315,7 +315,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
             }
 
             amrex::ParallelFor(nbx, NQ,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
               bool test = (n == QGC) || (n == QTEMP);
 
@@ -336,7 +336,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
             if (do_hydro == 0) {
 
               amrex::ParallelFor(nbx, NUM_STATE,
-              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
               {
                 f_arr(i,j,k,n) = 0.0;
               });
@@ -360,7 +360,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
             Array4<Real> const flux_arr = (flux[idir]).array();
 
             amrex::ParallelFor(nbx, NUM_STATE,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
 
               Real lap = trans_laplacian(i, j, k, n, idir, f_avg_arr,
@@ -394,7 +394,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
               Array4<Real const> const avis_arr = avis.array();
 
               amrex::ParallelFor(nbx, NUM_STATE,
-              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
               {
                   if (n == UTEMP) {
                     flux_arr(i,j,k,n) = 0.0;
@@ -518,7 +518,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
               Array4<Real const> const uin_arr = Sborder.array(mfi);
 
               amrex::ParallelFor(nbx,
-              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
               {
                 flux_arr(i,j,k,UTEMP) = 0.e0;
 #ifdef SHOCK_VAR
@@ -684,7 +684,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 #if AMREX_SPACEDIM == 1
             if (!Geom().IsCartesian()) {
               amrex::ParallelFor(nbx,
-              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
               {
                 pradial_fab(i,j,k) = qex_fab(i,j,k,prescomp) * dt;
               });
@@ -694,7 +694,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 #if AMREX_SPACEDIM == 2
             if (!mom_flux_has_p(0, 0, coord)) {
               amrex::ParallelFor(nbx,
-              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
               {
                 pradial_fab(i,j,k) = qex_fab(i,j,k,prescomp) * dt;
               });

--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -50,7 +50,7 @@ Castro::ctoprim(const Box& bx,
 #endif
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
 #ifndef AMREX_USE_CUDA
@@ -228,7 +228,7 @@ Castro::shock(const Box& bx,
 #endif
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
     Real div_u = 0.0_rt;
 
@@ -388,7 +388,7 @@ Castro::divu(const Box& bx,
 #endif
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
 #if AMREX_SPACEDIM == 1
@@ -491,7 +491,7 @@ Castro::apply_av(const Box& bx,
   Real diff_coeff = difmag;
 
   amrex::ParallelFor(bx, NUM_STATE,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
 
     if (n == UTEMP) return;
@@ -541,7 +541,7 @@ Castro::apply_av_rad(const Box& bx,
   Real diff_coeff = difmag;
 
   amrex::ParallelFor(bx, Radiation::nGroups,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
 
     Real div1;
@@ -583,7 +583,7 @@ Castro::normalize_species_fluxes(const Box& bx,
   // defined in Plewa & Muller, 1999, A&A, 342, 179.
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real sum = 0.0_rt;
@@ -627,7 +627,7 @@ Castro::scale_flux(const Box& bx,
 #endif
 
   amrex::ParallelFor(bx, NUM_STATE,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
 
     flux(i,j,k,n) = dt * flux(i,j,k,n) * area_arr(i,j,k);
@@ -649,7 +649,7 @@ Castro::scale_rad_flux(const Box& bx,
                        const Real dt) {
 
   amrex::ParallelFor(bx, Radiation::nGroups,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int g) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int g)
   {
     rflux(i,j,k,g) = dt * rflux(i,j,k,g) * area_arr(i,j,k);
   });
@@ -1087,7 +1087,7 @@ Castro::do_enforce_minimum_density(const Box& bx,
 #endif
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     if (state_arr(i,j,k,URHO) < small_dens) {

--- a/Source/hydro/edge_util.cpp
+++ b/Source/hydro/edge_util.cpp
@@ -15,7 +15,7 @@ Castro::reset_edge_state_thermo(const Box& bx,
     Real small_p = small_pres;
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
 #ifdef RADIATION
@@ -86,7 +86,7 @@ Castro::edge_state_temp_to_pres(const Box& bx,
     // use T to define p
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         // We just got the extremes corresponding to a particular cell-center, but now

--- a/Source/hydro/flatten.cpp
+++ b/Source/hydro/flatten.cpp
@@ -23,7 +23,7 @@ Castro::uflatten(const Box& bx,
   constexpr Real dzcut = 1.0_rt / (zcut2-zcut1);
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // x-direction flattening coef

--- a/Source/hydro/fourth_center_average.cpp
+++ b/Source/hydro/fourth_center_average.cpp
@@ -40,7 +40,7 @@ Castro::make_cell_center(const Box& bx,
   }
 
   amrex::ParallelFor(bx, U.nComp(),
-  [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
   {
     Real lap = compute_laplacian(i, j, k, n, U,
                                  lo_periodic, hi_periodic, domlo, domhi);
@@ -75,14 +75,14 @@ Castro::make_cell_center_in_place(const Box& bx,
   for (int n = 0; n < U.nComp(); n++) {
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {
       tmp(i,j,k) = compute_laplacian(i, j, k, n, U,
                                      lo_periodic, hi_periodic, domlo, domhi);
     });
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {
       U(i,j,k,n) = U(i,j,k,n) - (1.0_rt/24.0_rt) * tmp(i,j,k);
     });
@@ -110,7 +110,7 @@ Castro::compute_lap_term(const Box& bx,
   }
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_DEVICE (int i, int j, int k)
   {
     lap(i,j,k) = (1.0_rt/24.0_rt) *
       compute_laplacian(i, j, k, ncomp, U,
@@ -141,7 +141,7 @@ Castro::make_fourth_average(const Box& bx,
   }
 
   amrex::ParallelFor(bx, q.nComp(),
-  [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
   {
     Real lap = compute_laplacian(i, j, k, n, q_bar,
                                  lo_periodic, hi_periodic, domlo, domhi);
@@ -191,14 +191,14 @@ Castro::make_fourth_in_place_n(const Box& bx,
   }
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_DEVICE (int i, int j, int k)
   {
     tmp(i,j,k) = compute_laplacian(i, j, k, ncomp, q,
                                    lo_periodic, hi_periodic, domlo, domhi);
   });
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_DEVICE (int i, int j, int k)
   {
     q(i,j,k,ncomp) += (1.0_rt/24.0_rt) * tmp(i,j,k);
   });

--- a/Source/hydro/fourth_order.cpp
+++ b/Source/hydro/fourth_order.cpp
@@ -31,7 +31,7 @@ Castro::fourth_interfaces(const Box& bx,
     // this loop is over interfaces
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
       // interpolate to the edges -- this is a_{i-1/2}
@@ -95,7 +95,7 @@ Castro::fourth_interfaces(const Box& bx,
     // this loop is over interfaces
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
       // interpolate to the edges
@@ -159,7 +159,7 @@ Castro::fourth_interfaces(const Box& bx,
     // this loop is over interfaces
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
       // interpolate to the edges
@@ -252,7 +252,7 @@ Castro::states(const Box& bx,
     if (limit_fourth_order == 0) {
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
         al(i+1,j,k,ncomp) = a_int(i+1,j,k);
         ar(i,j,k,ncomp) = a_int(i,j,k);
@@ -266,7 +266,7 @@ Castro::states(const Box& bx,
       // i-1/2,R and i+1/2,L
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         al(i+1,j,k,ncomp) = a_int(i+1,j,k);
@@ -419,7 +419,7 @@ Castro::states(const Box& bx,
     if (limit_fourth_order == 0) {
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
         al(i,j+1,k,ncomp) = a_int(i,j+1,k);
         ar(i,j,k,ncomp) = a_int(i,j,k);
@@ -433,7 +433,7 @@ Castro::states(const Box& bx,
       // j-1/2,R and j+1/2,L
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
         al(i,j+1,k,ncomp) = a_int(i,j+1,k);
         ar(i,j,k,ncomp) = a_int(i,j,k);
@@ -584,7 +584,7 @@ Castro::states(const Box& bx,
     if (limit_fourth_order == 0) {
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
         al(i,j,k+1,ncomp) = a_int(i,j,k+1);
         ar(i,j,k,ncomp) = a_int(i,j,k);
@@ -596,7 +596,7 @@ Castro::states(const Box& bx,
       // k-1/2,R and k+1/2,L
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
 
         al(i,j,k+1,ncomp) = a_int(i,j,k+1);
@@ -775,7 +775,7 @@ Castro::fourth_avisc(const Box& bx,
 #endif
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real cmin;
@@ -858,7 +858,7 @@ Castro::fourth_add_diffusive_flux(const Box& bx,
   const auto dx = geom.CellSizeArray();
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     eos_t eos_state;

--- a/Source/hydro/riemann.cpp
+++ b/Source/hydro/riemann.cpp
@@ -74,7 +74,7 @@ Castro::cmpflx_plus_godunov(const Box& bx,
     auto coord = geom.Coord();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
       int is_shock = 0;
@@ -189,7 +189,7 @@ Castro::riemann_state(const Box& bx,
     const Real lT_guess = T_guess;
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
      eos_t eos_state;

--- a/Source/hydro/riemann_solvers.cpp
+++ b/Source/hydro/riemann_solvers.cpp
@@ -88,7 +88,7 @@ Castro::riemanncg(const Box& bx,
   const Real lsmall = riemann_constants::small;
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
 #ifndef AMREX_USE_CUDA
@@ -625,7 +625,7 @@ Castro::riemannus(const Box& bx,
   const Real lT_guess = T_guess;
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // deal with hard walls
@@ -1104,7 +1104,7 @@ Castro::HLLC(const Box& bx,
   int coord = geom.Coord();
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // deal with hard walls

--- a/Source/hydro/riemann_util.cpp
+++ b/Source/hydro/riemann_util.cpp
@@ -190,7 +190,7 @@ Castro::store_godunov_state(const Box& bx,
   // hydro advancement.
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // the hybrid routine uses the Godunov indices, not the full NQ state

--- a/Source/hydro/trace_plm.cpp
+++ b/Source/hydro/trace_plm.cpp
@@ -95,7 +95,7 @@ Castro::trace_plm(const Box& bx, const int idir,
   // Compute left and right traced states
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     bool lo_bc_test = lo_symm && ((idir == 0 && i == domlo[0]) ||

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -136,7 +136,7 @@ Castro::trace_ppm(const Box& bx,
 
   // Trace to left and right edges using upwind PPM
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real cc = qaux_arr(i,j,k,QC);

--- a/Source/hydro/trans.cpp
+++ b/Source/hydro/trans.cpp
@@ -111,7 +111,7 @@ Castro::actual_trans_single(const Box& bx,
 #endif
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         // We are handling the states at the interface of
@@ -517,7 +517,7 @@ Castro::actual_trans_final(const Box& bx,
 #endif
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
         // the normal state

--- a/Source/mhd/Castro_mhd.cpp
+++ b/Source/mhd/Castro_mhd.cpp
@@ -192,7 +192,7 @@ Castro::construct_ctu_mhd_source(Real time, Real dt)
 
           if (use_flattening == 0) {
             amrex::ParallelFor(bxi,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
               flatn_arr(i,j,k) = 1.0;
             });
@@ -203,7 +203,7 @@ Castro::construct_ctu_mhd_source(Real time, Real dt)
             uflatten(bxi, q_arr, flatg_arr, QPTOT);
 
             amrex::ParallelFor(bxi,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
               flatn_arr(i,j,k) = flatn_arr(i,j,k) * flatg_arr(i,j,k);
             });
@@ -474,19 +474,19 @@ Castro::construct_ctu_mhd_source(Real time, Real dt)
           // eq. 42 and 43
 
           amrex::ParallelFor(ccbx, NUM_STATE+3,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
           {
             flxx1D_arr(i,j,k,n) = 0.5_rt * (flx_xy_arr(i,j,k,n) + flx_xz_arr(i,j,k,n));
           });
 
           amrex::ParallelFor(ccby, NUM_STATE+3,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
           {
             flxy1D_arr(i,j,k,n) = 0.5_rt * (flx_yx_arr(i,j,k,n) + flx_yz_arr(i,j,k,n));
           });
 
           amrex::ParallelFor(ccbz, NUM_STATE+3,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
           {
             flxz1D_arr(i,j,k,n) = 0.5_rt * (flx_zx_arr(i,j,k,n) + flx_zy_arr(i,j,k,n));
           });
@@ -613,7 +613,7 @@ Castro::construct_ctu_mhd_source(Real time, Real dt)
 
             // Zero out shock and temp fluxes -- these are physically meaningless here
             amrex::ParallelFor(nbx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
               flux_arr(i,j,k,UTEMP) = 0.e0;
 #ifdef SHOCK_VAR
@@ -637,7 +637,7 @@ Castro::construct_ctu_mhd_source(Real time, Real dt)
           Real dtdx = dt / dx[0];
 
           amrex::ParallelFor(nbx,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
             Bxo_arr(i,j,k) = Bx_arr(i,j,k) + dtdx *
               ((Ey_arr(i,j,k+1) - Ey_arr(i,j,k)) - (Ez_arr(i,j+1,k) - Ez_arr(i,j,k)));
@@ -650,7 +650,7 @@ Castro::construct_ctu_mhd_source(Real time, Real dt)
 #endif
 
           amrex::ParallelFor(nby,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
             Byo_arr(i,j,k) = By_arr(i,j,k) + dtdx *
               ((Ez_arr(i+1,j,k) - Ez_arr(i,j,k)) - (Ex_arr(i,j,k+1) - Ex_arr(i,j,k)));
@@ -663,7 +663,7 @@ Castro::construct_ctu_mhd_source(Real time, Real dt)
 #endif
 
           amrex::ParallelFor(nbz,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
             Bzo_arr(i,j,k) = Bz_arr(i,j,k) + dtdx *
               ((Ex_arr(i,j+1,k) - Ex_arr(i,j,k)) - (Ey_arr(i+1,j,k) - Ey_arr(i,j,k)));

--- a/Source/mhd/ct_upwind.cpp
+++ b/Source/mhd/ct_upwind.cpp
@@ -89,7 +89,7 @@ Castro::corner_couple(const Box& bx,
   int UMAGD3 = UMAGX + d3;
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // first the conserved state
@@ -166,7 +166,7 @@ Castro::corner_couple(const Box& bx,
   ell[d1] -= 1;
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // conservative state
@@ -293,7 +293,7 @@ Castro::half_step(const Box& bx,
 
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // first the conservative state
@@ -382,7 +382,7 @@ Castro::half_step(const Box& bx,
 
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // left interface (e.g., U_{i+1/2,j,k,L} or the "+" state in MM notation)

--- a/Source/mhd/electric.cpp
+++ b/Source/mhd/electric.cpp
@@ -15,7 +15,7 @@ Castro::electric_edge_x(const Box& bx,
   // Compute Ex on an edge.  This will compute Ex(i, j-1/2, k-1/2)
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real q_zone[NQ];
@@ -174,7 +174,7 @@ Castro::electric_edge_y(const Box& bx,
   // Compute Ey on an edge.  This will compute Ey(i-1/2, j, k-1/2)
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real q_zone[NQ];
@@ -329,7 +329,7 @@ Castro::electric_edge_z(const Box& bx,
   // Compute Ez on an edge.  This will compute Ez(i-1/2, j-1/2, k)
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real q_zone[NQ];

--- a/Source/mhd/hlld.cpp
+++ b/Source/mhd/hlld.cpp
@@ -71,7 +71,7 @@ Castro::hlld(const Box& bx,
   }
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // this is a loop over interfaces, so, e.g., for idir = 0 (x), we are seeing

--- a/Source/mhd/mhd_plm.cpp
+++ b/Source/mhd/mhd_plm.cpp
@@ -36,7 +36,7 @@ Castro::plm(const Box& bx,
   Real dtdx = dt/dx[idir];
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     bool lo_bc_test = lo_symm && ((idir == 0 && i == domlo[0]) ||

--- a/Source/mhd/mhd_ppm.cpp
+++ b/Source/mhd/mhd_ppm.cpp
@@ -71,7 +71,7 @@ Castro::ppm_mhd(const Box& bx,
 
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     // compute the eigenvectors and eigenvalues for this coordinate direction

--- a/Source/mhd/mhd_util.cpp
+++ b/Source/mhd/mhd_util.cpp
@@ -33,7 +33,7 @@ Castro::check_for_mhd_cfl_violation(const Box& bx,
   using ReduceTuple = typename decltype(reduce_data)::Type;
 
   reduce_op.eval(bx, reduce_data,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
   {
 
     //sound speed for ideal mhd
@@ -141,7 +141,7 @@ Castro::consup_mhd(const Box& bx,
 #endif
 
   amrex::ParallelFor(bx, NUM_STATE,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
 
     if (n == UTEMP) {
@@ -173,7 +173,7 @@ Castro::PrimToCons(const Box& bx,
   // calculate the conserved variables from the primitive
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     u_arr(i,j,k,URHO) = q_arr(i,j,k,QRHO);
@@ -234,7 +234,7 @@ Castro::prim_half(const Box& bx,
   auto dx = geom.CellSizeArray();
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real divF[NUM_STATE+3];

--- a/Source/problems/Castro_bc_fill_nd.cpp
+++ b/Source/problems/Castro_bc_fill_nd.cpp
@@ -118,7 +118,7 @@ void ca_statefill(Box const& bx, FArrayBox& data,
     const auto geomdata = geom.data();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         problem_bc_fill(i, j, k, state, time, bcs, geomdata);
     });

--- a/Source/problems/Castro_problem_source.cpp
+++ b/Source/problems/Castro_problem_source.cpp
@@ -130,7 +130,7 @@ Castro::fill_ext_source (const Real time, const Real dt, const MultiFab& state_o
         Array4<Real> const src = ext_src.array(mfi);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             problem_source(i, j, k, geomdata, snew, src, dt, time);
         });

--- a/Source/problems/ambient_fill.cpp
+++ b/Source/problems/ambient_fill.cpp
@@ -73,7 +73,7 @@ ambient_fill(const Box& bx, Array4<Real> const& state,
     const auto domhi = geom.Domain().hiVect3d();
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         bool ambient_x_lo = (castro::ambient_fill_dir == 0 || castro::ambient_fill_dir == -1) &&
                             (bcs(URHO).lo(0) == FOEXTRAP || bcs(URHO).lo(0) == HOEXTRAP);

--- a/Source/problems/hse_fill.cpp
+++ b/Source/problems/hse_fill.cpp
@@ -49,7 +49,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     IntVect(D_DECL(domlo[0]-1, hi[1], hi[2])));
 
             amrex::ParallelFor(gbx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
 
                 Real dens_above = adv(domlo[0],j,k,URHO);
@@ -239,7 +239,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     IntVect(D_DECL(domhi[0]+1, hi[1], hi[2])));
 
             amrex::ParallelFor(gbx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
 
                 Real dens_below = adv(domhi[0],j,k,URHO);
@@ -429,7 +429,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     IntVect(D_DECL(hi[0], domlo[1]-1, hi[2])));
 
             amrex::ParallelFor(gbx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
 
                 Real dens_above = adv(i,domlo[1],k,URHO);
@@ -617,7 +617,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     IntVect(D_DECL(hi[0], domhi[1]+1, hi[2])));
 
             amrex::ParallelFor(gbx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
 
                 Real dens_below = adv(i,domhi[1],k,URHO);
@@ -806,7 +806,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     IntVect(D_DECL(hi[0], hi[1], domlo[2]-1)));
 
             amrex::ParallelFor(gbx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
 
                 Real dens_above = adv(i,j,domlo[2],URHO);

--- a/Source/radiation/HypreABec.cpp
+++ b/Source/radiation/HypreABec.cpp
@@ -361,7 +361,7 @@ void HypreABec::hacoef (const Box& bx,
                         Real alpha)
 {
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         if (alpha == 0.e0_rt) {
             mat(i,j,k)[AMREX_SPACEDIM] = 0.e0_rt;
@@ -386,7 +386,7 @@ void HypreABec::hbcoef (const Box& bx,
         const Real fac = beta / (dx[0] * dx[0]);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             mat(i,j,k)[0] = -fac * b(i,j,k);
             mat(i,j,k)[AMREX_SPACEDIM] += fac * (b(i,j,k) + b(i+1,j,k));
@@ -398,7 +398,7 @@ void HypreABec::hbcoef (const Box& bx,
         const Real fac = beta / (dx[1] * dx[1]);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             mat(i,j,k)[1] = -fac * b(i,j,k);
             mat(i,j,k)[AMREX_SPACEDIM] += fac * (b(i,j,k) + b(i,j+1,k));
@@ -410,7 +410,7 @@ void HypreABec::hbcoef (const Box& bx,
         const Real fac = beta / (dx[2] * dx[2]);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             mat(i,j,k)[2] = -fac * b(i,j,k);
             mat(i,j,k)[AMREX_SPACEDIM] += fac * (b(i,j,k) + b(i,j,k+1));
@@ -525,7 +525,7 @@ void HypreABec::hbmat (const Box& bx,
     }
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         if (mask.contains(i-1,j,k)) {
 
@@ -677,7 +677,7 @@ void HypreABec::hbmat3 (const Box& bx,
     // from the interior stencil which must be removed at the boundary.
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         Real r;
         face_metric(i, j, k, bx.loVect()[0], bx.hiVect()[0], geomdata, idir, ori_lo, r);
@@ -1263,7 +1263,7 @@ void HypreABec::hbvec3 (const Box& bx,
     }
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         Real r;
         face_metric(i, j, k, bx.loVect()[0], bx.hiVect()[0], geomdata, idir, ori_lo, r);
@@ -1616,7 +1616,7 @@ void HypreABec::hbvec (const Box& bx,
     }
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         if (mask.contains(i-1,j,k)) {
 

--- a/Source/radiation/HypreExtMultiABec.cpp
+++ b/Source/radiation/HypreExtMultiABec.cpp
@@ -219,7 +219,7 @@ void HypreExtMultiABec::loadMatrix()
             auto a2 = (*a2coefs[level])[idim][mfi].array();
 
             amrex::ParallelFor(reg,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 if (idim == 0) {
                     mat(i,j,k,0) += fac * (a2(i,j,k) + a2(i+1,j,k));
@@ -247,7 +247,7 @@ void HypreExtMultiABec::loadMatrix()
             auto c = (*ccoefs[level])[idim][mfi].array();
 
             amrex::ParallelFor(reg,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 if (idim == 0) {
                     mat(i,j,k,0) += -fac * (c(i,j,k) - c(i+1,j,k));
@@ -275,7 +275,7 @@ void HypreExtMultiABec::loadMatrix()
             auto d1 = (*d1coefs[level])[idim][mfi].array();
 
             amrex::ParallelFor(reg,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 if (idim == 0) {
                     mat(i,j,k,1) += -fac * d1(i,j,k);
@@ -300,7 +300,7 @@ void HypreExtMultiABec::loadMatrix()
             auto d2 = (*d2coefs[level])[idim][mfi].array();
 
             amrex::ParallelFor(reg,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 if (idim == 0) {
                     mat(i,j,k,0) += fac * (d2(i,j,k) - d2(i+1,j,k));

--- a/Source/radiation/HypreMultiABec.cpp
+++ b/Source/radiation/HypreMultiABec.cpp
@@ -1344,7 +1344,7 @@ void HypreMultiABec::hmac (const Box& bx,
                            Real alpha)
 {
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         if (alpha == 0.e0_rt) {
             mat(i,j,k)[0] = 0.e0_rt;
@@ -1367,7 +1367,7 @@ void HypreMultiABec::hmbc (const Box& bx,
         const Real fac = beta / (dx[0] * dx[0]);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             mat(i,j,k)[0] += fac * (b(i,j,k) + b(i+1,j,k));
             mat(i,j,k)[1] = -fac * b(i,j,k);
@@ -1380,7 +1380,7 @@ void HypreMultiABec::hmbc (const Box& bx,
         const Real fac = beta / (dx[1] * dx[1]);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             mat(i,j,k)[0] += fac * (b(i,j,k) + b(i,j+1,k));
             mat(i,j,k)[3] = -fac * b(i,j,k);
@@ -1393,7 +1393,7 @@ void HypreMultiABec::hmbc (const Box& bx,
         const Real fac = beta / (dx[2] * dx[2]);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             mat(i,j,k)[0] += fac * (b(i,j,k) + b(i,j,k+1));
             mat(i,j,k)[5] = -fac * b(i,j,k);
@@ -1529,7 +1529,7 @@ HypreMultiABec::hmmat (const Box& bx,
     }
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         if (mask.contains(i-1,j,k)) {
 
@@ -1713,7 +1713,7 @@ HypreMultiABec::hmmat3 (const Box& bx,
     // from the interior stencil which must be removed at the boundary.
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         Real r;
         face_metric(i, j, k, bx.loVect()[0], bx.hiVect()[0], geomdata, idir, ori_lo, r);

--- a/Source/radiation/MGFLD.cpp
+++ b/Source/radiation/MGFLD.cpp
@@ -40,7 +40,7 @@ void Radiation::check_convergence_er(Real& relative, Real& absolute, Real& err_e
       const auto temp = temp_new[mfi].array();
 
       reduce_op.eval(bx, reduce_data,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
       {
           Real chg = 0.e0_rt;
           Real tot = 0.e0_rt;
@@ -115,7 +115,7 @@ void Radiation::check_convergence_matt(const MultiFab& rhoe_new, const MultiFab&
       Real cdt = C::c_light * delta_t;
 
       reduce_op.eval(bx, reduce_data,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
       {
           Real abschg_re = std::abs(ren(i,j,k) - res(i,j,k));
           Real relchg_re = std::abs(abschg_re / (ren(i,j,k) + 1.e-50_rt));
@@ -214,7 +214,7 @@ void Radiation::compute_etat(MultiFab& etaT, MultiFab& etaTz,
         auto rho_arr = rho[mfi].array();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real sigma = 1.e0_rt + ptc_tau;
             Real cdt = C::c_light * delta_t;
@@ -329,7 +329,7 @@ void Radiation::eos_opacity_emissivity(const MultiFab& S_new,
       }
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           const Real fac = 0.5e0_rt;
           const Real minfrac = 1.e-8_rt;
@@ -392,7 +392,7 @@ void Radiation::eos_opacity_emissivity(const MultiFab& S_new,
       const Box& reg = mfi.tilebox();
 
       amrex::ParallelFor(reg,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           // Integrate the Planck distribution upward from zero frequency.
           // This handles both the single-group and multi-group cases.
@@ -479,7 +479,7 @@ void Radiation::gray_accel(MultiFab& Er_new, MultiFab& Er_pi,
     Real cdt1 = 1.e0_rt / (C::c_light * delta_t);
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         Real epsilon[NGROUPS];
         Real sumeps = 0.0;
@@ -529,7 +529,7 @@ void Radiation::gray_accel(MultiFab& Er_new, MultiFab& Er_pi,
       const Real dt1 = (1.e0_rt + ptc_tau) / delta_t;
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           Real kbar = 0.0;
           for (int g = 0; g < NGROUPS; ++g) {
@@ -581,7 +581,7 @@ void Radiation::gray_accel(MultiFab& Er_new, MultiFab& Er_pi,
           auto ccoefs_arr = ccoefs[idim][mfi].array();
 
           amrex::ParallelFor(bx,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
               if (idim == 0) {
                   bcoefs_arr(i,j,k) += 0.5e0_rt * (spec_arr(i-1,j,k) + spec_arr(i,j,k)) * bcgrp_arr(i,j,k);
@@ -596,7 +596,7 @@ void Radiation::gray_accel(MultiFab& Er_new, MultiFab& Er_pi,
           
           if (nGroups > 1) {
               amrex::ParallelFor(bx,
-              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
               {
                   int ioff, joff, koff;
                   Real h1;
@@ -654,7 +654,7 @@ void Radiation::gray_accel(MultiFab& Er_new, MultiFab& Er_pi,
       auto rhs_arr = rhs[mfi].array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           Real rt_term = 0.0;
           for (int g = 0; g < NGROUPS; ++g) {
@@ -687,7 +687,7 @@ void Radiation::gray_accel(MultiFab& Er_new, MultiFab& Er_pi,
       auto accel_arr = accel[mfi].array();
 
       amrex::ParallelFor(reg,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           for (int n = 0; n < NGROUPS; ++n) {
               Er_new_arr(i,j,k,n) = Er_new_arr(i,j,k,n) + spec_arr(i,j,k,n) * accel_arr(i,j,k);
@@ -723,7 +723,7 @@ void Radiation::local_accel(MultiFab& Er_new, const MultiFab& Er_pi,
         Real cdt1 = 1.0_rt / (C::c_light * delta_t);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real Hg[NGROUPS], kapt[NGROUPS];
             Real rt_term = 0.0_rt;
@@ -841,7 +841,7 @@ void Radiation::update_matter(MultiFab& rhoe_new, MultiFab& temp_new,
         if (conservative_update) {
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 Real H1 = eta1_arr(i,j,k);
 
@@ -861,7 +861,7 @@ void Radiation::update_matter(MultiFab& rhoe_new, MultiFab& temp_new,
             Gpu::synchronize();
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 // Get T from rhoe (temp_new comes in with rhoe)
 
@@ -898,7 +898,7 @@ void Radiation::update_matter(MultiFab& rhoe_new, MultiFab& temp_new,
             const Real fac = 0.01_rt;
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 Real cpT = 0.e0_rt;
 
@@ -1039,7 +1039,7 @@ void Radiation::MGFLD_compute_rosseland(FArrayBox& kappa_r, const FArrayBox& sta
   }
 
   amrex::ParallelFor(kbox,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
       Real rho = state_arr(i,j,k,URHO);
       Real temp = state_arr(i,j,k,UTEMP);
@@ -1082,7 +1082,7 @@ void Radiation::MGFLD_compute_rosseland(MultiFab& kappa_r, const MultiFab& state
         auto kpr = kappa_r[mfi].array();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real rho = state_arr(i,j,k,URHO);
             Real temp = state_arr(i,j,k,UTEMP);
@@ -1118,7 +1118,7 @@ void Radiation::MGFLD_compute_scattering(FArrayBox& kappa_s, const FArrayBox& st
     const Real nu = nugroup[0];
 
     amrex::ParallelFor(kbox,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
         Real rho = sta(i,j,k,URHO);
         Real temp = sta(i,j,k,UTEMP);
@@ -1158,7 +1158,7 @@ void Radiation::bisect_matter(MultiFab& rhoe_new, MultiFab& temp_new,
       auto state = S_new[mfi].array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           Real rhoInv = 1.e0_rt / state(i,j,k,URHO);
 
@@ -1196,7 +1196,7 @@ void Radiation::rhstoEr(MultiFab& rhs, Real dt, int level)
         auto rhs_arr = rhs[ri].array();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real r, s;
             cell_center_metric(i, j, k, geomdata, r, s);

--- a/Source/radiation/RadSolve.cpp
+++ b/Source/radiation/RadSolve.cpp
@@ -153,7 +153,7 @@ void RadSolve::cellCenteredApplyMetrics(int level, MultiFab& cc)
         auto cc_arr = cc[mfi].array();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real r, s;
             cell_center_metric(i, j, k, geomdata, r, s);
@@ -227,7 +227,7 @@ void RadSolve::levelACoeffs(int level,
       const Real dtm = 1.e0_rt / delta_t;
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           Real r, s;
           cell_center_metric(i, j, k, geomdata, r, s);
@@ -334,7 +334,7 @@ void RadSolve::levelBCoeffs(int level,
         auto kappa_r_arr = kappa_r[mfi].array(kcomp);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             if (idim == 0) {
 
@@ -417,7 +417,7 @@ void RadSolve::levelDCoeffs(int level, Array<MultiFab, BL_SPACEDIM>& lambda,
             auto dcf_arr = dcf[mfi].array();
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 Real r, s;
 
@@ -532,7 +532,7 @@ void RadSolve::levelRhs(int level, MultiFab& rhs,
       const Real dtm = 1.0_rt / delta_t;
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           Real ek = fkp_arr(i,j,k) * eta_arr(i,j,k);
           Real bs = etainv_arr(i,j,k) * 4.e0_rt * sigma * fkp_arr(i,j,k) * std::pow(temp_arr(i,j,k), 4);
@@ -700,7 +700,7 @@ void RadSolve::levelFlux(int level,
           Real beta = radsolve::beta;
 
           amrex::ParallelFor(bx,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
               if (n == 0) {
 
@@ -899,7 +899,7 @@ void RadSolve::computeBCoeffs(MultiFab& bcoefs, int idim,
       auto kappa_r_arr = kappa_r[mfi].array(kcomp);
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           if (idim == 0) {
 
@@ -971,7 +971,7 @@ void RadSolve::levelACoeffs(int level, MultiFab& kpp,
       auto kpp_arr = kpp[mfi].array(igroup);
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           Real r, s;
           cell_center_metric(i, j, k, geomdata, r, s);
@@ -1028,7 +1028,7 @@ void RadSolve::levelRhs(int level, MultiFab& rhs, const MultiFab& jg,
       auto rhoe_star_arr = rhoe_star[ri].array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           Real Hg = mugT_arr(i,j,k,igroup) * etaT_arr(i,j,k);
 

--- a/Source/radiation/Radiation.cpp
+++ b/Source/radiation/Radiation.cpp
@@ -850,7 +850,7 @@ void Radiation::compute_exchange(MultiFab& exch,
         Real lc = c;
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             exch_arr(i,j,k) = fkp_arr(i,j,k) * (4.e0_rt * lsigma * std::pow(exch_arr(i,j,k), 4) - lc * Er_arr(i,j,k));
         });
@@ -895,7 +895,7 @@ void Radiation::compute_eta(MultiFab& eta, MultiFab& etainv,
                 const Real dT_loc = dT;
 
                 amrex::ParallelFor(bx,
-                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                 {
                     Real rho = state_arr(i,j,k,URHO);
                     Real temp = state_arr(i,j,k,UTEMP) + dT_loc;
@@ -936,7 +936,7 @@ void Radiation::compute_eta(MultiFab& eta, MultiFab& etainv,
             const Real fac2 = delta_t * c / dT;
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 Real d;
 
@@ -1003,7 +1003,7 @@ void Radiation::internal_energy_update(Real& relative, Real& absolute,
       auto frhoes_arr = frhoes[mfi].array();
 
       reduce_op.eval(bx, reduce_data,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
       {
           Real chg = 0.e0_rt;
           Real tot = 0.e0_rt;
@@ -1150,7 +1150,7 @@ void Radiation::state_update(MultiFab& state, MultiFab& frhoes)
         auto frhoes_arr = frhoes[mfi].array();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real kin = state_arr(i,j,k,UEDEN) - state_arr(i,j,k,UEINT);
             state_arr(i,j,k,UEINT) = frhoes_arr(i,j,k);
@@ -1420,7 +1420,7 @@ void Radiation::get_frhoe(MultiFab& frhoe,
         auto state_arr = state[si].array();
 
         amrex::ParallelFor(reg,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             frhoe_arr(i,j,k) = state_arr(i,j,k,UEINT);
         });
@@ -1450,7 +1450,7 @@ void Radiation::get_planck_and_temp(MultiFab& fkp,
         // Get T from rhoe; overwrite temp with T
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             if (temp_arr(i,j,k) <= 0.e0_rt)
             {
@@ -1482,7 +1482,7 @@ void Radiation::get_planck_and_temp(MultiFab& fkp,
         const Real nu = nugroup[igroup];
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             Real rho = state_arr(i,j,k,URHO);
             Real temp = state_arr(i,j,k,UTEMP);
@@ -1504,7 +1504,7 @@ void Radiation::get_planck_and_temp(MultiFab& fkp,
         int ncomp = temp[mfi].nComp();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             const Real temp_floor = 1.e-10_rt;
 
@@ -1559,7 +1559,7 @@ void Radiation::get_rosseland(MultiFab& kappa_r,
           auto kpr = kappa_r[mfi].array();
 
           amrex::ParallelFor(bx,
-          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+          [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
           {
               // frhoe will be overwritten with temperature here
 
@@ -1640,7 +1640,7 @@ void Radiation::update_rosseland_from_temp(MultiFab& kappa_r,
       auto kpr = kappa_r[mfi].array();
 
       amrex::ParallelFor(bx,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           state_arr(i,j,k,UTEMP) = temp_arr(i,j,k);
 
@@ -1683,7 +1683,7 @@ void Radiation::SGFLD_compute_rosseland(MultiFab& kappa_r, const MultiFab& state
       auto kpr = kappa_r[mfi].array();
 
       amrex::ParallelFor(kbox,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           Real rho = state_arr(i,j,k,URHO);
           Real temp = state_arr(i,j,k,UTEMP);
@@ -1718,7 +1718,7 @@ void Radiation::SGFLD_compute_rosseland(FArrayBox& kappa_r, const FArrayBox& sta
   auto kpr = kappa_r.array();
 
   amrex::ParallelFor(kbox,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
       Real rho = state_arr(i,j,k,URHO);
       Real temp = state_arr(i,j,k,UTEMP);
@@ -2163,7 +2163,7 @@ void Radiation::scaledGradient(int level,
               auto Er_arr = Erborder[mfi].array();
 
               amrex::ParallelFor(nbx,
-              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
               {
                   Real dxInv[3] = {0.0};
 
@@ -2451,7 +2451,7 @@ void Radiation::fluxLimiter(int level,
             auto lambda_arr = lambda[idim][mfi].array(lamcomp);
 
             amrex::ParallelFor(bx,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 lambda_arr(i,j,k) = FLDlambda(lambda_arr(i,j,k), limiter);
             });
@@ -2512,7 +2512,7 @@ void Radiation::get_rosseland_v_dcf(MultiFab& kappa_r, MultiFab& v, MultiFab& dc
             auto dcf_arr = dcf[mfi].array();
 
             amrex::ParallelFor(reg,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 // Get T from rhoe
 
@@ -2551,7 +2551,7 @@ void Radiation::get_rosseland_v_dcf(MultiFab& kappa_r, MultiFab& v, MultiFab& dc
             const Real nu = nugroup[igroup];
 
             amrex::ParallelFor(reg,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
             {
                 Real rho = S_arr(i,j,k,URHO);
                 Real temp = S_arr(i,j,k,UTEMP);
@@ -2619,7 +2619,7 @@ void Radiation::update_dcf(MultiFab& dcf, MultiFab& etainv, MultiFab& kp, MultiF
         auto kr_arr = kr[mfi].array();
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             dcf_arr(i,j,k) = 2.e0_rt * etainv_arr(i,j,k) * (kp_arr(i,j,k) / kr_arr(i,j,k));
         });

--- a/Source/radiation/SGRadSolver.cpp
+++ b/Source/radiation/SGRadSolver.cpp
@@ -76,7 +76,7 @@ void Radiation::single_group_update(int level, int iteration, int ncycle)
       auto S_new_arr = S_new[mfi].array();
 
       amrex::ParallelFor(reg,
-      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+      [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
       {
           frhoem_arr(i,j,k) = S_new_arr(i,j,k,UEINT);
       });

--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -80,7 +80,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt)
         if (level <= castro::reactions_max_solve_level) {
 
             reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+            [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
             {
 
                 burn_t burn_state;
@@ -178,7 +178,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt)
         // Now update the state with the reactions data.
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
         {
             if (U.contains(i,j,k) && reactions.contains(i,j,k)) {
                 for (int n = 0; n < NumSpec; ++n) {
@@ -314,7 +314,7 @@ Castro::react_state(Real time, Real dt)
         auto mask = interior_mask.array(mfi);
 
         reduce_op.eval(bx, reduce_data,
-        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) -> ReduceTuple
         {
 
             burn_t burn_state;

--- a/Source/rotation/Rotation.cpp
+++ b/Source/rotation/Rotation.cpp
@@ -15,7 +15,7 @@ Castro::fill_rotational_potential(const Box& bx,
   auto dx = geom.CellSizeArray();
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     GpuArray<Real, 3> r;
@@ -62,7 +62,7 @@ Castro::fill_rotational_psi(const Box& bx,
   auto dx = geom.CellSizeArray();
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     GpuArray<Real, 3> r;

--- a/Source/rotation/rotation_sources.cpp
+++ b/Source/rotation/rotation_sources.cpp
@@ -15,7 +15,7 @@ Castro::rsrc(const Box& bx,
   GeometryData geomdata = geom.data();
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real Sr[3] = {};
@@ -242,7 +242,7 @@ Castro::corrrsrc(const Box& bx,
   }
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real Sr_old[3] = {};

--- a/Source/sources/Castro_sponge.cpp
+++ b/Source/sources/Castro_sponge.cpp
@@ -159,7 +159,7 @@ Castro::apply_sponge(const Box& bx,
   }
 
   amrex::ParallelFor(bx,
-  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+  [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
 
     Real src[NSRC];

--- a/Source/sources/Castro_thermo.cpp
+++ b/Source/sources/Castro_thermo.cpp
@@ -134,7 +134,7 @@ Castro::fill_thermo_source (MultiFab& state_in, MultiFab& thermo_src)
 
 
     amrex::ParallelFor(bx,
-    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
 
       // radius for non-Cartesian


### PR DESCRIPTION

## PR summary

This works around an nvcc issue with -std=c++17.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
