### PR TITLE
use the burn_t in the eos call for nuclear dt estimation

### DIFF
--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -429,10 +429,7 @@ Castro::estdt_burning()
                 X[n] = amrex::max(state.xn[n], small_x);
             }
 
-            eos_t eos_state;
-            burn_to_eos(state, eos_state);
-            eos(eos_input_rt, eos_state);
-            eos_to_burn(eos_state, state);
+            eos(eos_input_rt, state);
 
 #ifdef STRANG
             state.self_heat = true;
@@ -465,6 +462,13 @@ Castro::estdt_burning()
             Real dt_tmp = 1.e200_rt;
 
 #ifdef NSE
+            // we need to use the eos_state interface here because for
+            // SDC, if we come in with a burn_t, it expects to
+            // evaluate the NSE criterion based on the conserved state.
+
+            eos_t eos_state;
+            burn_to_eos(state, eos_state);
+
             if (!in_nse(eos_state)) {
 #endif
                 dt_tmp = dtnuc_e * e / dedt;


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
