### PR TITLE
Fix issue where Castro was using uninitialized tracer particle parameters

### DIFF
--- a/Source/particles/CastroParticles.cpp
+++ b/Source/particles/CastroParticles.cpp
@@ -16,11 +16,6 @@ using namespace amrex;
 AmrTracerParticleContainer* Castro::TracerPC =  0;
 
 namespace {
-    std::string       particle_init_file;
-    std::string       particle_restart_file;
-    int               restart_from_nonparticle_chkfile = 0;
-    std::string       particle_output_file;
-    std::string       timestamp_dir;
     std::vector<int>  timestamp_indices;
     //
     const std::string chk_tracer_particle_file("Tracer");
@@ -33,8 +28,8 @@ Castro::read_particle_params ()
   ParmParse pp("particles");
 
     if (ParallelDescriptor::IOProcessor())
-        if (!amrex::UtilCreateDirectory(timestamp_dir, 0755))
-            amrex::CreateDirectoryFailed(timestamp_dir);
+        if (!amrex::UtilCreateDirectory(particles::timestamp_dir, 0755))
+            amrex::CreateDirectoryFailed(particles::timestamp_dir);
     //
     // Force other processors to wait till directory is built.
     //
@@ -57,9 +52,9 @@ Castro::init_particles ()
 
         TracerPC->SetVerbose(particles::particle_verbose);
 
-        if (! particle_init_file.empty())
+        if (! particles::particle_init_file.empty())
         {
-            TracerPC->InitFromAsciiFile(particle_init_file,0);
+            TracerPC->InitFromAsciiFile(particles::particle_init_file,0);
         }
     }
 }
@@ -102,19 +97,19 @@ Castro::ParticlePostRestart (const std::string& restart_file)
             // We want to be able to add new particles on a restart.
             // As well as the ability to write the particles out to an ascii file.
             //
-            if (!restart_from_nonparticle_chkfile)
+            if (!particles::restart_from_nonparticle_chkfile)
             {
                 TracerPC->Restart(parent->theRestartFile(), chk_tracer_particle_file);
             }
 
-            if (!particle_restart_file.empty())
+            if (!particles::particle_restart_file.empty())
             {
-                TracerPC->InitFromAsciiFile(particle_restart_file,0);
+                TracerPC->InitFromAsciiFile(particles::particle_restart_file,0);
             }
 
-            if (!particle_output_file.empty())
+            if (!particles::particle_output_file.empty())
             {
-                TracerPC->WriteAsciiFile(particle_output_file);
+                TracerPC->WriteAsciiFile(particles::particle_output_file);
             }
         }
     }
@@ -221,9 +216,9 @@ Castro::TimestampParticles (int ngrow)
         }
     }
 
-    if ( TracerPC && !timestamp_dir.empty())
+    if ( TracerPC && !particles::timestamp_dir.empty())
     {
-        std::string basename = timestamp_dir;
+        std::string basename = particles::timestamp_dir;
 
         if (basename[basename.length()-1] != '/') basename += '/';
 


### PR DESCRIPTION
`CastroParticles.cpp` was previously using an unitialized, unnamed namespace in that file to hold tracer particle parameters that were also defined in the `particles` namespace defined with `_cpp_parameters` and included through:

 ```
#include <particles_params.H>
#include <particles_declares.H>
```

As a result, the code inside this source file was using the uninitialized parameters in the unnamed namespace instead of the parameters by the same names in the `particles` namespace.

This removes the duplicate parameters from the unnamed namespace and adds the `particles::` namespace specifier where necessary.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
