### PR TITLE
Add hse_fixed_temp parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
      scaling performance increase when using multiple threads
      in with OpenMP. See issue #2038.
 
+   * `castro.hse_fixed_temp` was added to allow for a fixed temperature
+     at an HSE boundary. It can be enabled by setting it to a positive
+     value and setting castro.hse_interp_temp=0. (#2042)
+
 # 21.10
 
    * A new option, `castro.drive_initial_convection` was added that

--- a/Exec/science/flame_wave/inputs_H_He/inputs.H_He.1000Hz
+++ b/Exec/science/flame_wave/inputs_H_He/inputs.H_He.1000Hz
@@ -18,7 +18,7 @@ castro.lo_bc       =  3   1
 castro.hi_bc       =  2   2
 
 castro.yl_ext_bc_type = 1
-castro.hse_interp_temp = 1
+castro.hse_interp_temp = 0
 castro.hse_reflect_vels = 1
 
 castro.fill_ambient_bc = 1
@@ -104,6 +104,7 @@ problem.dx_model = 30.e0
 
 problem.dens_base = 1.e6
 
+castro.hse_fixed_temp = 1.e8
 problem.T_star = 1.e8
 problem.T_hi = 2.e8
 problem.T_lo   = 8.e6

--- a/Exec/science/flame_wave/inputs_H_He/inputs.H_He.500Hz
+++ b/Exec/science/flame_wave/inputs_H_He/inputs.H_He.500Hz
@@ -18,7 +18,7 @@ castro.lo_bc       =  3   1
 castro.hi_bc       =  2   2
 
 castro.yl_ext_bc_type = 1
-castro.hse_interp_temp = 1
+castro.hse_interp_temp = 0
 castro.hse_reflect_vels = 1
 
 castro.fill_ambient_bc = 1
@@ -104,6 +104,7 @@ problem.dx_model = 30.e0
 
 problem.dens_base = 1.e6
 
+castro.hse_fixed_temp = 1.e8
 problem.T_star = 1.e8
 problem.T_hi = 2.e8
 problem.T_lo   = 8.e6

--- a/Exec/science/flame_wave/problem_initialize.H
+++ b/Exec/science/flame_wave/problem_initialize.H
@@ -24,6 +24,12 @@ void problem_initialize ()
         amrex::Error("ERROR: small_dens should be set lower than low_density_cutoff");
     }
 
+    // make sure hse_fixed_temp is the same as T_star, if it's specified
+
+    if (hse_fixed_temp > 0.0_rt && hse_fixed_temp != problem::T_star) {
+        amrex::Error("ERROR: hse_fixed_temp should be the same as T_star");
+    }
+
     // get the species indices
 
     bool species_defined = true;

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -219,10 +219,10 @@ zr_ext_bc_type               int          -1
 hse_zero_vels                int           0
 
 # if we are doing HSE boundary conditions, should we get the temperature
-# via interpolation (using model_parser) or hold it constant?
+# via interpolation (constant gradient) or hold it constant?
 hse_interp_temp              int           0
 
-# if we are doing HSE boundary conditions and not interpolating the temperature,
+# if we are doing HSE boundary conditions and holding the temperature constant,
 # then set it to a fixed value at the boundaries (only if positive)
 hse_fixed_temp               Real          -1.e200
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -222,6 +222,10 @@ hse_zero_vels                int           0
 # via interpolation (using model_parser) or hold it constant?
 hse_interp_temp              int           0
 
+# if we are doing HSE boundary conditions and not interpolating the temperature,
+# then set it to a fixed value at the boundaries (only if positive)
+hse_fixed_temp               Real          -1.e200
+
 # if we are doing HSE boundary conditions, how do we treat the velocity?
 # reflect? or outflow?
 hse_reflect_vels             int           0

--- a/Source/problems/hse_fill.cpp
+++ b/Source/problems/hse_fill.cpp
@@ -104,7 +104,11 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     if (hse_interp_temp == 1) {
                         temp_zone = 2*adv(ii+1,j,k,UTEMP) - adv(ii+2,j,k,UTEMP);
                     } else {
-                        temp_zone = temp_above;
+                        if (hse_fixed_temp > 0.0_rt) {
+                            temp_zone = hse_fixed_temp;
+                        } else {
+                            temp_zone = temp_above;
+                        }
                     }
 
                     bool converged_hse = false;
@@ -290,7 +294,11 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     if (hse_interp_temp == 1) {
                         temp_zone = 2*adv(ii-1,j,k,UTEMP) - adv(ii-2,j,k,UTEMP);
                     } else {
-                        temp_zone = temp_below;
+                        if (hse_fixed_temp > 0.0_rt) {
+                            temp_zone = hse_fixed_temp;
+                        } else {
+                            temp_zone = temp_below;
+                        }
                     }
 
                     bool converged_hse = false;
@@ -481,7 +489,11 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     if (hse_interp_temp == 1) {
                         temp_zone = 2*adv(i,jj+1,k,UTEMP) - adv(i,jj+2,k,UTEMP);
                     } else {
-                        temp_zone = temp_above;
+                        if (hse_fixed_temp > 0.0_rt) {
+                            temp_zone = hse_fixed_temp;
+                        } else {
+                            temp_zone = temp_above;
+                        }
                     }
 
                     bool converged_hse = false;
@@ -668,7 +680,11 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     if (hse_interp_temp == 1) {
                         temp_zone = 2*adv(i,jj-1,k,UTEMP) - adv(i,jj-2,k,UTEMP);
                     } else {
-                        temp_zone = temp_below;
+                        if (hse_fixed_temp > 0.0_rt) {
+                            temp_zone = hse_fixed_temp;
+                        } else {
+                            temp_zone = temp_below;
+                        }
                     }
 
                     bool converged_hse = false;
@@ -858,7 +874,11 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                     if (hse_interp_temp == 1) {
                         temp_zone = 2*adv(i,j,kk+1,UTEMP) - adv(i,j,kk+2,UTEMP);
                     } else {
-                        temp_zone = temp_above;
+                        if (hse_fixed_temp > 0.0_rt) {
+                            temp_zone = hse_fixed_temp;
+                        } else {
+                            temp_zone = temp_above;
+                        }
                     }
 
                     bool converged_hse = false;


### PR DESCRIPTION
## PR summary

Adds castro.hse_fixed_temp, which sets the temperature at an HSE boundary if hse_interp_temp = 0.
Addresses #2035.

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
