### PR TITLE
fix the error checking on the axisymmetric geom term

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 
+# 21.02
+
    * In axisymmetric geometry, there are additional forces that arise
      due to the changing direction of the unit vectors in the div{rho
      U U} term. The paper by Bernand-Champmartin discusses this. See
@@ -6,8 +8,6 @@
      in 2-d axisymmetry is already consistent with a right-handed
      system despite our internal ordering of the state was r, z,
      theta.  (#923)
-
-# 21.02
 
    * We can now set any of the Microphysics runtime parameters in the
      inputs file instead of probin.  Each group of parameters has a

--- a/Exec/science/rotating_star/probin.sdc_test
+++ b/Exec/science/rotating_star/probin.sdc_test
@@ -1,6 +1,6 @@
 &fortin
 
-  model_name =  "15m_500_sec.hse.6400"
+  model_name =  "15m_aprox19.6400"
 
 /
 
@@ -50,5 +50,7 @@
   retry_burn = F
   abort_on_failure = F
 
-  jacobian = 2
+  rho_nse = 5.e7
+
+  jacobian = 1
 /

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -397,7 +397,13 @@ Castro::read_params ()
         amrex::Error();
       }
 
-
+#ifdef ROTATION
+    if (dgeom.IsRZ() && state_in_rotating_frame == 0 && use_axisymmetric_geom_source)
+    {
+        std::cerr << "use_axisymmetric_geom_source is not compatible with state_in_rotating_frame=0\n";
+        amrex::Error();
+    }
+#endif
 
     // Make sure not to call refluxing if we're not actually doing any hydro.
     if (do_hydro == 0) {

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -448,7 +448,7 @@ rotation_include_coriolis    int           1                  n        ROTATION
 # in that rotating frame. If this option is disabled by setting it to 0,
 # the state variables will be measured with respect to an observer fixed
 # in the inertial frame (but the frame will still rotate).
-state_in_rotating_frame      int           1                  n        ROTATION
+state_in_rotating_frame     int           1                  n        ROTATION
 
 # determines how the rotation source terms are added to the momentum and
 # energy equations

--- a/Source/sources/Castro_geom.cpp
+++ b/Source/sources/Castro_geom.cpp
@@ -3,16 +3,21 @@
 
 using namespace amrex;
 
+///
+/// this adds the geometric source term for axisymmetric
+/// coordinates as described in Bernand-Champmartin.  This only
+/// applies to axisymmetric geometry.
+///
 void
 Castro::construct_old_geom_source(MultiFab& source, MultiFab& state_in, Real time, Real dt)
 {
 
   if (geom.Coord() != 1) {
-    amrex::Abort("this is only defined for axisymmetric geometry");
+      return;
   }
 
   if (use_axisymmetric_geom_source == 0) {
-    return;
+      return;
   }
 
   const Real strt_time = ParallelDescriptor::second();
@@ -53,11 +58,11 @@ Castro::construct_new_geom_source(MultiFab& source, MultiFab& state_old, MultiFa
 {
 
   if (geom.Coord() != 1) {
-    amrex::Abort("this is only defined for axisymmetric geometry");
+      return;
   }
 
   if (use_axisymmetric_geom_source == 0) {
-    return;
+      return;
   }
 
   const Real strt_time = ParallelDescriptor::second();


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

this also adds an abort if we try to use the new geometry term with state_in_rotating_frame=0

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
