### PR TITLE
Use S_new instead of S_old in CFL violation check

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -153,8 +153,11 @@ Castro::do_advance_ctu(Real time,
     if (do_hydro)
     {
 #ifndef MHD
-      // Check for CFL violations.
-      check_for_cfl_violation(S_old, dt);
+      // Check for CFL violations in S_new. The new-time state has seen
+      // the effect of the old-time source terms, so it is a first-order
+      // accurate estimate of whether the advance will violate the CFL
+      // criterion.
+      check_for_cfl_violation(S_new, dt);
 
       // If we detect one, return immediately.
       if (cfl_violation) {


### PR DESCRIPTION

## PR summary

The CFL violation check just prior to the hydro is intended to guess whether the hydro update will violate the CFL stability criterion. For that we can either use the old state or the state updated with the old-time sources. This change switches from the former to the latter. The motivation is the observation that when we fill new fine grids with data from coarse grids, the momentum may be inaccurate at a sharp density gradient like at the edge of a star. This change allows us to apply the sponge to the state (if a sponge is used) before checking whether it violates the CFL criterion, which will avoid spurious CFL violation warnings.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
