### PR TITLE
Add inline functions for computing geometry factors

### DIFF
--- a/Source/driver/Castro_util.H
+++ b/Source/driver/Castro_util.H
@@ -248,12 +248,12 @@ Real area(const int& i, const int& j, const int& k,
 
         // Cylindrical
 
-        Real r = geomdata.ProbLo()[0] + static_cast<Real>(i) * dx[0];
-
         if (idir == 0) {
+            Real r = geomdata.ProbLo()[0] + static_cast<Real>(i) * dx[0];
             a = 2.0_rt * M_PI * r * dx[1];
         }
         else {
+            Real r = geomdata.ProbLo()[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0];
             a = 2.0_rt * M_PI * r * dx[0];
         }
 

--- a/Source/driver/Castro_util.H
+++ b/Source/driver/Castro_util.H
@@ -162,10 +162,7 @@ Real volume(const int& i, const int& j, const int& k,
 
         // Spherical
 
-        Real r_l = static_cast<Real>(i) * dx[0];
-        Real r_r = static_cast<Real>(i + 1) * dx[0];
-
-        Real vol = (4.0_rt / 3.0_rt) * M_PI * dx[0] * dx[0] * dx[0];
+        vol = (4.0_rt / 3.0_rt) * M_PI * dx[0] * dx[0] * dx[0];
 
     }
 

--- a/Source/driver/Castro_util.H
+++ b/Source/driver/Castro_util.H
@@ -162,7 +162,10 @@ Real volume(const int& i, const int& j, const int& k,
 
         // Spherical
 
-        vol = (4.0_rt / 3.0_rt) * M_PI * dx[0] * dx[0] * dx[0];
+        Real rl = geomdata.ProbLo()[0] + static_cast<Real>(i) * dx[0];
+        Real rr = rl + dx[0];
+
+        vol = (4.0_rt / 3.0_rt) * M_PI * dx[0] * (rl * rl + rl * rr + rr * rr);
 
     }
 

--- a/Source/driver/Castro_util.H
+++ b/Source/driver/Castro_util.H
@@ -181,8 +181,8 @@ Real volume(const int& i, const int& j, const int& k,
 
         // Cylindrical
 
-        Real r_l = geomdata.ProbLo() + static_cast<Real>(i) * dx[0];
-        Real r_r = geomdata.ProbLo() + static_cast<Real>(i+1) * dx[0];
+        Real r_l = geomdata.ProbLo()[0] + static_cast<Real>(i) * dx[0];
+        Real r_r = geomdata.ProbLo()[0] + static_cast<Real>(i+1) * dx[0];
 
         vol = M_PI * (r_l + r_r) * dx[0] * dx[1];
 

--- a/Source/driver/Castro_util.H
+++ b/Source/driver/Castro_util.H
@@ -131,4 +131,156 @@ void position(int i, int j, int k,
 
 }
 
+namespace geometry_util
+{
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+Real volume(const int& i, const int& j, const int& k,
+            const GeometryData& geomdata)
+{
+    // Given 3D cell-centered indices (i,j,k), return the volume of the zone.
+    // Note that Castro has no support for angular coordinates, so
+    // this function only provides Cartesian in 1D/2D/3D, Cylindrical (R-Z)
+    // in 2D, and Spherical in 1D.
+
+    auto dx = geomdata.CellSize();
+
+    Real vol;
+
+#if AMREX_SPACEDIM == 1
+
+    auto coord = geomdata.Coord();
+
+    if (coord == 0) {
+
+        // Cartesian
+
+        vol = dx[0];
+
+    }
+    else {
+
+        // Spherical
+
+        Real r_l = static_cast<Real>(i) * dx[0];
+        Real r_r = static_cast<Real>(i + 1) * dx[0];
+
+        Real vol = (4.0_rt / 3.0_rt) * M_PI * dx[0] * dx[0] * dx[0];
+
+    }
+
+#elif AMREX_SPACEDIM == 2
+
+    auto coord = geomdata.Coord();
+
+    if (coord == 0) {
+
+        // Cartesian
+
+        vol = dx[0] * dx[1];
+
+    }
+    else {
+
+        // Cylindrical
+
+        Real r_l = geomdata.ProbLo() + static_cast<Real>(i) * dx[0];
+        Real r_r = geomdata.ProbLo() + static_cast<Real>(i+1) * dx[0];
+
+        vol = M_PI * (r_l + r_r) * dx[0] * dx[1];
+
+    }
+
+#else
+
+    // Cartesian
+
+    vol = dx[0] * dx[1] * dx[2];
+
+#endif
+
+    return vol;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+Real area(const int& i, const int& j, const int& k,
+          const int& idir, const GeometryData& geomdata)
+{
+    auto dx = geomdata.CellSize();
+
+    Real a;
+
+#if AMREX_SPACEDIM == 1
+
+    auto coord = geomdata.Coord();
+
+    if (coord == 0) {
+
+        // Cartesian
+
+        a = 1.0_rt;
+
+    }
+    else {
+
+        // Spherical
+
+        Real r = geomdata.ProbLo()[0] + static_cast<Real>(i) * dx[0];
+
+        a = 4.0_rt * M_PI * r * r;
+
+    }
+
+#elif AMREX_SPACEDIM == 2
+
+    auto coord = geomdata.Coord();
+
+    if (coord == 0) {
+
+        // Cartesian
+
+        if (idir == 0) {
+            a = dx[1];
+        }
+        else {
+            a = dx[0];
+        }
+
+    }
+    else  {
+
+        // Cylindrical
+
+        Real r = geomdata.ProbLo()[0] + static_cast<Real>(i) * dx[0];
+
+        if (idir == 0) {
+            a = 2.0_rt * M_PI * r * dx[1];
+        }
+        else {
+            a = 2.0_rt * M_PI * r * dx[0];
+        }
+
+    }
+
+#else
+
+    // Cartesian
+
+    if (idir == 0) {
+        a = dx[1] * dx[2];
+    }
+    else if (idir == 1) {
+        a = dx[0] * dx[2];
+    }
+    else {
+        a = dx[0] * dx[1];
+    }
+
+#endif
+
+    return a;
+}
+
+}
+
 #endif

--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -16,39 +16,33 @@ Castro::consup_hydro(const Box& bx,
                      Array4<Real> const& U_new,
                      Array4<Real> const& flux0,
                      Array4<Real const> const& qx,
-                     Array4<Real const> const& area0,
 #if AMREX_SPACEDIM >= 2
                      Array4<Real> const& flux1,
                      Array4<Real const> const& qy,
-                     Array4<Real const> const& area1,
 #endif
 #if AMREX_SPACEDIM == 3
                      Array4<Real> const& flux2,
                      Array4<Real const> const& qz,
-                     Array4<Real const> const& area2,
 #endif
-                     Array4<Real const> const& vol,
                      const Real dt)
 {
-
-
-  const auto dx = geom.CellSizeArray();
-
-  int coord = geom.Coord();
+  auto geomdata = geom.data();
 
   amrex::ParallelFor(bx, NUM_STATE,
   [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k, int n)
   {
-
-    Real volinv = 1.0 / vol(i,j,k);
+    Real volinv = 1.0 / geometry_util::volume(i, j, k, geomdata);
 
     U_new(i,j,k,n) = U_new(i,j,k,n) + dt *
-      ( flux0(i,j,k,n) * area0(i,j,k) - flux0(i+1,j,k,n) * area0(i+1,j,k)
+        ( flux0(i,  j,k,n) * geometry_util::area(i,   j, k, 0, geomdata)
+        - flux0(i+1,j,k,n) * geometry_util::area(i+1, j, k, 0, geomdata)
 #if AMREX_SPACEDIM >= 2
-      + flux1(i,j,k,n) * area1(i,j,k) - flux1(i,j+1,k,n) * area1(i,j+1,k)
+        + flux1(i,j,  k,n) * geometry_util::area(i, j,   k, 1, geomdata)
+        - flux1(i,j+1,k,n) * geometry_util::area(i, j+1, k, 1, geomdata)
 #endif
 #if AMREX_SPACEDIM == 3
-      + flux2(i,j,k,n) * area2(i,j,k) - flux2(i,j,k+1,n) * area2(i,j,k+1)
+        + flux2(i,j,k,  n) * geometry_util::area(i, j, k,   2, geomdata)
+        - flux2(i,j,k+1,n) * geometry_util::area(i, j, k+1, 2, geomdata)
 #endif
         ) * volinv;
 
@@ -56,16 +50,19 @@ Castro::consup_hydro(const Box& bx,
     if (n == UEINT) {
 
       Real pdu = (qx(i+1,j,k,GDPRES) + qx(i,j,k,GDPRES)) *
-                 (qx(i+1,j,k,GDU) * area0(i+1,j,k) - qx(i,j,k,GDU) * area0(i,j,k));
+          (qx(i+1,j,k,GDU) * geometry_util::area(i+1, j, k, 0, geomdata) -
+           qx(i,  j,k,GDU) * geometry_util::area(i,   j, k, 0, geomdata));
 
 #if AMREX_SPACEDIM >= 2
       pdu += (qy(i,j+1,k,GDPRES) + qy(i,j,k,GDPRES)) *
-             (qy(i,j+1,k,GDV) * area1(i,j+1,k) - qy(i,j,k,GDV) * area1(i,j,k));
+          (qy(i,j+1,k,GDV) * geometry_util::area(i, j+1, k, 1, geomdata) -
+           qy(i,j,  k,GDV) * geometry_util::area(i, j,   k, 1, geomdata));
 #endif
 
 #if AMREX_SPACEDIM == 3
       pdu += (qz(i,j,k+1,GDPRES) + qz(i,j,k,GDPRES)) *
-             (qz(i,j,k+1,GDW) * area2(i,j,k+1) - qz(i,j,k,GDW) * area2(i,j,k));
+          (qz(i,j,k+1,GDW) * geometry_util::area(i, j, k+1, 2, geomdata) -
+           qz(i,j,k  ,GDW) * geometry_util::area(i, j, k,   2, geomdata));
 #endif
 
       pdu = 0.5 * pdu * volinv;
@@ -81,8 +78,8 @@ Castro::consup_hydro(const Box& bx,
       // Add gradp term to momentum equation -- only for axisymmetric
       // coords (and only for the radial flux).
 
-      if (!mom_flux_has_p(0, 0, coord)) {
-        U_new(i,j,k,UMX) += - dt * (qx(i+1,j,k,GDPRES) - qx(i,j,k,GDPRES)) / dx[0];
+      if (!mom_flux_has_p(0, 0, geomdata.Coord())) {
+        U_new(i,j,k,UMX) += - dt * (qx(i+1,j,k,GDPRES) - qx(i,j,k,GDPRES)) / geomdata.CellSize()[0];
       }
     }
   });

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1259,14 +1259,13 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
                    shk_arr,
 #endif
                    update_arr,
-                   flx_arr, qx_arr, areax_arr,
+                   flx_arr, qx_arr,
 #if AMREX_SPACEDIM >= 2
-                   fly_arr, qy_arr, areay_arr,
+                   fly_arr, qy_arr,
 #endif
 #if AMREX_SPACEDIM == 3
-                   flz_arr, qz_arr, areaz_arr,
+                   flz_arr, qz_arr,
 #endif
-                   vol_arr,
                    dt);
 
 

--- a/Source/hydro/Castro_hydro.H
+++ b/Source/hydro/Castro_hydro.H
@@ -699,14 +699,10 @@
 /// @param update  the hydrodynamics update term, -div{F} + S(U)
 /// @param flux0   flux in the x direction
 /// @param qx      Godunov state in the x direction
-/// @param area0   area of x faces
 /// @param flux1   flux in the y direction
 /// @param qy      Godunov state in the y direction
-/// @param area1   area of y faces
 /// @param flux2   flux in the z direction
 /// @param qz      Godunov state in the z direction
-/// @param area2   area of z faces
-/// @param vol     volume of the cell
 /// @param dt      timestep
 ///
     void consup_hydro(const amrex::Box& bx,
@@ -716,18 +712,14 @@
                       amrex::Array4<amrex::Real> const& update,
                       amrex::Array4<amrex::Real> const& flux0,
                       amrex::Array4<amrex::Real const> const& qx,
-                      amrex::Array4<amrex::Real const> const& area0,
 #if AMREX_SPACEDIM >= 2
                       amrex::Array4<amrex::Real> const& flux1,
                       amrex::Array4<amrex::Real const> const& qy,
-                      amrex::Array4<amrex::Real const> const& area1,
 #endif
 #if AMREX_SPACEDIM == 3
                       amrex::Array4<amrex::Real> const& flux2,
                       amrex::Array4<amrex::Real const> const& qz,
-                      amrex::Array4<amrex::Real const> const& area2,
 #endif
-                      amrex::Array4<amrex::Real const> const& vol,
                       const amrex::Real dt);
 
 


### PR DESCRIPTION

## PR summary

Begins to address #1688. The new functions are used in consup as a demonstration.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
