### PR TITLE
Normalize species fluxes on reflux

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -57,6 +57,8 @@
 
 #include <ambient.H>
 
+#include <advection_util.H>
+
 using namespace amrex;
 
 bool         Castro::signalStopJob = false;
@@ -2651,6 +2653,11 @@ Castro::reflux(int crse_level, int fine_level)
                             F(i,j,k,n) = 0.0;
                         }
                     }
+
+                    // The fluxes may also result in sum(X) != 1. Normalize them now.
+                    // This will be a non-conservative correction.
+
+                    normalize_species_flux(i, j, k, F);
                 });
             }
 

--- a/Source/hydro/advection_util.H
+++ b/Source/hydro/advection_util.H
@@ -7,7 +7,7 @@
 #include <hybrid.H>
 #endif
 
-AMREX_GPU_HOST_DEVICE
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void
 dflux(const GpuArray<Real, NUM_STATE>& u,
       const GpuArray<Real, NQ>& q,
@@ -77,4 +77,36 @@ dflux(const GpuArray<Real, NUM_STATE>& u,
 
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void
+normalize_species_flux (int i, int j, int k, Array4<Real> const& flux)
+{
+    // Normalize the fluxes of the mass fractions so that
+    // they sum to 0. This is essentially the CMA procedure that is
+    // defined in Plewa & Muller, 1999, A&A, 342, 179.
+
+    Real sum = 0.0_rt;
+
+    for (int n = UFS; n < UFS+NumSpec; n++) {
+      sum += flux(i,j,k,n);
+    }
+
+    Real fac = 1.0_rt;
+
+    // We skip the normalization if the sum is zero or within epsilon.
+    // There can be numerical problems here if the density flux is
+    // approximately zero at the interface but not exactly, resulting in
+    // division by a small number and/or resulting in one of the species
+    // fluxes being negative because of roundoff error. There are also other
+    // terms like artificial viscosity which can cause these problems.
+    // So checking that sum is sufficiently large helps avoid this.
+
+    if (std::abs(sum) > std::numeric_limits<Real>::epsilon() * std::abs(flux(i,j,k,URHO))) {
+      fac = flux(i,j,k,URHO) / sum;
+    }
+
+    for (int n = UFS; n < UFS+NumSpec; n++) {
+      flux(i,j,k,n) = flux(i,j,k,n) * fac;
+    }
+}
 #endif

--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -577,38 +577,10 @@ Castro::apply_av_rad(const Box& bx,
 void
 Castro::normalize_species_fluxes(const Box& bx,
                                  Array4<Real> const& flux) {
-
-  // Normalize the fluxes of the mass fractions so that
-  // they sum to 0.  This is essentially the CMA procedure that is
-  // defined in Plewa & Muller, 1999, A&A, 342, 179.
-
   amrex::ParallelFor(bx,
   [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
-
-    Real sum = 0.0_rt;
-
-    for (int n = UFS; n < UFS+NumSpec; n++) {
-      sum += flux(i,j,k,n);
-    }
-
-    Real fac = 1.0_rt;
-
-    // We skip the normalization if the sum is zero or within epsilon.
-    // There can be numerical problems here if the density flux is
-    // approximately zero at the interface but not exactly, resulting in
-    // division by a small number and/or resulting in one of the species
-    // fluxes being negative because of roundoff error. There are also other
-    // terms like artificial viscosity which can cause these problems.
-    // So checking that sum is sufficiently large helps avoid this.
-
-    if (std::abs(sum) > std::numeric_limits<Real>::epsilon() * std::abs(flux(i,j,k,URHO))) {
-      fac = flux(i,j,k,URHO) / sum;
-    }
-
-    for (int n = UFS; n < UFS+NumSpec; n++) {
-      flux(i,j,k,n) = flux(i,j,k,n) * fac;
-    }
+      normalize_species_flux(i, j, k, flux);
   });
 }
 


### PR DESCRIPTION
## PR summary

This is intended to address #2096, which is observed after a reflux.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
