### PR TITLE
add a check on the runtime parameters in inputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 21.07
+
+   * Castro can now validate the runtime parameters set in the inputs
+     file or on the commandline by setting
+     castro.abort_on_invalid_params=1 (#1882)
+
 # 21.06
 
    * Starting with this release, problem setups written in Fortran are

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -205,29 +205,14 @@ Castro::variableSetUp ()
   // initializations (e.g., set phys_bc)
   read_params();
 
-  // now check the runtime parameters to warn / abort if the user set
-  // anything that isn't known to Castro
-  validate_runparams();
-
   // initialize the C++ values of the problem-specific runtime parameters.
 
   init_prob_parameters();
 
-  // check to make sure that we didn't set any parameters that don't
-  // exist in C++ (like because of misspelling).  All of the problem.*
-  // parameters should have been accessed via parmparse at this point.
+  // now check the runtime parameters to warn / abort if the user set
+  // anything that isn't known to Castro
 
-  if (ParmParse::hasUnusedInputs("problem")) {
-      amrex::Print() << "Warning: the following problem.* parameters are ignored\n";
-      auto unused = ParmParse::getUnusedInputs("problem"); 
-      for (auto p: unused) {
-          amrex::Print() << p << "\n";
-      }
-      amrex::Print() << std::endl;
-      if (abort_on_invalid_params) {
-          amrex::Error("Error: invalid parameters");
-      }
-  }
+  validate_runparams();
 
   // Initialize the runtime parameters for any of the external
   // microphysics (these are the parameters that are in the &extern

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -8,6 +8,7 @@
 #include <Castro_bc_fill_nd.H>
 #include <Castro_generic_fill.H>
 #include <Derive.H>
+#include <runtime_parameters.H>
 #ifdef RADIATION
 #include <Radiation.H>
 #include <RadDerive.H>
@@ -204,6 +205,10 @@ Castro::variableSetUp ()
   // initializations (e.g., set phys_bc)
   read_params();
 
+  // now check the runtime parameters to warn / abort if the user set
+  // anything that isn't known to Castro
+  validate_runparams();
+
   // initialize the C++ values of the problem-specific runtime parameters.
 
   init_prob_parameters();
@@ -219,6 +224,9 @@ Castro::variableSetUp ()
           amrex::Print() << p << "\n";
       }
       amrex::Print() << std::endl;
+      if (abort_on_invalid_params) {
+          amrex::Error("Error: invalid parameters");
+      }
   }
 
   // Initialize the runtime parameters for any of the external

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -623,6 +623,10 @@ reset_checkpoint_step        int           -1
 # enabled then more memory will be allocated to hold the results of the burn
 store_omegadot               int            0
 
+# Do we abort the run if the inputs file specifies a runtime parameter that we don't
+# know about?  Note: this will only take effect for those namespaces where 100%
+# of the runtime parameters are managed by the python scripts.
+abort_on_invalid_params      int            0
 
 #-----------------------------------------------------------------------------
 # category: particles

