### PR TITLE
Compile with MPI_THREAD_MULTIPLE support by default

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -99,6 +99,13 @@ ifeq ($(USE_SYSTEM_BLAS), TRUE)
   LIBRARIES += $(BLAS_LIBRARY)
 endif
 
+ifeq ($(USE_MPI), TRUE)
+  # Use thread support in MPI to support asynchronous I/O
+  MPI_THREAD_MULTIPLE := TRUE
+  # But keep the suffix MPI, not MTMPI, for simplicity
+  MPI_THREAD_MULTIPLE_UPDATE_SUFFIX := FALSE
+endif
+
 ifeq ($(USE_CUDA),TRUE)
   DEFINES += -DCUDA
   CUDA_VERBOSE = FALSE


### PR DESCRIPTION

## PR summary

This allows us to use `amrex.async_out=1` at runtime.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
