### PR TITLE
rename sdc_use_analytic_jac -> sdc_newton_use_analytic_jac

### DIFF
--- a/Docs/source/sdc.rst
+++ b/Docs/source/sdc.rst
@@ -57,7 +57,7 @@ The options that affect the nonlinear solve are:
 
 * ``sdc_solve_for_rhoe`` : whether we solve the system in terms of :math:`(\rho e)` or :math:`(\rho E)`.
 
-* ``sdc_use_analytic_jac`` : whether we use the analytic Jacobian for
+* ``sdc_newton_use_analytic_jac`` : whether we use the analytic Jacobian when doing Newton iterations for
   the reaction part of the system or compute it numerically.
 
 

--- a/Exec/science/Detonation/inputs-det-x.sdc
+++ b/Exec/science/Detonation/inputs-det-x.sdc
@@ -28,7 +28,7 @@ castro.sdc_solver = 2
 castro.sdc_solver_tol_dens = 1.e-5
 castro.sdc_solver_tol_spec = 1.e-5
 castro.sdc_solver_tol_ener = 1.e-5
-castro.sdc_use_analytic_jac = 0
+castro.sdc_newton_use_analytic_jac = 0
 
 castro.ppm_type = 0
 

--- a/Exec/science/Detonation/inputs-det-x.sdc.test
+++ b/Exec/science/Detonation/inputs-det-x.sdc.test
@@ -32,7 +32,7 @@ castro.sdc_solver_tol_dens = 1.e-5
 castro.sdc_solver_tol_spec = 1.e-5
 castro.sdc_solver_tol_ener = 1.e-5
 castro.sdc_solver_atol = 1.e-10
-castro.sdc_use_analytic_jac = 1
+castro.sdc_newton_use_analytic_jac = 1
 
 castro.ppm_type = 0
 

--- a/Exec/science/Detonation/inputs-det-x.sdc2
+++ b/Exec/science/Detonation/inputs-det-x.sdc2
@@ -33,7 +33,7 @@ castro.sdc_solver = 1
 castro.sdc_solver_tol_dens = 1.e-5
 castro.sdc_solver_tol_spec = 1.e-5
 castro.sdc_solver_tol_ener = 1.e-5
-castro.sdc_use_analytic_jac = 1
+castro.sdc_newton_use_analytic_jac = 1
 
 castro.ppm_type = 0
 

--- a/Exec/science/Detonation/nse_runs/inputs.template.true_sdc
+++ b/Exec/science/Detonation/nse_runs/inputs.template.true_sdc
@@ -44,7 +44,7 @@ castro.sdc_solver_tol_spec=1.e-8
 castro.sdc_solver_tol_ener=1.e-8
 castro.sdc_solver_atol = 1.e-8
 castro.sdc_solver=2
-castro.sdc_use_analytic_jac = 1
+castro.sdc_newton_use_analytic_jac = 1
 
 
 

--- a/Exec/science/flame/inputs.1d.sdc
+++ b/Exec/science/flame/inputs.1d.sdc
@@ -31,7 +31,7 @@ castro.sdc_solver_tol_spec = 1.e-10
 castro.sdc_solver_tol_ener = 1.e-6
 castro.sdc_solver_atol = 1.e-10
 castro.sdc_solver = 1
-castro.sdc_use_analytic_jac = 1
+castro.sdc_newton_use_analytic_jac = 1
 castro.sdc_solver_relax_factor = 1
 
 castro.use_reconstructed_gamma1 = 1

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -290,7 +290,7 @@ sdc_solve_for_rhoe           int           1
 
 # do we use the analytic or numerical Jacobian for the Newton-Raphson solver?
 # for the VODE solver, we use integrator.jacobian instead
-sdc_use_analytic_jac         int           1
+sdc_newton_use_analytic_jac         int           1
 
 # for 2-d axisymmetry, do we include the geometry source terms from Bernand-Champmartin?
 use_axisymmetric_geom_source int           1

--- a/Source/reactions/Castro_react_util.H
+++ b/Source/reactions/Castro_react_util.H
@@ -151,7 +151,7 @@ single_zone_jac(GpuArray<Real, NUM_STATE> const& state,
     // network variables, X, T. e.  It does not have derivatives with
     // respect to density, so we'll have to compute those ourselves.
 
-    if (sdc_use_analytic_jac == 0) {
+    if (sdc_newton_use_analytic_jac == 0) {
         // note the numerical Jacobian will be returned in terms of X
         numerical_jac(burn_state, Jac);
     } else {


### PR DESCRIPTION
this better reinforces the idea that this is only for Newton iteration,
and not for VODE

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
