### PR TITLE
Require castro.change_max to be greater than 1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
      castro.store_burn_weights=1.  Additionally, they now give a better
      estimate of the cost for the numerical Jacobian (#1946, #1949)
 
+   * castro.change_max is now required to be greater than 1.0. To enforce
+     a timestep cap but still allow the timestep to decrease, use
+     castro.max_dt. (#1976)
 
 # 21.09
 

--- a/Exec/gravity_tests/DustCollapse/inputs_pointmass
+++ b/Exec/gravity_tests/DustCollapse/inputs_pointmass
@@ -35,7 +35,7 @@ castro.small_dens    = 1.e-6
 # TIME STEP CONTROL
 castro.cfl            = 0.5
 castro.init_shrink    = 0.01
-castro.change_max     = 1.0
+#castro.change_max     = 1.0
 castro.limit_fluxes_on_small_dens = 1
 
 # SPONGE

--- a/Exec/gravity_tests/hse_convergence/inputs.ppm.128
+++ b/Exec/gravity_tests/hse_convergence/inputs.ppm.128
@@ -40,7 +40,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 castro.fixed_dt = 7.5e-5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence/inputs.ppm.256
+++ b/Exec/gravity_tests/hse_convergence/inputs.ppm.256
@@ -40,7 +40,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 castro.fixed_dt = 3.75e-5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence/inputs.ppm.512
+++ b/Exec/gravity_tests/hse_convergence/inputs.ppm.512
@@ -40,7 +40,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 castro.fixed_dt = 1.875e-5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence/inputs.ppm.64
+++ b/Exec/gravity_tests/hse_convergence/inputs.ppm.64
@@ -40,7 +40,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 castro.fixed_dt = 1.5e-4
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence/inputs.sdc2-pslope-reflect.testsuite
+++ b/Exec/gravity_tests/hse_convergence/inputs.sdc2-pslope-reflect.testsuite
@@ -39,7 +39,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 castro.fixed_dt = 3.75e-5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/gravity_tests/hse_convergence/inputs.sdc4-reflect.testsuite
+++ b/Exec/gravity_tests/hse_convergence/inputs.sdc4-reflect.testsuite
@@ -39,7 +39,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 castro.fixed_dt = 3.75e-5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/radiation_tests/RadFront/inputs1d
+++ b/Exec/radiation_tests/RadFront/inputs1d
@@ -80,7 +80,6 @@ castro.small_dens =1.0e-10
 # TIME STEP CONTROL
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
-castro.change_max     = 1.0e-9 
 
 castro.fixed_dt       = 1.3e-12
 

--- a/Exec/radiation_tests/RadShestakovBolstad/inputs.common
+++ b/Exec/radiation_tests/RadShestakovBolstad/inputs.common
@@ -77,7 +77,6 @@ castro.do_react       = 0        # reactions?
 # TIME STEP CONTROL
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0
 #castro.initial_dt     = 1.e-12
 
 castro.fixed_dt  =  4.5339149910673475e-08   # 1/256

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.128
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.128
@@ -44,7 +44,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 
 castro.fixed_dt = 0.75e-4
 

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.256
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.256
@@ -44,7 +44,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 
 castro.fixed_dt = 0.375e-4
 

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.32
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.32
@@ -44,7 +44,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 
 castro.fixed_dt = 3e-4
 

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.512
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.512
@@ -44,7 +44,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 
 castro.fixed_dt = 0.1875e-4
 

--- a/Exec/reacting_tests/bubble_convergence/inputs_2d.64
+++ b/Exec/reacting_tests/bubble_convergence/inputs_2d.64
@@ -44,7 +44,6 @@ gravity.const_grav   = -1.e10
 # TIME STEP CONTROL
 castro.cfl            = 0.9     # cfl number for hyperbolic system
 castro.init_shrink    = 1.0     # scale back initial timestep
-castro.change_max     = 1.0     # max time step growth
 
 castro.fixed_dt = 1.5e-4
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -440,6 +440,12 @@ Castro::read_params ()
         amrex::Error();
       }
 
+    if (change_max <= 1.0)
+    {
+        std::cerr << "change_max must be greater than 1.0\n";
+        amrex::Error();
+    }
+
 #ifdef AMREX_PARTICLES
     read_particle_params();
 #endif

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -327,7 +327,8 @@ cfl                          Real          0.8
 init_shrink                  Real          1.0
 
 # the maximum factor by which the timestep can increase or decrease from
-# one step to the next
+# one step to the next. Must be greater than 1.0---use max_dt to set a cap
+# on the timestep.
 change_max                   Real          1.1
 
 # enforce that the AMR plot interval must be hit exactly


### PR DESCRIPTION
Addresses #1863.
All but one of the changed inputs use fixed_dt, so change_max is unnecessary.
The remaining test (gravity_tests/DustCollapse/inputs_pointmass) fails with the existing code, and I'll open an issue about that.
For now, I've commented that line out, so we don't hide the real error.

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [x] if appropriate, this change is described in the docs
