### PR TITLE
Calculate position on grid for SCF relative to center

### DIFF
--- a/Source/scf/scf_relax.cpp
+++ b/Source/scf/scf_relax.cpp
@@ -167,8 +167,6 @@ Castro::do_hscf_solve()
 
             psi[lev].reset(new MultiFab(getLevel(lev).grids, getLevel(lev).dmap, 1, 0));
 
-            const Real* dx = parent->Geom(lev).CellSize();
-
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -255,12 +253,12 @@ Castro::do_hscf_solve()
 
                     Real r[3] = {0.0};
 
-                    r[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0];
+                    r[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
 #if AMREX_SPACEDIM >= 2
-                    r[1] = problo[1] + (static_cast<Real>(j) + 0.5_rt) * dx[1];
+                    r[1] = problo[1] + (static_cast<Real>(j) + 0.5_rt) * dx[1] - problem::center[1];
 #endif
 #if AMREX_SPACEDIM == 3
-                    r[2] = problo[2] + (static_cast<Real>(k) + 0.5_rt) * dx[2];
+                    r[2] = problo[2] + (static_cast<Real>(k) + 0.5_rt) * dx[2] - problem::center[2];
 #endif
 
                     // Do a trilinear interpolation to find the contribution from
@@ -408,12 +406,12 @@ Castro::do_hscf_solve()
 
                     Real r[3] = {0.0};
 
-                    r[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0];
+                    r[0] = problo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0] - problem::center[0];
 #if AMREX_SPACEDIM >= 2
-                    r[1] = problo[1] + (static_cast<Real>(j) + 0.5_rt) * dx[1];
+                    r[1] = problo[1] + (static_cast<Real>(j) + 0.5_rt) * dx[1] - problem::center[1];
 #endif
 #if AMREX_SPACEDIM == 3
-                    r[2] = problo[2] + (static_cast<Real>(k) + 0.5_rt) * dx[2];
+                    r[2] = problo[2] + (static_cast<Real>(k) + 0.5_rt) * dx[2] - problem::center[2];
 #endif
 
                     // Do a trilinear interpolation to find the contribution from


### PR DESCRIPTION

## PR summary

This is a minor bug fix for the SCF calculation -- the positions on the grid should be calculated with respect to `center` because that's where the stellar edges are placed with respect to. This had no effect on the SCF single star test because the center for that problem happens to be at the origin.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
