### PR TITLE
Deal with the case where sponge is applied after a density reset

### DIFF
--- a/Source/sources/Castro_sources.H
+++ b/Source/sources/Castro_sources.H
@@ -190,12 +190,14 @@
 ///
 /// @param bx           Box to operate over
 /// @param state        input state
+/// @param state_new    input state at new time, if applicable
 /// @param source       source incremented with the sponge
 /// @param dt           timestep
 /// @param mult_factor  multiplicative factor in front of the source
 ///
     void apply_sponge(const amrex::Box& bx,
                       amrex::Array4<amrex::Real const> const state,
+                      amrex::Array4<amrex::Real const> const state_new,
                       amrex::Array4<amrex::Real> const source,
                       amrex::Real dt, amrex::Real mult_factor);
 

--- a/Source/sources/Castro_sponge.cpp
+++ b/Source/sources/Castro_sponge.cpp
@@ -284,7 +284,7 @@ Castro::apply_sponge(const Box& bx,
       // in practice due to time-centering in Strang not understanding that the reset
       // in between the old-time and new-time makes time-centering inappropriate.
 
-      if (state_new(i,j,k,UMX+n) != sponge_target_velocity[n]) {
+      if (state_new(i,j,k,UMX+n) != state_new(i,j,k,URHO) * sponge_target_velocity[n]) {
         Sr[n] = (state(i,j,k,UMX+n) - rho * sponge_target_velocity[n]) * fac * mult_factor / dt;
         src[UMX+n] = Sr[n];
       }


### PR DESCRIPTION

## PR summary

Implements the change described in #1846: in the "new" sponge source, we consider both the old-time and new-time state data in reconstructing the old-time sponge source. If the new-time velocity is identically zero (which should only have happened after a density reset), then we set the old-time sponge to zero so that it cannot accidentally cause a velocity which is now larger than zero.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
