### PR TITLE
Add GPU synchronizes to avoid race conditions in Hypre solve

### DIFF
--- a/Source/radiation/HypreABec.cpp
+++ b/Source/radiation/HypreABec.cpp
@@ -1711,6 +1711,7 @@ void HypreABec::solve(MultiFab& dest, int icomp, MultiFab& rhs, BC_Mode inhom)
       fcomp = 0;
 
       AMREX_PARALLEL_FOR_3D(reg, i, j, k, { f_arr(i,j,k,fcomp) = d_arr(i,j,k,icomp); });
+      Gpu::streamSynchronize();
     }
     Elixir f_elix = fnew.elixir();
 
@@ -1723,6 +1724,7 @@ void HypreABec::solve(MultiFab& dest, int icomp, MultiFab& rhs, BC_Mode inhom)
     Array4<Real> const f_arr = f->array();
 
     AMREX_PARALLEL_FOR_3D(reg, i, j, k, { f_arr(i,j,k,fcomp) = r_arr(i,j,k,0); });
+    Gpu::streamSynchronize();
 
     // add b.c.'s to rhs
 


### PR DESCRIPTION

## PR summary

This routine is not async-safe presently, which is why many of the operations have synchronizes already, but these two were missed, and could result in race conditions.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
