### PR TITLE
disable Fortran automatically unless needed

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -30,6 +30,24 @@ EOS_HOME ?= $(MICROPHYSICS_HOME)/EOS
 NETWORK_HOME ?= $(MICROPHYSICS_HOME)/networks
 CONDUCTIVITY_HOME ?= $(MICROPHYSICS_HOME)/conductivity
 
+# only pynucastro nets or radiation builds need Fortran
+pynucastro_file_exists := $(wildcard $(NETWORK_HOME)/$(strip $(NETWORK_DIR))/pynucastro.net)
+ifeq ("$(pynucastro_file_exists)","")
+  # we are not using a pynucastro net
+  ifeq ($(USE_RAD), TRUE)
+    USE_FORT_MICROPHYSICS := TRUE
+    BL_NO_FORT := FALSE
+  else
+    USE_FORT_MICROPHYSICS := FALSE
+    BL_NO_FORT := TRUE
+  endif
+else
+  $(warning pynucastro network detected--enabling Fortran)
+  USE_FORT_MICROPHYSICS := TRUE
+  BL_NO_FORT := FALSE
+endif
+
+
 # AMReX is a git submodule of Castro. By default
 # we assume it is in the external/ directory.
 # The user may override this with their own installation
@@ -300,6 +318,7 @@ Bpack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
 # file (including the general_null network) to our temporary build
 # directory
 NETWORK_OUTPUT_PATH = $(CASTRO_AUTO_SOURCE_DIR)
+
 
 USE_CXX_EOS := TRUE
 

--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -319,7 +319,6 @@ Bpack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
 # directory
 NETWORK_OUTPUT_PATH = $(CASTRO_AUTO_SOURCE_DIR)
 
-
 USE_CXX_EOS := TRUE
 
 include $(MICROPHYSICS_HOME)/Make.Microphysics_extern


### PR DESCRIPTION
We only need Fortran for 2 things right now: radiation and a pynucastro net
this now turns off Fortran in Microphysics and AMReX in all other cases

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
