### PR TITLE
Use eos_re_t in places where it is sufficient

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1374,7 +1374,7 @@ Castro::initData ()
                Real v = S_arr(i,j,k,UMY) * rhoInv;
                Real w = S_arr(i,j,k,UMZ) * rhoInv;
 
-               eos_t eos_state;
+               eos_re_t eos_state;
                eos_state.rho = S_arr(i,j,k,URHO);
                eos_state.T = S_arr(i,j,k,UTEMP);
                eos_state.e = S_arr(i,j,k,UEINT) * rhoInv - 0.5_rt * (u*u + v*v + w*w);
@@ -3829,7 +3829,7 @@ Castro::reset_internal_energy(const Box& bx,
         Real Wp = u(i,j,k,UMZ) * rhoInv;
         Real ke = 0.5_rt * (Up * Up + Vp * Vp + Wp * Wp);
 
-        eos_t eos_state;
+        eos_re_t eos_state;
 
         eos_state.rho = u(i,j,k,URHO);
         eos_state.T   = lsmall_temp;
@@ -4146,7 +4146,7 @@ Castro::computeTemp(
 
           Real rhoInv = 1.0_rt / u(i,j,k,URHO);
 
-          eos_t eos_state;
+          eos_re_t eos_state;
 
           eos_state.rho = u(i,j,k,URHO);
           eos_state.T   = u(i,j,k,UTEMP); // Initial guess for the EOS

--- a/Source/radiation/MGFLD.cpp
+++ b/Source/radiation/MGFLD.cpp
@@ -280,7 +280,7 @@ void Radiation::eos_opacity_emissivity(const MultiFab& S_new,
       {
           Real rhoInv = 1.e0_rt / S_new_arr(i,j,k,URHO);
 
-          eos_t eos_state;
+          eos_re_t eos_state;
           eos_state.rho = S_new_arr(i,j,k,URHO);
           eos_state.T   = temp_arr(i,j,k);
           for (int n = 0; n < NumSpec; ++n) {
@@ -873,7 +873,7 @@ void Radiation::update_matter(MultiFab& rhoe_new, MultiFab& temp_new,
                 {
                     Real rhoInv = 1.e0_rt / S_new_arr(i,j,k,URHO);
 
-                    eos_t eos_state;
+                    eos_re_t eos_state;
                     eos_state.rho = S_new_arr(i,j,k,URHO);
                     eos_state.T   = S_new_arr(i,j,k,UTEMP);
                     eos_state.e   = Tp_n(i,j,k) * rhoInv;
@@ -918,7 +918,7 @@ void Radiation::update_matter(MultiFab& rhoe_new, MultiFab& temp_new,
 
                 Real rhoInv = 1.e0_rt / S_new_arr(i,j,k,URHO);
 
-                eos_t eos_state;
+                eos_re_t eos_state;
                 eos_state.rho = S_new_arr(i,j,k,URHO);
                 eos_state.T   = Tp_n(i,j,k);
                 for (int n = 0; n < NumSpec; ++n) {
@@ -1578,7 +1578,7 @@ void Radiation::bisect_matter(MultiFab& rhoe_new, MultiFab& temp_new,
       {
           Real rhoInv = 1.e0_rt / state(i,j,k,URHO);
 
-          eos_t eos_state;
+          eos_re_t eos_state;
           eos_state.rho = state(i,j,k,URHO);
           eos_state.T   =  temp(i,j,k);
           for (int n = 0; n < NumSpec; ++n) {

--- a/Source/radiation/Radiation.cpp
+++ b/Source/radiation/Radiation.cpp
@@ -1166,7 +1166,7 @@ void Radiation::state_update(MultiFab& state, MultiFab& frhoes)
             {
                 Real rhoInv = 1.e0_rt / state_arr(i,j,k,URHO);
 
-                eos_t eos_state;
+                eos_re_t eos_state;
                 eos_state.rho = state_arr(i,j,k,URHO);
                 eos_state.T   = state_arr(i,j,k,UTEMP);
                 eos_state.e   = state_arr(i,j,k,UEINT) * rhoInv;
@@ -1388,7 +1388,7 @@ void Radiation::get_c_v(FArrayBox& c_v, FArrayBox& temp, FArrayBox& state,
     {
         Real rhoInv = 1.e0_rt / state_arr(i,j,k,URHO);
 
-        eos_t eos_state;
+        eos_re_t eos_state;
         eos_state.rho = state_arr(i,j,k,URHO);
         eos_state.T   = temp_arr(i,j,k);
         for (int n = 0; n < NumSpec; ++n) {
@@ -1460,7 +1460,7 @@ void Radiation::get_planck_and_temp(MultiFab& fkp,
             {
                 Real rhoInv = 1.e0_rt / state_arr(i,j,k,URHO);
 
-                eos_t eos_state;
+                eos_re_t eos_state;
                 eos_state.rho = state_arr(i,j,k,URHO);
                 eos_state.T   = state_arr(i,j,k,UTEMP);
                 eos_state.e   = temp_arr(i,j,k) * rhoInv;
@@ -1571,7 +1571,7 @@ void Radiation::get_rosseland(MultiFab& kappa_r,
               {
                   Real rhoInv = 1.e0_rt / state_arr(i,j,k,URHO);
 
-                  eos_t eos_state;
+                  eos_re_t eos_state;
                   eos_state.rho = state_arr(i,j,k,URHO);
                   eos_state.T   = state_arr(i,j,k,UTEMP);
                   eos_state.e   = state_arr(i,j,k,UEINT) * rhoInv;
@@ -2524,7 +2524,7 @@ void Radiation::get_rosseland_v_dcf(MultiFab& kappa_r, MultiFab& v, MultiFab& dc
                 {
                     Real rhoInv = 1.e0_rt / S_arr(i,j,k,URHO);
 
-                    eos_t eos_state;
+                    eos_re_t eos_state;
                     eos_state.rho = S_arr(i,j,k,URHO);
                     eos_state.T   = S_arr(i,j,k,UTEMP);
                     eos_state.e   = S_arr(i,j,k,UEINT) * rhoInv;


### PR DESCRIPTION

## PR summary

In several places like `computeTemp()`, we only need (rho, T, e) in the EOS state, we do not need pressure (or other fields like entropy and enthalpy). For those cases we switch to the thinner state, which allows equations of state to skip calculating those unused fields.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
