### PR TITLE
docs: the BACKTRACE stuff no longer seems to be the ifdef

### DIFF
--- a/Docs/source/faq.rst
+++ b/Docs/source/faq.rst
@@ -94,21 +94,19 @@ Debugging
 
    -  ``amrex.fpe_trap_overflow``
 
-   For further capabilities, defining ``BACKTRACE=TRUE`` enables you
-   to get more information than the backtrace of the call stack info by
-   instrumenting the code. (This is in C code only). Here is an
+   For further capabilities, you can get 
+   more information than the backtrace of the call stack info by
+   instrumenting the code.  Here is an
    example. You know the line ``Real rho = state(cell,0);`` is
    causing a segfault. You could add a print statement before that.
    But it might print out thousands (or even millions) of line before
-   it hits the segfault. With ``BACKTRACE``, you could do
+   it hits the segfault. Instead, you could
 
-   ::
+   .. code:: c++
 
-             #ifdef AMREX_BACKTRACING
-                std::ostringstream ss;
-                ss << ``state.box() = `` << state.box() << `` cell = `` << cell;
-                BL_BACKTRACE_PUSH(ss.str()); // PUSH takes std::string
-             #endif
+             std::ostringstream ss;
+             ss << ``state.box() = `` << state.box() << `` cell = `` << cell;
+             BL_BACKTRACE_PUSH(ss.str()); // PUSH takes std::string
 
              Real rho = state(cell,0);  // state is a Fab, and cell is an IntVect.
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
