### PR TITLE
remove an unneeded clean_state in true SDC advance

### DIFF
--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -220,9 +220,6 @@ Castro::do_advance_sdc (Real time,
 
       do_sdc_update(m, m+1, dt); //(dt_sdc[m+1] - dt_sdc[m])*dt);
 
-      // we now have a new value of k_new[m+1], do a clean_state on it
-      clean_state(S_new, cur_time, 0);
-
     }
 
 

--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -220,6 +220,9 @@ Castro::do_advance_sdc (Real time,
 
       do_sdc_update(m, m+1, dt); //(dt_sdc[m+1] - dt_sdc[m])*dt);
 
+      // we now have a new value of k_new[m+1], do a clean_state on it
+      clean_state(*(k_new[m+1]), cur_time, 0);
+
     }
 
 


### PR DESCRIPTION
we do a clean_state at the top of the node loop, so we don't
need to do it at the very end too.  Plus, we were not calling
it on the right MF at the end anyway...

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
