### PR TITLE
Avoid accesses to static radiation data in device code

### DIFF
--- a/Source/hydro/riemann.cpp
+++ b/Source/hydro/riemann.cpp
@@ -66,6 +66,13 @@ Castro::cmpflx_plus_godunov(const Box& bx,
     const auto domlo = geom.Domain().loVect3d();
     const auto domhi = geom.Domain().hiVect3d();
 
+#ifdef RADIATION
+    int fspace_t = Radiation::fspace_advection_type;
+    int comov = Radiation::comoving;
+    int limiter = Radiation::limiter;
+    int closure = Radiation::closure;
+#endif
+
     amrex::ParallelFor(bx,
     [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
@@ -92,6 +99,8 @@ Castro::cmpflx_plus_godunov(const Box& bx,
                            qint, flx,
 #ifdef RADIATION
                            rflx,
+                           fspace_t, comov,
+                           limiter, closure,
 #endif
                            qgdnv, store_full_state);
 

--- a/Source/hydro/riemann_solvers.H
+++ b/Source/hydro/riemann_solvers.H
@@ -19,6 +19,8 @@ compute_flux_q(const int i, const int j, const int k, const int idir,
                Array4<Real> const& F,
 #ifdef RADIATION
                Array4<Real> const& rF,
+               int fspace_t, int comov,
+               int limiter, int closure,
 #endif
                Array4<Real> const& qgdnv, const bool store_full_state) {
 
@@ -45,13 +47,6 @@ compute_flux_q(const int i, const int j, const int k, const int idir,
         im2 = UMX;
         im3 = UMY;
     }
-
-#ifdef RADIATION
-    int fspace_t = Radiation::fspace_advection_type;
-    int comov = Radiation::comoving;
-    int limiter = Radiation::limiter;
-    int closure = Radiation::closure;
-#endif
 
     // Compute fluxes, order as conserved state (not q)
     F(i,j,k,URHO) = qint.rho * qint.un;

--- a/Source/radiation/RadDerive.cpp
+++ b/Source/radiation/RadDerive.cpp
@@ -6,9 +6,7 @@
 
 #include <Radiation.H>
 
-
 using namespace amrex;
-
 
 void ca_derertot(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
                  const FArrayBox& datfab, const Geometry& /*geomdata*/,
@@ -18,6 +16,8 @@ void ca_derertot(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
     auto const dat = datfab.array();
     auto const der = derfab.array();
 
+    Real radtoE = Radiation::radtoE;
+
     amrex::ParallelFor(bx,
     [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
@@ -25,7 +25,7 @@ void ca_derertot(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
         der(i,j,k,0) = 0.0_rt;
 
         for (int g = 0; g < NGROUPS; g++) {
-            der(i,j,k,0) += dat(i,j,k,g) * Radiation::radtoE;
+            der(i,j,k,0) += dat(i,j,k,g) * radtoE;
         }
     });
 }

--- a/Source/radiation/RadPlotvar.cpp
+++ b/Source/radiation/RadPlotvar.cpp
@@ -42,6 +42,8 @@ void Radiation::save_lab_Er_in_plotvar(int level, const MultiFab& Snew,
     int ifz = 0;
 #endif
 
+    int ier = icomp_lab_Er;
+
     Real c2 = 1.e0_rt / (Radiation::clight * Radiation::clight);
 
     GpuArray<Real, NGROUPS> dlognu = {0.0};
@@ -81,9 +83,9 @@ void Radiation::save_lab_Er_in_plotvar(int level, const MultiFab& Snew,
 #endif
 
             for (int g = 0; g < NGROUPS; ++g) {
-                Elab_arr(i,j,k,g+icomp_lab_Er) = Ecom_arr(i,j,k,g) + 2.0_rt * (vxc2 * F_arr(i,j,k,ifx+g) +
-                                                                               vyc2 * F_arr(i,j,k,ify+g) +
-                                                                               vzc2 * F_arr(i,j,k,ifz+g));
+                Elab_arr(i,j,k,g+ier) = Ecom_arr(i,j,k,g) + 2.0_rt * (vxc2 * F_arr(i,j,k,ifx+g) +
+                                                                      vyc2 * F_arr(i,j,k,ify+g) +
+                                                                      vzc2 * F_arr(i,j,k,ifz+g));
             }
 
             if (NGROUPS > 1) {
@@ -103,9 +105,9 @@ void Radiation::save_lab_Er_in_plotvar(int level, const MultiFab& Snew,
                 nufnuz(NGROUPS) = -nufnuz(NGROUPS-1);
 
                 for (int g = 0; g < NGROUPS; ++g) {
-                    Elab_arr(i,j,k,g+icomp_lab_Er) -= vxc2 * 0.5_rt * (nufnux(g+1) - nufnux(g-1)) +
-                                                      vyc2 * 0.5_rt * (nufnuy(g+1) - nufnuy(g-1)) +
-                                                      vzc2 * 0.5_rt * (nufnuz(g+1) - nufnuz(g-1));
+                    Elab_arr(i,j,k,g+ier) -= vxc2 * 0.5_rt * (nufnux(g+1) - nufnux(g-1)) +
+                                             vyc2 * 0.5_rt * (nufnuy(g+1) - nufnuy(g-1)) +
+                                             vzc2 * 0.5_rt * (nufnuz(g+1) - nufnuz(g-1));
                 }
             }
         });


### PR DESCRIPTION

## PR summary

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
