### PR TITLE
Fix _prob_params parsing

### DIFF
--- a/Util/scripts/write_probdata.py
+++ b/Util/scripts/write_probdata.py
@@ -56,6 +56,8 @@ def get_next_line(fin):
         line = fin.readline()
         pos = line.find("#")
 
+    if pos == -1:
+        return line.strip()
     return line[:pos]
 
 


### PR DESCRIPTION
If a line doesn't have a comment, then `line.find("#")` returns -1.
Normally, `line[:-1]` will just remove a trailing newline, but if the
file doesn't have a newline at the end, this will instead remove the
last character on the line. If this is a "y" in the 4th column, then the
last parameter cannot be set at runtime.
Closes #1980.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
