### PR TITLE
Protect against negative (rho e) in trans

### DIFF
--- a/Source/hydro/trans.cpp
+++ b/Source/hydro/trans.cpp
@@ -390,6 +390,14 @@ Castro::actual_trans_single(const Box& bx,
 #endif
             }
 
+            // If (rho e) is negative by this point,
+            // set it back to the original interface state,
+            // which turns off the transverse correction.
+
+            if (qo_arr(i,j,k,QREINT) <= 0.0_rt) {
+                qo_arr(i,j,k,QREINT) = q_arr(i,j,k,QREINT);
+            }
+
             // Pretend QREINT has been fixed and transverse_use_eos != 1.
             // If we are wrong, we will fix it later.
 
@@ -405,6 +413,7 @@ Castro::actual_trans_single(const Box& bx,
         }
         else {
             qo_arr(i,j,k,QPRES) = q_arr(i,j,k,QPRES);
+            qo_arr(i,j,k,QREINT) = q_arr(i,j,k,QREINT);
         }
 
 #ifdef RADIATION
@@ -810,6 +819,14 @@ Castro::actual_trans_final(const Box& bx,
                                                flux_t2(il_t2,jl_t2,kl_t2,UEINT) + pt2av * dut2);
             }
 
+            // If (rho e) is negative by this point,
+            // set it back to the original interface state,
+            // which turns off the transverse correction.
+
+            if (qo_arr(i,j,k,QREINT) <= 0.0_rt) {
+                qo_arr(i,j,k,QREINT) = q_arr(i,j,k,QREINT);
+            }
+
             // Pretend QREINT has been fixed and transverse_use_eos != 1.
             // If we are wrong, we will fix it later.
 
@@ -819,6 +836,7 @@ Castro::actual_trans_final(const Box& bx,
         }
         else {
             qo_arr(i,j,k,QPRES) = q_arr(i,j,k,QPRES);
+            qo_arr(i,j,k,QREINT) = q_arr(i,j,k,QREINT);
         }
 
         qo_arr(i,j,k,QPRES) = amrex::max(qo_arr(i,j,k,QPRES), small_p);


### PR DESCRIPTION

## PR summary

When using `transverse_reset_rhoe`, the code detects if the (rho E)-based transverse update makes (rho e) negative, and if so resets to an update that is based on the equation for (rho e). But it's possible for the (rho e) update to also result in a negative (rho e), particularly for ambient material. So we check against this case now and turn off the transverse correction if it would result in a negative (rho e). Also, if there was a density reset then we make (rho e) the unmodified edge state, similar to what we do with pressure.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
