### PR TITLE
Fix argument passing in ca_init_fort_constants

### DIFF
--- a/Source/radiation/Rad_nd.F90
+++ b/Source/radiation/Rad_nd.F90
@@ -5,7 +5,7 @@ subroutine ca_init_fort_constants(hplanck_in, avogadro_in) bind(C, name="ca_init
 
   implicit none
 
-  real(rt), intent(in) :: hplanck_in, avogadro_in
+  real(rt), intent(in), value :: hplanck_in, avogadro_in
 
   hplanck = hplanck_in
   avogadro = avogadro_in


### PR DESCRIPTION

## PR summary

#2048 switched the argument passing in C to pass-by-value, but this was not updated in the Fortran by treating the arguments as having the value attribute. This is fixed.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
