### PR TITLE
Remove CFL violation check for CTU advance

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -153,19 +153,6 @@ Castro::do_advance_ctu(Real time,
     if (do_hydro)
     {
 #ifndef MHD
-      // Check for CFL violations in S_new. The new-time state has seen
-      // the effect of the old-time source terms, so it is a first-order
-      // accurate estimate of whether the advance will violate the CFL
-      // criterion.
-      check_for_cfl_violation(S_new, dt);
-
-      // If we detect one, return immediately.
-      if (cfl_violation) {
-          status.success = false;
-          status.reason = "CFL violation";
-          return status;
-      }
-
       construct_ctu_hydro_source(time, dt);
 
 //      if (print_update_diagnostics) {


### PR DESCRIPTION

## PR summary

The code in question checks the old state (plus, as of #1842, the old-time sources) to see whether it violates the CFL criterion. But this has been superfluous ever since we added the logic at the end of the timestep to see if the timestep constraint is violated at that point. If there is a violation at that point, we will retry the timestep. So this prior additional check is now removed.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
