### PR TITLE
remove the use_eos_in_riemann parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 21.05
+
+   * The parameter use_eos_in_riemann was removed -- we found no
+     instances of it being used (#1623)
+
 # 21.04
 
    * For simplified-SDC, we now correctly store only the reactive

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -129,10 +129,6 @@ cg_tol                       Real          1.0e-5
 # 2 = do a bisection search for another 2 * cg_maxiter iterations.
 cg_blend                     int           2
 
-# should we use the EOS in the Riemann solver to ensure
-# thermodynamic consistency?
-use_eos_in_riemann           int           0
-
 # flatten the reconstructed profiles around shocks to prevent them
 # from becoming too thin
 use_flattening               int           1

--- a/Source/hydro/riemann_solvers.cpp
+++ b/Source/hydro/riemann_solvers.cpp
@@ -617,8 +617,6 @@ Castro::riemannus(const Box& bx,
                                hi_bc[idir] == SlipWall ||
                                hi_bc[idir] == NoSlipWall);
 
-  const int luse_eos_in_riemann = use_eos_in_riemann;
-
   const Real lsmall = riemann_constants::small;
   const Real lsmall_dens = small_dens;
   const Real lsmall_pres = small_pres;

--- a/Source/hydro/riemann_solvers.cpp
+++ b/Source/hydro/riemann_solvers.cpp
@@ -1004,33 +1004,6 @@ Castro::riemannus(const Box& bx,
     qint(i,j,k,QREINT) = regdnv;
 #endif
 
-    // we are potentially thermodynamically inconsistent, fix that
-    // here
-    if (luse_eos_in_riemann == 1) {
-      // we need to know the species -- they only jump across
-      // the contact
-      eos_t eos_state;
-
-      eos_state.rho = qint(i,j,k,QRHO);
-      eos_state.p = qint(i,j,k,QPRES);
-
-      for (int n = 0; n < NumSpec; n++) {
-        eos_state.xn[n] = fp*ql(i,j,k,QFS+n) + fm*qr(i,j,k,QFS+n);
-      }
-
-      eos_state.T = lT_guess;
-
-#if NAUX_NET > 0
-      for (int n = 0; n < NumAux; n++) {
-        eos_state.aux[n] = fp*ql(i,j,k,QFX+n) + fm*qr(i,j,k,QFX+n);
-      }
-#endif
-
-      eos(eos_input_rp, eos_state);
-
-      qint(i,j,k,QREINT) = eos_state.rho * eos_state.e;
-    }
-
     // Enforce that fluxes through a symmetry plane or wall are hard zero.
     qint(i,j,k,iu) = qint(i,j,k,iu) * bnd_fac;
 


### PR DESCRIPTION
I could find no instance where this was used

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
