### PR TITLE
fix reacting_convergence compilation

### DIFF
--- a/Exec/reacting_tests/reacting_convergence/problem_initialize.H
+++ b/Exec/reacting_tests/reacting_convergence/problem_initialize.H
@@ -4,7 +4,10 @@
 #include <prob_parameters.H>
 #include <eos.H>
 #include <network.H>
+#include <network_properties.H>
+#ifdef NSE_THERMO
 #include <actual_network.H>
+#endif
 
 AMREX_INLINE
 void problem_initialize ()
@@ -35,7 +38,7 @@ void problem_initialize ()
     for (int n = 0; n < NumSpec; n++) {
         aux[AuxZero::iye] += xn[n] * zion[n] * aion_inv[n];
         aux[AuxZero::iabar] += xn[n] * aion_inv[n];
-        aux[AuxZero::ibea] += xn[n] * aprox19::bion(n+1) * aion_inv[n];
+        aux[AuxZero::ibea] += xn[n] * network::bion(n+1) * aion_inv[n];
     }
     aux[AuxZero::iabar] = 1.0_rt/aux[AuxZero::iabar];
 

--- a/Exec/reacting_tests/reacting_convergence/problem_initialize_state_data.H
+++ b/Exec/reacting_tests/reacting_convergence/problem_initialize_state_data.H
@@ -4,7 +4,7 @@
 #include <prob_parameters.H>
 #include <eos.H>
 #include <network.H>
-#include <actual_network.H>
+#include <network_properties.H>
 #ifdef NSE_THERMO
 #include <nse.H>
 #endif


### PR DESCRIPTION
for NSE, bion now comes from network::
for pynucastro nets, there is no actual_network.H

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
