### PR TITLE
add an optional perturbation to StarGrav

### DIFF
--- a/Exec/gravity_tests/StarGrav/_prob_params
+++ b/Exec/gravity_tests/StarGrav/_prob_params
@@ -1,3 +1,9 @@
-model_name       character          ""        y
+model_name       character          ""          y
 
-m_0              real               1.e30_rt    y         
+m_0              real               1.e30_rt    y
+
+pert_dist        real               0.0         y
+
+pert_radius      real               0.0         y
+
+pert_amplitude   real               0.0         y

--- a/Exec/gravity_tests/StarGrav/problem_initialize_state_data.H
+++ b/Exec/gravity_tests/StarGrav/problem_initialize_state_data.H
@@ -43,6 +43,24 @@ void problem_initialize_state_data (int i, int j, int k,
 
     eos(eos_input_rt, eos_state);
 
+
+    // perturbuation on y axis
+
+    if (problem::pert_amplitude > 0.0_rt) {
+        Real pdist2 = x * x + (y - problem::pert_dist) * (y - problem::pert_dist);
+
+        Real T_new = state(i,j,k,UTEMP) *
+            (1.0_rt + problem::pert_amplitude * std::exp(-pdist2 / std::pow(problem::pert_radius, 2)));
+
+        eos_state.T = T_new;
+
+        eos(eos_input_tp, eos_state);
+
+        state(i,j,k,URHO) = eos_state.rho;
+        state(i,j,k,UTEMP) = T_new;
+
+    }
+
     state(i,j,k,UEINT) = state(i,j,k,URHO) * eos_state.e;
     state(i,j,k,UEDEN) = state(i,j,k,URHO) * eos_state.e;
 


### PR DESCRIPTION
this is intended to help test the effect of the source in the reference state

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
