### PR TITLE
adjust the number of ghost cells for source terms

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -791,8 +791,6 @@ public:
                  amrex::MultiFab&          mf,
                  int                dcomp) override;
 
-    static int numGrow();
-
 
 #ifdef REACTIONS
 #include <Castro_react.H>
@@ -1449,6 +1447,7 @@ protected:
     static int              num_err_list_default;
     static amrex::BCRec     phys_bc;
     static int       NUM_GROW;
+    static int       NUM_GROW_SRC;
 
     static int         lastDtPlotLimited;
     static amrex::Real lastDtBeforePlotLimiting;
@@ -1546,13 +1545,6 @@ public:
 //
 // Inlines.
 //
-
-inline
-int
-Castro::numGrow()
-{
-    return NUM_GROW;
-}
 
 inline
 amrex::MultiFab*

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -75,6 +75,7 @@ int          Castro::num_err_list_default = 0;
 int          Castro::radius_grow   = 1;
 BCRec        Castro::phys_bc;
 int          Castro::NUM_GROW      = -1;
+int          Castro::NUM_GROW_SRC  = -1;
 
 int          Castro::lastDtPlotLimited = 0;
 Real         Castro::lastDtBeforePlotLimiting = 0.0;
@@ -1000,7 +1001,7 @@ Castro::initData ()
 #ifdef REACTIONS
    if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
        MultiFab& react_src_new = get_new_data(Simplified_SDC_React_Type);
-       react_src_new.setVal(0.0, NUM_GROW);
+       react_src_new.setVal(0.0, NUM_GROW_SRC);
    }
 #endif
 #endif
@@ -4196,9 +4197,9 @@ Castro::create_source_corrector()
 
         const Real time = get_state_data(Source_Type).prevTime();
 
-        AmrLevel::FillPatch(*this, source_corrector, NUM_GROW, time, Source_Type, UMX, 3, UMX);
+        AmrLevel::FillPatch(*this, source_corrector, NUM_GROW_SRC, time, Source_Type, UMX, 3, UMX);
 
-        source_corrector.mult(2.0 / lastDt, NUM_GROW);
+        source_corrector.mult(2.0 / lastDt, NUM_GROW_SRC);
 
     }
     else if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
@@ -4214,7 +4215,7 @@ Castro::create_source_corrector()
 
         const Real time = get_state_data(Source_Type).prevTime();
 
-        AmrLevel::FillPatch(*this, source_corrector, NUM_GROW, time, Source_Type, 0, NSRC);
+        AmrLevel::FillPatch(*this, source_corrector, NUM_GROW_SRC, time, Source_Type, 0, NSRC);
 
     }
 

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -286,13 +286,13 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration, int amr_ncycle
     // This array holds the sum of all source terms that affect the
     // hydrodynamics.
 
-    sources_for_hydro.define(grids, dmap, NSRC, NUM_GROW);
-    sources_for_hydro.setVal(0.0, NUM_GROW);
+    sources_for_hydro.define(grids, dmap, NSRC, NUM_GROW_SRC);
+    sources_for_hydro.setVal(0.0, NUM_GROW_SRC);
 
     // This array holds the source term corrector.
 
