### PR TITLE
Set up separate probin for 1D dustcollapse

### DIFF
--- a/Exec/gravity_tests/DustCollapse/inputs_1d
+++ b/Exec/gravity_tests/DustCollapse/inputs_1d
@@ -70,4 +70,4 @@ amr.plot_int        = 10000    # number of timesteps between plotfiles
 amr.derive_plot_vars = NONE
 
 #PROBIN FILENAME
-amr.probin_file = probin.fullstar
+amr.probin_file = probin.fullstar.1d

--- a/Exec/gravity_tests/DustCollapse/probin.fullstar.1d
+++ b/Exec/gravity_tests/DustCollapse/probin.fullstar.1d
@@ -1,0 +1,29 @@
+&fortin
+  rho_0 = 1.d9
+  r_0   = 6.5d8
+  p_0   = 1.d15
+  rho_ambient = 1.0d-5
+  smooth_delta = 4.d6
+
+  center_x = 0.0
+  center_y = 0.0
+  center_z = 0.0
+/
+
+&tagging
+  dengrad = 1.d7
+  max_dengrad_lev = 3
+/
+
+&sponge
+  sponge_lower_density = 1.0d-3
+  sponge_upper_density = 1.0d-3
+  sponge_timescale = 1.0d-3
+/
+
+&extern
+
+  eos_gamma = 1.66666
+  eos_assume_neutral = T
+
+/


### PR DESCRIPTION

## PR summary

#1717 converted DustCollapse to C++ but did not do the same thing as the Fortran with respect to enforcing the location of `center`. So this adds a probin that sets the center at zero for the 1D use case.

## PR motivation

I don't like it when problem setups override user inputs, so I would prefer this solution over editing the setup to respect what the Fortran did.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
