### PR TITLE
increase p0 for DustCollapse pointmass test so it runs without crashing

### DIFF
--- a/Exec/gravity_tests/DustCollapse/inputs_pointmass
+++ b/Exec/gravity_tests/DustCollapse/inputs_pointmass
@@ -74,7 +74,7 @@ amr.derive_plot_vars = NONE
 
 # PROBLEM PARAMETERS
 problem.rho_0 = 1.0e7
-problem.p_0   = 1.0e8
+problem.p_0   = 1.0e12
 problem.rho_ambient = 1.0e-4
 problem.r_0   = 4.0e8
 problem.r_offset = 1.0e8


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

we don't remember the reason why p0 was so much lower in this inputs compared to the others.

This fixes #1979 

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
