### PR TITLE
don't do the clean_state on S_new after applying the advective update

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -244,12 +244,14 @@ Castro::do_advance_ctu(Real time,
     }
 
 
+#ifndef SIMPLIFIED_SDC
     // Sync up state after old sources and hydro source.
     clean_state(
 #ifdef MHD
                 Bx_new, By_new, Bz_new,
 #endif
                 S_new, cur_time, 0);
+#endif
 
 #ifndef AMREX_USE_GPU
     // Check for NaN's.


### PR DESCRIPTION
that state is incomplete -- it had a reactive predictor, but we didn't apply the reactive
state to it

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
