### PR TITLE
change how we handle species sources in simplified-SDC

### DIFF
--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -442,6 +442,37 @@ Castro::ctu_plm_states(const Box& bx, const Box& vbx,
 
 
 void
+Castro::add_species_source_to_states(const Box& bx, const int idir, const Real dt,
+                                     Array4<Real> const& qleft,
+                                     Array4<Real> const& qright,
+                                     Array4<Real const> const& src_q)
+{
+
+    amrex::ParallelFor(bx,
+    [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
+    {
+
+        for (int ipassive = 0; ipassive < npassive; ipassive++) {
+
+            int n = qpassmap(ipassive);
+
+            if (idir == 0) {
+                qleft(i,j,k,n) += 0.5 * dt * src_q(i-1,j,k,n);
+            } else if (idir == 1) {
+                qleft(i,j,k,n) += 0.5 * dt * src_q(i,j-1,k,n);
+            } else {
+                qleft(i,j,k,n) += 0.5 * dt * src_q(i,j,k-1,n);
+            }
+
+            qright(i,j,k,n) += 0.5 * dt * src_q(i,j,k,n);
+
+        }
+
+    });
+
+}
+
+void
 Castro::src_to_prim(const Box& bx,
                     Array4<Real const> const& q_arr,
                     Array4<Real const> const& src,

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -493,6 +493,16 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 #endif
 
 #if AMREX_SPACEDIM == 1
+
+#ifdef PRIM_SPECIES_HAVE_SOURCES
+      // if we are doing species sources, add them here
+
+      add_species_source_to_states(xbx, 0, dt,
+                                   qxm_arr, qxp_arr, src_q_arr);
+#endif
+
+      // compute the fluxes through the x-interface
+
       cmpflx_plus_godunov(xbx,
                           qxm_arr, qxp_arr,
                           flux0_arr,
@@ -619,6 +629,12 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
       // solve the final Riemann problem axross the x-interfaces
 
+#ifdef PRIM_SPECIES_HAVE_SOURCES
+      add_species_source_to_states(xbx, 0, dt,
+                                   ql_arr, qr_arr, src_q_arr);
+
+#endif
+
       cmpflx_plus_godunov(xbx,
                           ql_arr, qr_arr,
                           flux0_arr,
@@ -655,6 +671,12 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
 
       // solve the final Riemann problem axross the y-interfaces
+
+#ifdef PRIM_SPECIES_HAVE_SOURCES
+      add_species_source_to_states(ybx, 1, dt,
+                                   ql_arr, qr_arr, src_q_arr);
+
+#endif
 
       cmpflx_plus_godunov(ybx,
                           ql_arr, qr_arr,
@@ -979,6 +1001,13 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
       reset_edge_state_thermo(xbx, qr.array());
 
+#ifdef PRIM_SPECIES_HAVE_SOURCES
+      add_species_source_to_states(xbx, 0, dt,
+                                   ql_arr, qr_arr, src_q_arr);
+
+#endif
+
+
       cmpflx_plus_godunov(xbx,
                           ql_arr, qr_arr,
                           flux0_arr,
@@ -1049,6 +1078,13 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
       reset_edge_state_thermo(ybx, ql.array());
 
       reset_edge_state_thermo(ybx, qr.array());
+
+#ifdef PRIM_SPECIES_HAVE_SOURCES
+      add_species_source_to_states(ybx, 1, dt,
+                                   ql_arr, qr_arr, src_q_arr);
+
+#endif
+
 
       // Compute the final F^y
       // [lo(1), lo(2), lo(3)], [hi(1), hi(2)+1, hi(3)]
@@ -1122,6 +1158,12 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
       reset_edge_state_thermo(zbx, ql.array());
 
       reset_edge_state_thermo(zbx, qr.array());
+
+#ifdef PRIM_SPECIES_HAVE_SOURCES
+      add_species_source_to_states(zbx, 2, dt,
+                                   ql_arr, qr_arr, src_q_arr);
+
+#endif
 
       // compute the final z fluxes F^z
       // [lo(1), lo(2), lo(3)], [hi(1), hi(2), hi(3)+1]

--- a/Source/hydro/Castro_hydro.H
+++ b/Source/hydro/Castro_hydro.H
@@ -54,6 +54,23 @@
 ///
     void construct_mol_hydro_source(amrex::Real time, amrex::Real dt, amrex::MultiFab& A_update);
 
+
+///
+/// when using simplified-SDC, add the species source term predictor to
+/// the interface states
+///
+/// @param bx      the box to operate over
+/// @param idir    coordinate direction
+/// @param dt      timestep
+/// @param qleft   left state at the interface
+/// @param qright  right state at the interface
+/// @param src_q   primitive variable source array
+///
+    void add_species_source_to_states(const Box& bx, const int idir, const Real dt,
+                                      Array4<Real> const& qleft,
+                                      Array4<Real> const& qright,
+                                      Array4<Real const> const& src_q);
+
 ///
 /// convert the conserved form of the source terms, S(U), into source terms
 /// for the primitive variable equations, S(q).

--- a/Source/hydro/trace_plm.cpp
+++ b/Source/hydro/trace_plm.cpp
@@ -317,9 +317,6 @@ Castro::trace_plm(const Box& bx, const int idir,
 
         Real spzero = un >= 0.0_rt ? -1.0_rt : un*dtdx;
         qp(i,j,k,n) = q_arr(i,j,k,n) + 0.5_rt*(-1.0_rt - spzero)*dX;
-#if  PRIM_SPECIES_HAVE_SOURCES
-        qp(i,j,k,n) += 0.5_rt*dt*srcQ(i,j,k,n);
-#endif
       }
 
       // Left state
@@ -328,21 +325,12 @@ Castro::trace_plm(const Box& bx, const int idir,
 
       if (idir == 0 && i <= vhi[0]) {
         qm(i+1,j,k,n) = q_arr(i,j,k,n) + acmpleft;
-#if  PRIM_SPECIES_HAVE_SOURCES
-        qm(i+1,j,k,n) += 0.5_rt*dt*srcQ(i,j,k,n);
-#endif
 
       } else if (idir == 1 && j <= vhi[1]) {
         qm(i,j+1,k,n) = q_arr(i,j,k,n) + acmpleft;
-#if  PRIM_SPECIES_HAVE_SOURCES
-        qm(i,j+1,k,n) += 0.5_rt*dt*srcQ(i,j,k,n);
-#endif
 
       } else if (idir == 2 && k <= vhi[2]) {
         qm(i,j,k+1,n) = q_arr(i,j,k,n) + acmpleft;
-#if  PRIM_SPECIES_HAVE_SOURCES
-        qm(i,j,k+1,n) += 0.5_rt*dt*srcQ(i,j,k,n);
-#endif
       }
 
     }

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -336,10 +336,6 @@ Castro::trace_ppm(const Box& bx,
 
     Real Ip_passive;
     Real Im_passive;
-#ifdef PRIM_SPECIES_HAVE_SOURCES
-    Real Ip_src_passive;
-    Real Im_src_passive;
-#endif
 
     for (int ipassive = 0; ipassive < npassive; ipassive++) {
 
@@ -349,13 +345,6 @@ Castro::trace_ppm(const Box& bx,
         load_stencil(q_arr, idir, i, j, k, n, s);
         ppm_reconstruct(s, flat, sm, sp);
         ppm_int_profile_single(sm, sp, s[i0], un, dtdx, Ip_passive, Im_passive);
-
-#ifdef PRIM_SPECIES_HAVE_SOURCES
-        // if we turned this on, don't bother to check if it source is non-zero -- just trace
-        load_stencil(srcQ, idir, i, j, k, n, s);
-        ppm_reconstruct(s, flat, sm, sp);
-        ppm_int_profile_single(sm, sp, s[i0], un, dtdx, Ip_src_passive, Im_src_passive);
-#endif
 
         // Plus state on face i
 
@@ -373,29 +362,17 @@ Castro::trace_ppm(const Box& bx,
             // projecting, the reference state doesn't matter
 
             qp(i,j,k,n) = Im_passive;
-#ifdef PRIM_SPECIES_HAVE_SOURCES
-            qp(i,j,k,n) += 0.5_rt * dt * Im_src_passive;
-#endif
         }
 
         // Minus state on face i+1
         if (idir == 0 && i <= vhi[0]) {
             qm(i+1,j,k,n) = Ip_passive;
-#ifdef PRIM_SPECIES_HAVE_SOURCES
-            qm(i+1,j,k,n) += 0.5_rt * dt * Ip_src_passive;
-#endif
 
         } else if (idir == 1 && j <= vhi[1]) {
             qm(i,j+1,k,n) = Ip_passive;
-#ifdef PRIM_SPECIES_HAVE_SOURCES
-            qm(i,j+1,k,n) += 0.5_rt * dt * Ip_src_passive;
-#endif
 
         } else if (idir == 2 && k <= vhi[2]) {
             qm(i,j,k+1,n) = Ip_passive;
-#ifdef PRIM_SPECIES_HAVE_SOURCES
-            qm(i,j,k+1,n) += 0.5_rt * dt * Ip_src_passive;
-#endif
         }
     }
 


### PR DESCRIPTION
instead of adding the Iq source to the normal interface state before the
transverse corrections, we now wait until the end.  This is still 2nd order
accurate, but because we don't trace the state or put it through the
different transverse operations, there is no danger of it violating
sum{Iq} = 0

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
