### PR TITLE
Enable NaN check in the GPU build

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -4274,17 +4274,19 @@ Castro::check_for_nan(MultiFab& state_in, int check_ghost)
     ng = state_in.nGrow();
   }
 
-  if (state_in.contains_nan(URHO,state_in.nComp(),ng,true))
-    {
-      for (int i = 0; i < state_in.nComp(); i++)
-        {
-          if (state_in.contains_nan(URHO + i, 1, ng, true))
-            {
+  if (state_in.contains_nan(URHO,state_in.nComp(),ng,true)) {
+#ifdef AMREX_USE_GPU
+      std::string abort_string = std::string("State has NaNs in check_for_nan()");
+      amrex::Abort(abort_string.c_str());
+#else
+      for (int i = 0; i < state_in.nComp(); i++) {
+          if (state_in.contains_nan(URHO + i, 1, ng, true)) {
               std::string abort_string = std::string("State has NaNs in the ") + desc_lst[State_Type].name(i) + std::string(" component::check_for_nan()");
               amrex::Abort(abort_string.c_str());
-            }
-        }
-    }
+          }
+      }
+#endif
+  }
 }
 
 // Given State_Type state data, perform a number of cleaning steps to make

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -64,11 +64,9 @@ Castro::do_advance_ctu(Real time,
         create_source_corrector();
     }
 
-#ifndef AMREX_USE_GPU
     // Check for NaN's.
 
     check_for_nan(S_old);
-#endif
 
     // Since we are Strang splitting the reactions, do them now
 
@@ -238,11 +236,9 @@ Castro::do_advance_ctu(Real time,
 #endif
                 S_new, cur_time, 0);
 
-#ifndef AMREX_USE_GPU
     // Check for NaN's.
 
     check_for_nan(S_new);
-#endif
 
     // if we are done with the update do the source correction and
     // then the second half of the reactions
@@ -348,9 +344,7 @@ Castro::do_advance_ctu(Real time,
 
             // Check for NaN's.
 
-#ifndef AMREX_USE_GPU
             check_for_nan(S_new);
-#endif
 
         }
         else {


### PR DESCRIPTION

## PR summary

The Fab and MultiFab `contains_nan` methods are GPU safe, we just want to avoid the bit that iterates through the memory and prints out the zone value because that's not safe for non-managed-memory (though we could add that back for managed memory builds if needed).

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
