### PR TITLE
Remove make flags to use system BLAS

### DIFF
--- a/Docs/source/build_system.rst
+++ b/Docs/source/build_system.rst
@@ -19,7 +19,7 @@ space for variables that are not used.
 General Build Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: USE_ALL_CASTRO, USE_AMR_CORE, USE_SYSTEM_BLAS, USE_HYPRE
+.. index:: USE_ALL_CASTRO, USE_AMR_CORE, USE_HYPRE
 
 These Parameters affect the build (parallelism, performance, etc.)
 Most of these are parameters from AMReX.
@@ -33,12 +33,6 @@ Most of these are parameters from AMReX.
     ``Base/``, ``AmrCore/``, ``Amr/``, and ``Boundary/``.  This defaults
     to ``TRUE`` and should be left set for Castro simulations.  The purpose
     of this flag is for unit tests that don't need all of AMReX.
-
-  * ``USE_SYSTEM_BLAS``: for the linear algebra routines provided by
-    BLAS, should we compile our own versions or should we use a system
-    library that provides the BLAS routines?  If we set
-    ``USE_SYSTEM_BLAS = TRUE``, then we need to provide the name on
-    the library in the ``BLAS_LIBRARY`` build parameter.
 
   * ``USE_MLMG``: use the AMReX multi-level multigrid solver for gravity
     and diffusion.  This should always be set to ``TRUE``.

--- a/Docs/source/faq.rst
+++ b/Docs/source/faq.rst
@@ -45,14 +45,6 @@ Compiling
 
    This will tell you the value of all the compilers and their options.
 
-#. *How do I use a system’s BLAS library instead of compiling and
-   linking the one that comes with the StarKiller microphysics?*
-
-   To use a system’s BLAS library, set the Make variable
-   ``USE_SYSTEM_BLAS`` to ``TRUE``. This will then look at
-   the Make variable ``BLAS_LIBRARY`` for the library to link
-   (defaults to ``-lopenblas``).
-
 #. *How can I check to make sure the function signatures defined
    in C are consistent with their implementations in Fortran?*
 

--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -3,9 +3,6 @@ CASTRO_HOME ?= /path/to/Castro
 # radiation needs hypre
 HYPRE_DIR ?= /path/to/Hypre
 
-# system blas
-BLAS_LIBRARY ?= -lopenblas
-
 TOP := $(CASTRO_HOME)
 
 # Allow a problem setup to define a root location.
@@ -93,10 +90,6 @@ USE_MLMG = FALSE
 ifeq ($(USE_RAD), TRUE)
   USE_HYPRE := TRUE
   USE_MLMG = TRUE
-endif
-
-ifeq ($(USE_SYSTEM_BLAS), TRUE)
-  LIBRARIES += $(BLAS_LIBRARY)
 endif
 
 ifeq ($(USE_MPI), TRUE)


### PR DESCRIPTION

## PR summary

These are no longer relevant -- we removed all the BLAS calls because we can't rely on system calls for the GPU build.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
