### PR TITLE
Increase timestep for wdmerger_retry test

### DIFF
--- a/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
@@ -46,9 +46,6 @@ castro.use_stopping_criterion = 1
 # CFL number for hyperbolic system
 castro.cfl = 0.5
 
-# Fixed level 0 timestep; unused if < 0
-castro.fixed_dt = -1.0
-
 # Scale back initial timestep by this factor
 castro.init_shrink = 1.0
 
@@ -355,7 +352,7 @@ amr.data_log = grid_diag.out star_diag.out species_diag.out amr_diag.out primary
 # than the safe hydrodynamic timestep given the above
 # CFL value. This guarantees that we will retry on
 # all levels, at least in the first timestep.
-castro.fixed_dt = 0.08
+castro.fixed_dt = 0.25
 
 ############################################################################################
 # Problem parameters


### PR DESCRIPTION

## PR summary

#1873 removes the CFL violation check prior to the CTU hydro update, which is what is being relied on in the wdmerger_retry test to trigger a retry. This change increases the fixed_dt uses by that test to make it more likely to need a retry. Testing with this new dt reveals that even if the CFL violation check is removed, the hydro update will still generate a negative density, so there will be a retry.

## PR checklist

- [ ] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
