### PR TITLE
Use device memory instead of managed memory

### DIFF
--- a/Source/driver/main.cpp
+++ b/Source/driver/main.cpp
@@ -30,6 +30,21 @@ std::string inputs_name = "";
 
 amrex::LevelBld* getLevelBld ();
 
+// Any parameters we want to override the defaults for in AMReX
+
+void override_parameters ()
+{
+    ParmParse pp("amrex");
+    if (!pp.contains("the_arena_is_managed")) {
+        // Use device memory allocations, not managed memory.
+        pp.add("the_arena_is_managed", false);
+    }
+    if (!pp.contains("abort_on_out_of_gpu_memory")) {
+        // Abort if we run out of GPU memory.
+        pp.add("abort_on_out_of_gpu_memory", true);
+    }
+}
+
 int
 main (int   argc,
       char* argv[])
@@ -48,7 +63,7 @@ main (int   argc,
     //
     // Make sure to catch new failures.
     //
-    amrex::Initialize(argc,argv);
+    amrex::Initialize(argc, argv, true, MPI_COMM_WORLD, override_parameters);
     {
 
     // Refuse to continue if we did not provide an inputs file.


### PR DESCRIPTION

## PR summary

The arena used for Fab allocations will now be device memory instead of managed memory. Managed memory was extremely convenient during our initial GPU port, but now causes a lot of problems with people inadvertently overfilling GPU memory and running extremely slowly when they should probably abort and change their setup. Managed memory can still be opted into in the inputs file with `amrex.the_arena_is_managed = 1` for people who really want to oversubscribe, but it is non-recommended.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
