### PR TITLE
fix the check on whether we are in NSE for SDC in dtnuc_e

### DIFF
--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -465,7 +465,7 @@ Castro::estdt_burning()
             Real dt_tmp = 1.e200_rt;
 
 #ifdef NSE
-            if (!in_nse(state)) {
+            if (!in_nse(eos_state)) {
 #endif
                 dt_tmp = dtnuc_e * e / dedt;
 #ifdef NSE


### PR DESCRIPTION
the complication is that in_nse operating on a burn_t expects the data to come from
burn_t.y[] for simplified-SDC.  So we need to use the eos_t interface instead.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
