### PR TITLE
remove the unused compute_gammas option in Riemann

### DIFF
--- a/Source/hydro/Castro_hydro.H
+++ b/Source/hydro/Castro_hydro.H
@@ -758,7 +758,6 @@
 /// @param lambda_int      radiation flux limiter on the interface
 /// @param qaux            auxillary state
 /// @param idir            coordinate direction of the solve (0 = x, 1 = y, 2 = z)
-/// @param compute_gammas  do we call the EOS using the interface states to get Gamma_1 on interfaces
 ///
     void riemann_state(const amrex::Box& bx,
                        amrex::Array4<amrex::Real> const& qm,
@@ -768,7 +767,7 @@
                        amrex::Array4<amrex::Real> const& lambda_int,
 #endif
                        amrex::Array4<amrex::Real const> const& qaux,
-                       const int idir, const int compute_gammas);
+                       const int idir);
 
 ///
 /// The Colella-Glaz Riemann solver for pure hydrodynamics.  This is a
@@ -809,7 +808,7 @@
 #ifdef RADIATION
                    amrex::Array4<amrex::Real> const& lambda_int,
 #endif
-                   const int idir, const int compute_gammas);
+                   const int idir);
 
 ///
 /// A HLLC Riemann solver for pure hydrodynamics

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -259,7 +259,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
                           qm_arr, qp_arr,
                           q_avg_arr,
                           qaux_arr,
-                          idir, 0);
+                          idir);
 
             compute_flux_q(ibx[idir], q_avg_arr, f_avg_arr, idir);
 

--- a/Source/hydro/riemann.H
+++ b/Source/hydro/riemann.H
@@ -186,7 +186,7 @@ load_input_states(const int i, const int j, const int k, const int idir,
     // cleaning
 
 #ifdef TRUE_SDC
-    } else if (use_reconstructed_gamma1 == 1) {
+    if (use_reconstructed_gamma1 == 1) {
         ql.gamc = qleft_arr(i,j,k,QGC);
         qr.gamc = qright_arr(i,j,k,QGC);
     }

--- a/Source/hydro/riemann.H
+++ b/Source/hydro/riemann.H
@@ -69,7 +69,6 @@ load_input_states(const int i, const int j, const int k, const int idir,
                   Array4<Real const> const& qleft_arr,
                   Array4<Real const> const& qright_arr,
                   Array4<Real const> const& qaux_arr,
-                  const int compute_gammas,
                   RiemannState& ql, RiemannState& qr, RiemannAux& raux) {
 
     const Real small = 1.e-8_rt;
@@ -186,48 +185,10 @@ load_input_states(const int i, const int j, const int k, const int idir,
 
     // cleaning
 
-#ifndef RADIATION
-    if (compute_gammas == 1) {
-
-        // we come in with a good p, rho, and X on the interfaces
-        // -- use this to find the gamma used in the sound speed
-        eos_t eos_state;
-
-        eos_state.p = ql.p;
-        eos_state.rho = ql.rho;
-        for (int n = 0; n < NumSpec; n++) {
-            eos_state.xn[n] = qleft_arr(i,j,k,QFS+n);
-        }
-        eos_state.T = T_guess; // initial guess
-#if NAUX_NET > 0
-        for (int n = 0; n < NumAux; n++) {
-            eos_state.aux[n] = qleft_arr(i,j,k,QFX+n);
-        }
-#endif
-
-        eos(eos_input_rp, eos_state);
-        ql.gamc = eos_state.gam1;
-
-        eos_state.p = qr.p;
-        eos_state.rho = qr.rho;
-        for (int n = 0; n < NumSpec; n++) {
-            eos_state.xn[n] = qright_arr(i,j,k,QFS+n);
-        }
-        eos_state.T = T_guess; // initial guess
-#if NAUX_NET > 0
-        for (int n = 0; n < NumAux; n++) {
-            eos_state.aux[n] = qright_arr(i,j,k,QFX+n);
-        }
-#endif
-
-        eos(eos_input_rp, eos_state);
-        qr.gamc = eos_state.gam1;
-
 #ifdef TRUE_SDC
     } else if (use_reconstructed_gamma1 == 1) {
         ql.gamc = qleft_arr(i,j,k,QGC);
         qr.gamc = qright_arr(i,j,k,QGC);
-#endif
     }
 #endif
 
@@ -239,7 +200,7 @@ load_input_states(const int i, const int j, const int k, const int idir,
         std::cout <<  "WARNING: (rho e)_l < 0 or pl < small_pres in Riemann: " << ql.rhoe << " " << ql.p << " " << small_pres << std::endl;
 #endif
 
-        eos_t eos_state;
+        eos_rep_t eos_state;
         eos_state.T = small_temp;
         eos_state.rho = ql.rho;
         for (int n = 0; n < NumSpec; n++) {
@@ -263,7 +224,7 @@ load_input_states(const int i, const int j, const int k, const int idir,
         std::cout << "WARNING: (rho e)_r < 0 or pr < small_pres in Riemann: " << qr.rhoe << " " << qr.p << " " << small_pres << std::endl;
 #endif
 
-        eos_t eos_state;
+        eos_rep_t eos_state;
         eos_state.T = small_temp;
         eos_state.rho = qr.rho;
         for (int n = 0; n < NumSpec; n++) {

--- a/Source/hydro/riemann.cpp
+++ b/Source/hydro/riemann.cpp
@@ -44,7 +44,7 @@ Castro::cmpflx_plus_godunov(const Box& bx,
                   lambda_int,
 #endif
                   qaux_arr,
-                  idir, 0);
+                  idir);
 
     compute_flux_q(bx,
                    qint, flx,
@@ -148,7 +148,7 @@ Castro::riemann_state(const Box& bx,
                       Array4<Real> const& lambda_int,
 #endif
                       Array4<Real const> const& qaux_arr,
-                      const int idir, const int compute_gammas) {
+                      const int idir) {
 
   // just compute the hydrodynamic state on the interfaces
   // don't compute the fluxes
@@ -246,7 +246,7 @@ Castro::riemann_state(const Box& bx,
 #ifdef RADIATION
               lambda_int,
 #endif
-              idir, compute_gammas);
+              idir);
 
   } else if (riemann_solver == 1) {
     // Colella & Glaz solver

--- a/Source/hydro/riemann_solvers.cpp
+++ b/Source/hydro/riemann_solvers.cpp
@@ -83,11 +83,8 @@ Castro::riemanncg(const Box& bx,
     RiemannState qr;
     RiemannAux raux;
 
-    int compute_gammas = 0;
-
     load_input_states(i, j, k, idir,
                       qleft_arr, qright_arr, qaux_arr,
-                      compute_gammas,
                       ql, qr, raux);
 
     // deal with hard walls
@@ -467,7 +464,7 @@ Castro::riemannus(const Box& bx,
 #ifdef RADIATION
                   Array4<Real> const& lambda_int,
 #endif
-                  const int idir, const int compute_gammas) {
+                  const int idir) {
 
   // Colella, Glaz, and Ferguson solver
   //
@@ -550,7 +547,6 @@ Castro::riemannus(const Box& bx,
 
     load_input_states(i, j, k, idir,
                       qleft_arr, qright_arr, qaux_arr,
-                      compute_gammas,
                       ql, qr, raux);
 
 


### PR DESCRIPTION
also use some simpler eos types

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
