### PR TITLE
Initialize SDC reactions data to zero when do_react = 0

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -345,6 +345,20 @@ Castro::do_advance_ctu(Real time,
 #endif
 
         }
+        else {
+
+            // If we're not burning, just initialize the reactions data to zero.
+
+            MultiFab& SDC_react_new = get_new_data(Simplified_SDC_React_Type);
+            SDC_react_new.setVal(0.0, SDC_react_new.nGrow());
+
+            MultiFab& R_old = get_old_data(Reactions_Type);
+            R_old.setVal(0.0, R_old.nGrow());
+
+            MultiFab& R_new = get_new_data(Reactions_Type);
+            R_new.setVal(0.0, R_new.nGrow());
+
+        }
 
     }
 


### PR DESCRIPTION

## PR summary

If we have compiled with reactions and USE_SIMPLIFIED_SDC, but have set `castro.do_react = 0`, there is a bug in the current code where the new-time Reactions_Type data doesn't actually get initialized to zero during the CTU advance. This means that if anything attempts to access the data, such as a derived variable, there may be nonsense results. This change sets the new-time reactions type to zero explicitly so that there will always be valid data to access. For safety, we also set the old-time Reactions_Type data, as well as the Simplified_SDC_React_Type data, to zero.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
