### PR TITLE
Reset composition on a density reset in trans

### DIFF
--- a/Source/hydro/trans.cpp
+++ b/Source/hydro/trans.cpp
@@ -356,6 +356,10 @@ Castro::actual_trans_single(const Box& bx,
             rvnewn = rvn;
             rwnewn = rwn;
             renewn = ren;
+            for (int ipassive = 0; ipassive < npassive; ++ipassive) {
+                int nqp = qpassmap(ipassive);
+                qo_arr(i,j,k,nqp) = q_arr(i,j,k,nqp);
+            }
 #ifdef RADIATION
             for (int g = 0; g < NGROUPS; ++g) {
                 ernewn[g] = ern[g];
@@ -790,6 +794,10 @@ Castro::actual_trans_final(const Box& bx,
             rvnewn = rvn;
             rwnewn = rwn;
             renewn = ren;
+            for (int ipassive = 0; ipassive < npassive; ++ipassive) {
+                int nqp = qpassmap(ipassive);
+                qo_arr(i,j,k,nqp) = q_arr(i,j,k,nqp);
+            }
 #ifdef RADIATION
             for (int g = 0; g < NGROUPS; ++g) {
                 ernewn[g] = ern[g];


### PR DESCRIPTION

## PR summary

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
