### PR TITLE
Don't let rotation period change by too much in one SCF iteration

### DIFF
--- a/Source/scf/scf_relax.cpp
+++ b/Source/scf/scf_relax.cpp
@@ -347,8 +347,12 @@ Castro::do_hscf_solve()
             Real omega = sqrt(omegasq);
 
             // Rotational period is 2 pi / omega.
+            // Let's also be sure not to let the period
+            // change by too much in a single iteration.
 
-            rotational_period = 2.0 * M_PI / omega;
+            rotational_period = amrex::min(1.1_rt * rotational_period,
+                                           amrex::max(0.9_rt * rotational_period,
+                                                      2.0_rt * M_PI / omega));
 
         }
 


### PR DESCRIPTION

## PR summary

I observe that due to the numerical sensitivity of the method the rotation period can sometimes change by a large amount in one timestep, resulting in subsequent divergence of the model. Limiting the amount the guess for the rotation period can change in one iteration seems to help.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