--- a/Source/driver/runtime_parameters.H
+++ b/Source/driver/runtime_parameters.H
@@ -69,78 +69,37 @@ void
 validate_runparams()
 {
 
-    {
-        // "castro"
-        if (ParmParse::hasUnusedInputs("castro")) {
-            amrex::Print() << "Warning: the following castro.* parameters are ignored\n";
-            auto unused = ParmParse::getUnusedInputs("castro"); 
-            for (auto p: unused) {
-                amrex::Print() << p << "\n";
-            }
-            amrex::Print() << std::endl;
-            if (abort_on_invalid_params) {
-                amrex::Error("Error: invalid parameters");
-            }
-        }
-
-    }
-
+    amrex::Vector<std::string> check_namespaces = {"castro", "problem"};
 #ifdef AMREX_PARTICLES
-    {
-        // "particles"
-        if (ParmParse::hasUnusedInputs("particles")) {
-            amrex::Print() << "Warning: the following particles.* parameters are ignored\n";
-            auto unused = ParmParse::getUnusedInputs("particles"); 
-            for (auto p: unused) {
-                amrex::Print() << p << "\n";
-            }
-            amrex::Print() << std::endl;
-            if (abort_on_invalid_params) {
-                amrex::Error("Error: invalid parameters");
-            }
-        }
-
-    }
+    check_namespaces.push_back("particles");
 #endif
-
 #ifdef DIFFUSION
-    {
-        // "diffusion"
-        if (ParmParse::hasUnusedInputs("diffusion")) {
-            amrex::Print() << "Warning: the following diffusion.* parameters are ignored\n";
-            auto unused = ParmParse::getUnusedInputs("diffusion"); 
-            for (auto p: unused) {
-                amrex::Print() << p << "\n";
-            }
-            amrex::Print() << std::endl;
-            if (abort_on_invalid_params) {
-                amrex::Error("Error: invalid parameters");
-            }
-        }
-
-    }
+    check_namespaces.push_back("diffusion");
 #endif
-
 #ifdef GRAVITY
-    {
-        // "gravity"
-        if (ParmParse::hasUnusedInputs("gravity")) {
-            amrex::Print() << "Warning: the following gravity.* parameters are ignored\n";
-            auto unused = ParmParse::getUnusedInputs("gravity"); 
-            for (auto p: unused) {
-                amrex::Print() << p << "\n";
-            }
-            amrex::Print() << std::endl;
-            if (abort_on_invalid_params) {
-                amrex::Error("Error: invalid parameters");
-            }
-        }
-
-    }
+    check_namespaces.push_back("gravity");
 #endif
+
 
     // we don't validate radiation parameters yet, since a lot of the reads
     // are hardcoded into the radiation constructor
+
+    for (auto nm: check_namespaces)
+    {
+        // "castro"
+        if (ParmParse::hasUnusedInputs(nm)) {
+            amrex::Print() << "Warning: the following " + nm + ".* parameters are ignored\n";
+            auto unused = ParmParse::getUnusedInputs(nm); 
+            for (auto p: unused) {
+                amrex::Print() << p << "\n";
+            }
+            amrex::Print() << std::endl;
+            if (abort_on_invalid_params) {
+                amrex::Error("Error: invalid parameters");
+            }
+        }
+
+    }
 
 }
 

--- a/Source/driver/runtime_parameters.H
+++ b/Source/driver/runtime_parameters.H
@@ -59,4 +59,89 @@ initialize_cpp_runparams()
 
 }
 
+
+///
+/// Initialize all of the runtime parameters defined in _cpp_parameters
+/// regardless of the namespace
+///
+AMREX_INLINE
+void
+validate_runparams()
+{
+
+    {
+        // "castro"
+        if (ParmParse::hasUnusedInputs("castro")) {
+            amrex::Print() << "Warning: the following castro.* parameters are ignored\n";
+            auto unused = ParmParse::getUnusedInputs("castro"); 
+            for (auto p: unused) {
+                amrex::Print() << p << "\n";
+            }
+            amrex::Print() << std::endl;
+            if (abort_on_invalid_params) {
+                amrex::Error("Error: invalid parameters");
+            }
+        }
+
+    }
+
+#ifdef AMREX_PARTICLES
+    {
+        // "particles"
+        if (ParmParse::hasUnusedInputs("particles")) {
+            amrex::Print() << "Warning: the following particles.* parameters are ignored\n";
+            auto unused = ParmParse::getUnusedInputs("particles"); 
+            for (auto p: unused) {
+                amrex::Print() << p << "\n";
+            }
+            amrex::Print() << std::endl;
+            if (abort_on_invalid_params) {
+                amrex::Error("Error: invalid parameters");
+            }
+        }
+
+    }
+#endif
+
+#ifdef DIFFUSION
+    {
+        // "diffusion"
+        if (ParmParse::hasUnusedInputs("diffusion")) {
+            amrex::Print() << "Warning: the following diffusion.* parameters are ignored\n";
+            auto unused = ParmParse::getUnusedInputs("diffusion"); 
+            for (auto p: unused) {
+                amrex::Print() << p << "\n";
+            }
+            amrex::Print() << std::endl;
+            if (abort_on_invalid_params) {
+                amrex::Error("Error: invalid parameters");
+            }
+        }
+
+    }
+#endif
+
+#ifdef GRAVITY
+    {
+        // "gravity"
+        if (ParmParse::hasUnusedInputs("gravity")) {
+            amrex::Print() << "Warning: the following gravity.* parameters are ignored\n";
+            auto unused = ParmParse::getUnusedInputs("gravity"); 
+            for (auto p: unused) {
+                amrex::Print() << p << "\n";
+            }
+            amrex::Print() << std::endl;
+            if (abort_on_invalid_params) {
+                amrex::Error("Error: invalid parameters");
+            }
+        }
+
+    }
+#endif
+
+    // we don't validate radiation parameters yet, since a lot of the reads
+    // are hardcoded into the radiation constructor
+
+}
+
 #endif


### PR DESCRIPTION
this ensures that the parameters specified are valid / known to Castro
enable by setting castro.abort_on_invalid_params=1

Note: this does not cover microphysics presently

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
