### PR TITLE
Set amr.regrid_on_restart = 1 by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,11 @@
 
    * We no longer store Reactions_Type in checkpoint files.  This means
      that newer versions of Castro will not restart from old version.
+
+   * Castro now overrides the parameter amr.regrid_on_restart to default
+     to 1. The user can turn this off if desired with an explicit set of
+     amr.regrid_on_restart = 0 at the command line, however this will be
+     considered unsupported. (#1793)
      
 # 21.05
 

--- a/Docs/source/inputs.rst
+++ b/Docs/source/inputs.rst
@@ -169,7 +169,7 @@ factor of refinement between levels. The relevant parameters are:
     regrid (integer; must be set)
 
   * ``amr.regrid_on_restart``: should we regrid immediately after
-    restarting? (0 or 1; default: 0)
+    restarting? (0 or 1; default: 1)
 
 .. note:: if ``amr.max_level = 0`` then you do not need to set
    ``amr.ref_ratio`` or ``amr.regrid_int``.

--- a/Source/driver/main.cpp
+++ b/Source/driver/main.cpp
@@ -30,6 +30,18 @@ std::string inputs_name = "";
 
 amrex::LevelBld* getLevelBld ();
 
+// Any parameters we want to override the defaults for in AMReX
+
+void override_parameters ()
+{
+    ParmParse pp("amr");
+    if (!pp.contains("regrid_on_restart")) {
+        // Always force a regrid on a restart.
+        pp.add("regrid_on_restart", true);
+    }
+}
+
+
 int
 main (int   argc,
       char* argv[])
@@ -48,7 +60,7 @@ main (int   argc,
     //
     // Make sure to catch new failures.
     //
-    amrex::Initialize(argc,argv);
+    amrex::Initialize(argc, argv, true, MPI_COMM_WORLD, override_parameters);
     {
 
     // Refuse to continue if we did not provide an inputs file.


### PR DESCRIPTION

## PR summary

This helps support the SCF workflow we want of manually triggering regrids during the initialization phase, and there are probably not any workflows where regrid on restart is specifically undesired.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
