### PR TITLE
Prefetch radial gravity data before and after MPI reduction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# 22.03
+# 22.04
 
    * Fixed an issue with monopole gravity where running with multiple
      MPI ranks in a GPU build could result in an incorrect gravitational

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 22.03
+
+   * Fixed an issue with monopole gravity where running with multiple
+     MPI ranks in a GPU build could result in an incorrect gravitational
+     field calculation. (#2091)
+
 # 22.02
 
    * Microphysics has moved from Starkiller-Astro to AMReX-Astro.  The

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -3102,11 +3102,27 @@ Gravity::make_radial_gravity(int level, Real time, RealVector& radial_grav)
 #endif
         }
 
+        if (!ParallelDescriptor::UseGpuAwareMpi()) {
+            Gpu::prefetchToHost(radial_mass[lev].begin(), radial_mass[lev].end());
+            Gpu::prefetchToHost(radial_vol[lev].begin(), radial_vol[lev].end());
+#ifdef GR_GRAV
+            Gpu::prefetchToHost(radial_pres[lev].begin(), radial_pres[lev].end());
+#endif
+        }
+
         ParallelDescriptor::ReduceRealSum(radial_mass[lev].dataPtr() ,n1d);
         ParallelDescriptor::ReduceRealSum(radial_vol[lev].dataPtr()  ,n1d);
 #ifdef GR_GRAV
         ParallelDescriptor::ReduceRealSum(radial_pres[lev].dataPtr()  ,n1d);
 #endif
+
+        if (!ParallelDescriptor::UseGpuAwareMpi()) {
+            Gpu::prefetchToDevice(radial_mass[lev].begin(), radial_mass[lev].end());
+            Gpu::prefetchToDevice(radial_vol[lev].begin(), radial_vol[lev].end());
+#ifdef GR_GRAV
+            Gpu::prefetchToDevice(radial_pres[lev].begin(), radial_pres[lev].end());
+#endif
+        }
 
         if (do_diag > 0)
         {


### PR DESCRIPTION

## PR summary

When GPU-aware MPI is not being used, it is not generally safe to pass managed memory directly to an MPI call (depending on MPI implementation, this could lead to accessing invalid data). So we need to prefetch the data to the host before calling ParallelDescriptor reduction operations. (This is handled already for multipole gravity, but this was missed when monopole gravity was ported to GPUs.)

This addresses the issue identified in #2080.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
