### PR TITLE
Fix tiling bug in radiation estimate_gamrPr

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1626,13 +1626,12 @@ Castro::estTimeStep ()
 
                 for (MFIter mfi(stateMF, TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
-                    const Box& tbox = mfi.tilebox();
-                    const Box& vbox = mfi.validbox();
+                    const Box& box = mfi.tilebox();
 
-                    gPr.resize(tbox);
-                    radiation->estimate_gamrPr(stateMF[mfi], radMF[mfi], gPr, dx, vbox);
+                    gPr.resize(box);
+                    radiation->estimate_gamrPr(stateMF[mfi], radMF[mfi], gPr, dx, box);
 
-                    ca_estdt_rad(tbox.loVect(),tbox.hiVect(),
+                    ca_estdt_rad(box.loVect(), box.hiVect(),
                                  BL_TO_FORTRAN(stateMF[mfi]),
                                  BL_TO_FORTRAN(gPr),
                                  dx,&dt);


### PR DESCRIPTION

## PR summary

The `gPr` fab that is filled in `estimate_gamrPr` is [sized to a tilebox] in the radiation dt estimator in Castro.cpp but the box we pass to the function to operate over is the validbox. So the loop is trying to fill in zones in `gPr` that don't exist, leading to illegal memory accesses.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
