### PR TITLE
Fix loop bounds in estimate_gamrPr

### DIFF
--- a/Source/radiation/MGFLD.cpp
+++ b/Source/radiation/MGFLD.cpp
@@ -1069,7 +1069,7 @@ void Radiation::estimate_gamrPr(const FArrayBox& state, const FArrayBox& Er,
         }
 #endif
 
-        amrex::ParallelFor(box,
+        amrex::ParallelFor(gPr.box(),
         [=, limiter = limiter, comoving = Radiation::comoving, closure = Radiation::closure]
         AMREX_GPU_DEVICE (int i, int j, int k)
         {


### PR DESCRIPTION

## PR summary

PR #1554 introduced a bug for CPU builds (with tiling) by making the bounds of the loop based on the valid box, while the extent of the `gPr` array that is being filled is only the tile box.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
