### PR TITLE
Do not apply CFL constraint in sponge region

### DIFF
--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -13,6 +13,10 @@
 #include <Rotation.H>
 #endif
 
+#ifdef SPONGE
+#include <sponge.H>
+#endif
+
 #ifdef REACTIONS
 #ifdef NETWORK_HAS_CXX_IMPLEMENTATION
 #include <actual_rhs.H>
@@ -33,7 +37,7 @@ Castro::estdt_cfl(const Real time)
 
   // Courant-condition limited timestep
 
-#ifdef ROTATION
+#if (defined(ROTATION) || defined(SPONGE))
   GeometryData geomdata = geom.data();
 #endif
 
@@ -111,6 +115,18 @@ Castro::estdt_cfl(const Real time)
       dt3 = dx[2]/(c + std::abs(uz));
 #else
       dt3 = dt1;
+#endif
+
+#ifdef SPONGE
+      // Ignore zones inside the sponge region.
+
+      if (castro::do_sponge) {
+          if (sponge::in_sponge_region(i, j, k, geomdata, eos_state.rho, eos_state.p)) {
+              dt1 = std::numeric_limits<Real>::max();
+              dt2 = std::numeric_limits<Real>::max();
+              dt3 = std::numeric_limits<Real>::max();
+          }
+      }
 #endif
 
       // The CTU method has a less restrictive timestep than MOL-based

--- a/Source/sources/Make.package
+++ b/Source/sources/Make.package
@@ -4,6 +4,7 @@ CEXE_headers += Castro_sources.H
 FEXE_headers += Castro_sources_F.H
 
 CEXE_sources += Castro_sources.cpp
+CEXE_headers += sponge.H
 CEXE_sources += Castro_sponge.cpp
 CEXE_sources += Castro_thermo.cpp
 CEXE_sources += Castro_geom.cpp

--- a/Source/sources/sponge.H
+++ b/Source/sources/sponge.H
@@ -1,0 +1,37 @@
+#ifndef SPONGE_H
+#define SPONGE_H
+
+#ifdef SPONGE
+
+#include <Castro_util.H>
+
+namespace sponge
+{
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    int in_sponge_region (int i, int j, int k,
+                          const GeometryData& geomdata,
+                          Real density, Real pressure)
+    {
+        GpuArray<Real, 3> loc;
+        position(i, j, k, geomdata, loc);
+
+        for (int d = 0; d < 3; ++d) {
+            loc[d] -= problem::center[d];
+        }
+
+        Real r = std::sqrt(loc[0] * loc[0] + loc[1] * loc[1] + loc[2] * loc[2]);
+
+        if ((sponge_lower_radius > 0.0 && r >= sponge_lower_radius) ||
+            (sponge_upper_density > 0.0 && density <= sponge_upper_density) ||
+            (sponge_upper_pressure > 0.0 && pressure <= sponge_upper_pressure)) {
+            return 1;
+        }
+        else {
+            return 0;
+        }
+    }
+}
+
+#endif
+
+#endif


### PR DESCRIPTION

## PR summary

The meaning of applying a sponge is that we consider the material to be dynamically irrelevant, and want to ensure that it doesn't grow out of control and interfere with the material of interest. So we should be consistent with that and ignore this material in setting the timestep constraint. If the sponge is doing its job, there should not be any problems caused by the ambient material.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
