### PR TITLE
fix the burn_weights again with the numerical Jacobian

### DIFF
--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -141,8 +141,8 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt)
                     if (jacobian == 1) {
                         reactions(i,j,k,1) = amrex::max(1.0_rt, static_cast<Real>(burn_state.n_rhs + 2 * burn_state.n_jac));
                     } else {
-                        // the numerical Jacobian does a 1-sided diff, requiring NumSpec+1 RHS calls
-                        reactions(i,j,k,1) = amrex::max(1.0_rt, static_cast<Real>(burn_state.n_rhs + (NumSpec+1) * burn_state.n_jac));
+                        // the RHS evals for the numerical differencing in the Jacobian are already accounted for in n_rhs
+                        reactions(i,j,k,1) = amrex::max(1.0_rt, static_cast<Real>(burn_state.n_rhs));
                     }
 
                     if (store_omegadot == 1) {
@@ -425,8 +425,8 @@ Castro::react_state(Real time, Real dt)
                      if (jacobian == 1) {
                          react_src(i,j,k,1) = amrex::max(1.0_rt, static_cast<Real>(burn_state.n_rhs + 2 * burn_state.n_jac));
                      } else {
-                         // the numerical Jacobian does a 1-sided diff, requiring NumSpec+1 RHS calls
-                         react_src(i,j,k,1) = amrex::max(1.0_rt, static_cast<Real>(burn_state.n_rhs + (NumSpec+1) * burn_state.n_jac));
+                         // the RHS evals for the numerical differencing in the Jacobian are already accounted for in n_rhs
+                         react_src(i,j,k,1) = amrex::max(1.0_rt, static_cast<Real>(burn_state.n_rhs));
                      }
 
                      if (store_omegadot) {


### PR DESCRIPTION
the convention that VODE uses is that it already includes the NEQS RHS
calls in n_rhs so we don't need to readd them for each n_jac

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
