### PR TITLE
AMReX now calls HYPRE_init() so we don't have to

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -94,8 +94,11 @@ ifeq ($(USE_TRUE_SDC), TRUE)
   USERSuffix = .TRUESDC
 endif
 
+USE_MLMG = FALSE
+
 ifeq ($(USE_RAD), TRUE)
   USE_HYPRE := TRUE
+  USE_MLMG = TRUE
 endif
 
 ifeq ($(USE_SYSTEM_BLAS), TRUE)
@@ -147,7 +150,6 @@ ifeq ($(USE_ACC), TRUE)
   DEFINES += -DACC
 endif
 
-USE_MLMG = FALSE
 
 
 #------------------------------------------------------------------------------

--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -94,6 +94,10 @@ ifeq ($(USE_TRUE_SDC), TRUE)
   USERSuffix = .TRUESDC
 endif
 
+ifeq ($(USE_RAD), TRUE)
+  USE_HYPRE := TRUE
+endif
+
 ifeq ($(USE_SYSTEM_BLAS), TRUE)
   LIBRARIES += $(BLAS_LIBRARY)
 endif
@@ -251,8 +255,6 @@ ifeq ($(USE_RAD), TRUE)
   Bdirs += Source/radiation Source/radiation/_interpbndry
   DEFINES += -DRADIATION
   DEFINES += -DRAD_INTERP
-  USE_HYPRE := TRUE
-  DEFINES += -DHYPRE
 
   DEFINES += -DNGROUPS=$(NGROUPS)
 
@@ -328,16 +330,6 @@ Blocs += $(foreach dir, $(EXTERN_CORE), $(dir))
 #------------------------------------------------------------------------------
 # external libraries
 #------------------------------------------------------------------------------
-
-ifeq ($(USE_HYPRE), TRUE)
-  INCLUDE_LOCATIONS += $(HYPRE_DIR)/include
-  LIBRARY_LOCATIONS += $(HYPRE_DIR)/lib
-
-  LIBRARIES += -lHYPRE
-  ifeq ($(USE_CUDA),TRUE)
-    LIBRARIES += -lcusparse -lcurand
-  endif
-endif
 
 ifeq ($(USE_HDF5), TRUE)
   INCLUDE_LOCATIONS += $(HDF5_DIR)/include

--- a/Source/driver/main.cpp
+++ b/Source/driver/main.cpp
@@ -19,10 +19,6 @@
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_AmrLevel.H>
 
-#ifdef HYPRE
-#include <_hypre_utilities.h>
-#endif
-
 #include <time.h>
 
 #include <Castro.H>
@@ -64,11 +60,6 @@ main (int   argc,
     if (!strchr(argv[1], '=')) {
         inputs_name = argv[1];
     }
-
-#ifdef HYPRE
-    // Initialize Hypre.
-    HYPRE_Init();
-#endif
 
     BL_PROFILE_VAR("main()", pmain);
 
@@ -192,10 +183,6 @@ main (int   argc,
                 << time_pointer->tm_year + 1900 << "-"
                 << std::setw(2) << time_pointer->tm_mon + 1 << "-"
                 << std::setw(2) << time_pointer->tm_mday << "." << std::endl;
-
-#ifdef HYPRE
-    HYPRE_Finalize();
-#endif
 
     delete amrptr;
     //


### PR DESCRIPTION

## PR summary

We also update to use the AMReX GNU make package for Hypre instead of doing it on our own.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
