### PR TITLE
Protect against divide-by-zero in rotation

### DIFF
--- a/Source/rotation/Rotation.cpp
+++ b/Source/rotation/Rotation.cpp
@@ -79,8 +79,12 @@ Castro::fill_rotational_psi(const Box& bx,
     r[2] = 0.0_rt;
 #endif
 
-
-    psi(i,j,k) = rotational_potential(r) / denom;
+    if (denom != 0.0) {
+        psi(i,j,k) = rotational_potential(r) / denom;
+    }
+    else {
+        psi(i,j,k) = 0.0;
+    }
 
   });
 }


### PR DESCRIPTION

## PR summary

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
