### PR TITLE
Fix sign of gravitational energy in diags

### DIFF
--- a/Source/driver/sum_integrated_quantities.cpp
+++ b/Source/driver/sum_integrated_quantities.cpp
@@ -140,13 +140,15 @@ Castro::sum_integrated_quantities ()
 #ifdef GRAVITY
             rho_phi    = foo[i++];
 
-            // Total energy is -1/2 * rho * phi + rho * E for self-gravity,
-            // and -rho * phi + rho * E for externally-supplied gravity.
+            // Total energy is 1/2 * rho * phi + rho * E for self-gravity,
+            // and rho * phi + rho * E for externally-supplied gravity.
             std::string gravity_type = gravity->get_gravity_type();
-            if (gravity_type == "PoissonGrav" || gravity_type == "MonopoleGrav")
-              total_energy = -0.5 * rho_phi + rho_E;
-            else
-              total_energy = -rho_phi + rho_E;
+            if (gravity_type == "PoissonGrav" || gravity_type == "MonopoleGrav") {
+                total_energy = 0.5 * rho_phi + rho_E;
+            }
+            else {
+                total_energy = rho_phi + rho_E;
+            }
 #endif
 
             std::cout << '\n';


### PR DESCRIPTION

## PR summary

phiGrav is negative now so the total energy is constructed by adding rho*phi instead of subtracting it.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
