### PR TITLE
turn off all Fortran for problems that don't need it

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -63,9 +63,6 @@ USE_ALL_CASTRO ?= TRUE
 
 USE_AMR_CORE ?= TRUE
 
-# all Castro problems use a dimension-agnostic interface
-DIMENSION_AGNOSTIC = TRUE
-
 EBASE = Castro
 
 # EXTERN_CORE is simply a list of the directories we use in EOS,
@@ -291,7 +288,6 @@ ifeq ($(USE_PARTICLES), TRUE)
 endif
 
 ifeq ($(USE_MLMG), TRUE)
-   DEFINES += -DCASTRO_MLMG
    Pdirs += LinearSolvers/MLMG
 endif
 
@@ -346,6 +342,26 @@ VPATH_LOCATIONS   += $(Blocs)
 #------------------------------------------------------------------------------
 
 include $(TOP)/Exec/Make.auto_source
+
+# we don't need Fortran microphysics (and any Fortran actually) if we
+# have a C++ network or general_null
+
+ifeq ($(USE_REACT),TRUE)
+  ifeq ($(findstring NETWORK_HAS_CXX_IMPLEMENTATION, $(DEFINES)),NETWORK_HAS_CXX_IMPLEMENTATION)
+     CXX_NET = TRUE
+  endif
+endif
+
+ifeq ($(NETWORK_DIR),general_null)
+  CXX_NET = TRUE
+endif
+
+ifneq ($(USE_RAD),TRUE)
+  ifeq ($(CXX_NET),TRUE)
+    BL_NO_FORT = TRUE
+    USE_FORT_MICROPHYSICS = FALSE
+  endif
+endif
 
 #------------------------------------------------------------------------------
 # finish up

--- a/Exec/hydro_tests/Sedov/GNUmakefile
+++ b/Exec/hydro_tests/Sedov/GNUmakefile
@@ -12,9 +12,6 @@ USE_OMP    = FALSE
 
 USE_MHD    = FALSE
 
-USE_FORT_MICROPHYSICS := FALSE
-BL_NO_FORT := TRUE
-
 # define the location of the CASTRO top directory
 CASTRO_HOME  := ../../..
 


### PR DESCRIPTION
if we are using general_null or a C++ network and not doing
radiation, then we don't need to build any Fortran.

This also removes some defines that are no longer necessary /
implemented

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
