### PR TITLE
Set CUDA-specific make option under USE_CUDA

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -106,9 +106,11 @@ ifeq ($(USE_MPI), TRUE)
   MPI_THREAD_MULTIPLE_UPDATE_SUFFIX := FALSE
 endif
 
-ifeq ($(USE_GPU),TRUE)
+ifeq ($(USE_CUDA),TRUE)
   CUDA_VERBOSE = FALSE
+endif
 
+ifeq ($(USE_GPU),TRUE)
   # We don't currently support host-side OpenMP being enabled
   # when using GPUs. Throw an error to prevent this case.
   ifeq ($(USE_OMP),TRUE)


### PR DESCRIPTION

## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
