### PR TITLE
for multilevel simplified-SDC, explicitly fill the react source ghosts

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -148,11 +148,13 @@ Castro::do_advance_ctu(Real time,
 
 
 #ifdef SIMPLIFIED_SDC
+#ifdef REACTIONS
     // the SDC reactive source ghost cells on coarse levels might not
     // be in sync due to any average down done, so fill them here
 
     MultiFab& react_src = get_new_data(Simplified_SDC_React_Type);
     AmrLevel::FillPatch(*this, react_src, react_src.nGrow(), cur_time, Simplified_SDC_React_Type, 0, react_src.nComp());
+#endif
 #endif
 
     // Do the hydro update.  We build directly off of Sborder, which

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -147,6 +147,14 @@ Castro::do_advance_ctu(Real time,
     }
 
 
+#ifdef SIMPLIFIED_SDC
+    // the SDC reactive source ghost cells on coarse levels might not
+    // be in sync due to any average down done, so fill them here
+
+    MultiFab& react_src = get_new_data(Simplified_SDC_React_Type);
+    AmrLevel::FillPatch(*this, react_src, react_src.nGrow(), cur_time, Simplified_SDC_React_Type, 0, react_src.nComp());
+#endif
+
     // Do the hydro update.  We build directly off of Sborder, which
     // is the state that has already seen the burn
 


### PR DESCRIPTION
we do this before hydro because any average down may have made the ghost
cells inconsistent which can be especially problematic at symmetry boundaries

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
