### PR TITLE
Remove remaining OpenACC directives

### DIFF
--- a/Source/driver/Castro_nd.F90
+++ b/Source/driver/Castro_nd.F90
@@ -27,8 +27,6 @@ subroutine ca_microphysics_init() bind(C, name="ca_microphysics_init")
 
   call microphysics_init(small_dens=small_dens, small_temp=small_temp)
 
-  !$acc update device(small_dens, small_temp)
-
 end subroutine ca_microphysics_init
 
 
@@ -104,8 +102,6 @@ subroutine ca_set_method_params(dm) &
      small_ener = 1.e-200_rt
   endif
 
-  !$acc update device(small_dens, small_temp, small_pres, small_ener)
-
 end subroutine ca_set_method_params
 
 
@@ -162,11 +158,6 @@ subroutine ca_set_problem_params(dm, &
   if (dim .lt. 3) then
      dg(3) = 0
   endif
-
-  !$acc update device(dim)
-  !$acc update device(dg)
-  !$acc update device(coord_type)
-  !$acc update device(problo, probhi)
 
 end subroutine ca_set_problem_params
 

--- a/Source/driver/prob_params_nd.F90
+++ b/Source/driver/prob_params_nd.F90
@@ -20,10 +20,4 @@ module prob_params_module
   ! the format is dg(1:dim) = 1, dg(dim+1:3) = 0
   integer, save, allocatable :: dg(:)
 
-  !$acc declare create(physbc_lo, physbc_hi)
-  !$acc declare create(dim)
-  !$acc declare create(dg)
-  !$acc declare create(coord_type)
-  !$acc declare create(problo, probhi)
-
 end module prob_params_module


### PR DESCRIPTION
## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
