### PR TITLE
Only warn on density reset if below retry_small_density_cutoff

### DIFF
--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -1093,7 +1093,8 @@ Castro::do_enforce_minimum_density(const Box& bx,
     if (state_arr(i,j,k,URHO) < small_dens) {
 
 #ifndef AMREX_USE_GPU
-      if (verbose > 0) {
+      if (verbose > 1 ||
+          (verbose > 0 && state_arr(i,j,k,URHO) > castro::retry_small_density_cutoff)) {
         std::cout << " " << std::endl;
         if (state_arr(i,j,k,URHO) < 0.0_rt) {
           std::cout << ">>> RESETTING NEG.  DENSITY AT " << i << ", " << j << ", " << k << std::endl;


### PR DESCRIPTION

## PR summary

If the user sets `castro.retry_small_density_cutoff` > 0, they are telling the code not to care about density resets below this threshold. So the user probably does not want to be warned about these resets either; this change turns the warning off for that case. It can still be opted into with `castro.v = 2`.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