-    source_corrector.define(grids, dmap, NSRC, NUM_GROW);
-    source_corrector.setVal(0.0, NUM_GROW);
+    source_corrector.define(grids, dmap, NSRC, NUM_GROW_SRC);
+    source_corrector.setVal(0.0, NUM_GROW_SRC);
 
     // Swap the new data from the last timestep into the old state data.
 

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -52,7 +52,7 @@ Castro::do_advance_ctu(Real time,
 
     // Zero out the source term data.
 
-    sources_for_hydro.setVal(0.0, NUM_GROW);
+    sources_for_hydro.setVal(0.0, NUM_GROW_SRC);
 
     // Add any correctors to the source term data. This must be done
     // before the source term data is overwritten below. Note: we do
@@ -67,11 +67,11 @@ Castro::do_advance_ctu(Real time,
 
     if (time_integration_method == CornerTransportUpwind && source_term_predictor == 1) {
         // Add the source term predictor (scaled by dt/2).
-        MultiFab::Saxpy(sources_for_hydro, 0.5 * dt, source_corrector, UMX, UMX, 3, NUM_GROW);
+        MultiFab::Saxpy(sources_for_hydro, 0.5 * dt, source_corrector, UMX, UMX, 3, NUM_GROW_SRC);
     }
     else if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
         // Time center the sources.
-        MultiFab::Add(sources_for_hydro, source_corrector, 0, 0, NSRC, NUM_GROW);
+        MultiFab::Add(sources_for_hydro, source_corrector, 0, 0, NSRC, NUM_GROW_SRC);
     }
 
 #ifndef AMREX_USE_GPU
@@ -153,11 +153,11 @@ Castro::do_advance_ctu(Real time,
       // terms (e.g. the source term predictor, or the SDC source).
 
      if (do_hydro) {
-         AmrLevel::FillPatchAdd(*this, sources_for_hydro, NUM_GROW, time, Source_Type, 0, NSRC);
+         AmrLevel::FillPatchAdd(*this, sources_for_hydro, NUM_GROW_SRC, time, Source_Type, 0, NSRC);
      }
 
     } else {
-      old_source.setVal(0.0, NUM_GROW);
+      old_source.setVal(0.0, NUM_GROW_SRC);
 
     }
 
@@ -295,7 +295,7 @@ Castro::do_advance_ctu(Real time,
 
     } else {
 
-      new_source.setVal(0.0, NUM_GROW);
+      new_source.setVal(0.0, NUM_GROW_SRC);
 
     }
 

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -301,7 +301,11 @@ Castro::variableSetUp ()
 #ifdef MHD
   NUM_GROW_SRC = 6;
 #else
-  NUM_GROW_SRC = 3;
+  if (time_integration_method == SpectralDeferredCorrections) {
+      NUM_GROW_SRC = NUM_GROW;
+  } else {
+      NUM_GROW_SRC = 3;
+  }
 #endif
 
   const Real run_strt = ParallelDescriptor::second() ;
@@ -433,7 +437,7 @@ Castro::variableSetUp ()
   }
   else if (time_integration_method == SpectralDeferredCorrections) {
     if (sdc_order == 2 && use_pslope) {
-      source_ng = NUM_GROW;
+      source_ng = NUM_GROW_SRC;
     } else {
       source_ng = 1;
     }

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -287,11 +287,21 @@ Castro::variableSetUp ()
 
   const int dm = BL_SPACEDIM;
 
-  // NUM_GROW is the number of ghost cells needed for the hyperbolic portions
+  // NUM_GROW is the number of ghost cells needed for the hyperbolic
+  // portions -- note that this includes the flattening, which
+  // generally requires 4 ghost cells
 #ifdef MHD
   NUM_GROW = 6;
 #else
   NUM_GROW = 4;
+#endif
+
+  // NUM_GROW_SRC is for quantities that will be reconstructed, but
+  // don't need the full stencil required for flattening
+#ifdef MHD
+  NUM_GROW_SRC = 6;
+#else
+  NUM_GROW_SRC = 3;
 #endif
 
   const Real run_strt = ParallelDescriptor::second() ;
@@ -406,12 +416,12 @@ Castro::variableSetUp ()
 
   store_in_checkpoint = false;
   desc_lst.addDescriptor(Gravity_Type,IndexType::TheCellType(),
-                         StateDescriptor::Point,NUM_GROW,3,
+                         StateDescriptor::Point,NUM_GROW_SRC,3,
                          interp,state_data_extrap,store_in_checkpoint);
 #endif
 
   // Source terms -- for the CTU method, because we do characteristic
-  // tracing on the source terms, we need NUM_GROW ghost cells to do
+  // tracing on the source terms, we need NUM_GROW_SRC ghost cells to do
   // the reconstruction.  For SDC, on the other hand, we only
   // need 1 (for the fourth-order stuff). Simplified SDC uses the CTU
   // advance, so it behaves the same way as CTU here.
@@ -419,7 +429,7 @@ Castro::variableSetUp ()
   store_in_checkpoint = true;
   int source_ng = 0;
   if (time_integration_method == CornerTransportUpwind || time_integration_method == SimplifiedSpectralDeferredCorrections) {
-      source_ng = NUM_GROW;
+      source_ng = NUM_GROW_SRC;
   }
   else if (time_integration_method == SpectralDeferredCorrections) {
     if (sdc_order == 2 && use_pslope) {
@@ -463,7 +473,7 @@ Castro::variableSetUp ()
 
       store_in_checkpoint = true;
       desc_lst.addDescriptor(Simplified_SDC_React_Type, IndexType::TheCellType(),
-                             StateDescriptor::Point, NUM_GROW, NQSRC,
+                             StateDescriptor::Point, NUM_GROW_SRC, NQSRC,
                              interp, state_data_extrap, store_in_checkpoint);
 
   }

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -180,6 +180,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
       // the conserved variables.
 
       const Box& qbx = amrex::grow(bx, NUM_GROW);
+      const Box& qbx3 = amrex::grow(bx, 3);
 
       q.resize(qbx, NQ);
       Elixir elix_q = q.elixir();
@@ -299,14 +300,14 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
       // get the primitive variable hydro sources
 
-      src_q.resize(qbx, NQSRC);
+      src_q.resize(qbx3, NQSRC);
       Elixir elix_src_q = src_q.elixir();
       fab_size += src_q.nBytes();
       Array4<Real> const src_q_arr = src_q.array();
 
       Array4<Real> const src_arr = sources_for_hydro.array(mfi);
 
-      src_to_prim(qbx, q_arr, src_arr, src_q_arr);
+      src_to_prim(qbx3, q_arr, src_arr, src_q_arr);
 
 #ifndef RADIATION
 #ifdef SIMPLIFIED_SDC
@@ -318,7 +319,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
             MultiFab& SDC_react_source = get_new_data(Simplified_SDC_React_Type);
 
             if (do_react)
-              src_q.plus<RunOn::Device>(SDC_react_source[mfi], qbx, qbx, 0, 0, NQSRC);
+              src_q.plus<RunOn::Device>(SDC_react_source[mfi], qbx3, qbx3, 0, 0, NQSRC);
 
         }
 #endif

--- a/Source/sources/Castro_sources.cpp
+++ b/Source/sources/Castro_sources.cpp
@@ -177,7 +177,7 @@ Castro::do_new_sources(
 
     const Real strt_time = ParallelDescriptor::second();
 
-    source.setVal(0.0, NUM_GROW);
+    source.setVal(0.0, NUM_GROW_SRC);
 
     // Construct the new-time source terms.
 


### PR DESCRIPTION
sources that undergo reconstruction for tracing only need 3, not 4
ghost cells.  PPM requires 4 only for p, in the computation of the
flatting coefficient.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
