### PR TITLE
Move C++ probinit and prob params to buildMetrics

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -598,32 +598,6 @@ Castro::Castro (Amr&            papa,
 
     buildMetrics();
 
-    // initialize the C++ values of the runtime parameters
-    if (do_init_probparams == 0) {
-      init_prob_parameters();
-
-      do_init_probparams = 1;
-
-      // Copy ambient data from Fortran to C++. This should be done prior to
-      // problem_initialize() in case the C++ initialization overwrites it.
-
-      for (int n = 0; n < NUM_STATE; ++n) {
-          ambient::ambient_state[n] = 0.0_rt;
-      }
-
-      get_ambient_data(ambient::ambient_state);
-
-      // If we're doing C++ problem initialization, do it here. We have to make
-      // sure it's done after the above call to init_prob_parameters() in case
-      // any changes are made to the problem parameters.
-
-      problem_initialize();
-
-      // Sync Fortran back up with any changes we made to the problem parameters.
-      // If problem_initialize() didn't change them, this has no effect.
-      cxx_to_f90_prob_parameters();
-    }
-
     initMFs();
 
     // Coterminous AMR boundaries are not supported in Castro if we're doing refluxing.
@@ -890,6 +864,31 @@ Castro::initMFs()
 
     lastDt = 1.e200;
 
+    // initialize the C++ values of the runtime parameters
+    if (do_init_probparams == 0) {
+        init_prob_parameters();
+
+        do_init_probparams = 1;
+
+        // Copy ambient data from Fortran to C++. This should be done prior to
+        // problem_initialize() in case the C++ initialization overwrites it.
+
+        for (int n = 0; n < NUM_STATE; ++n) {
+            ambient::ambient_state[n] = 0.0_rt;
+        }
+
+        get_ambient_data(ambient::ambient_state);
+
+        // If we're doing C++ problem initialization, do it here. We have to make
+        // sure it's done after the above call to init_prob_parameters() in case
+        // any changes are made to the problem parameters.
+
+        problem_initialize();
+
+        // Sync Fortran back up with any changes we made to the problem parameters.
+        // If problem_initialize() didn't change them, this has no effect.
+        cxx_to_f90_prob_parameters();
+    }
 }
 
 void


### PR DESCRIPTION

## PR summary

Currently in C++, problem_initialize() and the read of the C++ parameters is not happening on a restart (as well as the setting of the C++ ambient data, the proximal cause for the issue in #1548). Moving to buildMetrics() fixes this, as it is also done on a restart.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
