### PR TITLE
Switch wdmerger density tagging to refinement_indicators

### DIFF
--- a/Exec/science/wdmerger/_prob_params
+++ b/Exec/science/wdmerger/_prob_params
@@ -179,10 +179,7 @@ tde_pericenter_radius           real                  0.0e0_rt                 n
 
 # Tagging criteria
 
-max_stellar_tagging_level       integer               20                       y
-stellar_density_threshold       real                  1.0e0_rt                 y
 max_tagging_radius              real                  0.75e0_rt                y
-roche_tagging_factor            real                  2.0e0_rt                 y
 
 
 
@@ -192,6 +189,8 @@ com_P                           real                  0.0e0_rt                 n
 com_S                           real                  0.0e0_rt                 n                      3
 vel_P                           real                  0.0e0_rt                 n                      3
 vel_S                           real                  0.0e0_rt                 n                      3
+
+stellar_density_threshold       real                  1.0e0_rt                 y
 
 
 

--- a/Exec/science/wdmerger/inputs
+++ b/Exec/science/wdmerger/inputs
@@ -132,7 +132,12 @@ castro.state_interp_order = 0
 castro.lin_limit_state_interp = 1
 
 # Add refinement indicators
-amr.refinement_indicators = temperature
+amr.refinement_indicators = density temperature
+
+# Density refinement criterion
+amr.refine.density.value_greater = 1.0e0
+amr.refine.density.field_name = density
+amr.refine.density.max_level = 20
 
 # Temperature refinement criterion
 amr.refine.temperature.value_greater = 5.0e8
@@ -455,10 +460,8 @@ problem.orbital_angle = 0.0e0
 problem.axis_1 = 1
 problem.axis_2 = 2
 
-problem.max_stellar_tagging_level = 20
 problem.stellar_density_threshold = 1.0e0
 problem.max_tagging_radius = 0.75e0
-problem.roche_tagging_factor = 2.0e0
 
 problem.bulk_velx = 0.0e0
 problem.bulk_vely = 0.0e0

--- a/Exec/science/wdmerger/problem_tagging.H
+++ b/Exec/science/wdmerger/problem_tagging.H
@@ -21,82 +21,22 @@ void problem_tagging(int i, int j, int k,
     loc[2] = problo[2] + (static_cast<Real>(k) + 0.5_rt) * dx[2];
 #endif
 
-    if (level < problem::max_stellar_tagging_level) {
+    // Clear all tagging that occurs outside the radius set by max_tagging_radius.
 
-        if (problem::problem == 0 || problem::problem == 2) {
+    Real r = std::sqrt((loc[0] - problem::center[0]) * (loc[0] - problem::center[0]) +
+                       (loc[1] - problem::center[1]) * (loc[1] - problem::center[1]) +
+                       (loc[2] - problem::center[2]) * (loc[2] - problem::center[2]));
 
-            // For the collision, free-fall, and TDE problems, we just want to tag every
-            // zone that meets the density criterion; we don't want to bother with
-            // the Roche lobe radius as that doesn't mean much in these cases.
+    Real max_dist_lo = 0.0;
+    Real max_dist_hi = 0.0;
 
-            if (state(i,j,k,URHO) > problem::stellar_density_threshold) {
+    for (int dim = 0; dim < AMREX_SPACEDIM; ++dim) {
+        max_dist_lo = amrex::max(max_dist_lo, std::abs(problo[dim] - problem::center[dim]));
+        max_dist_hi = amrex::max(max_dist_hi, std::abs(probhi[dim] - problem::center[dim]));
+    }
 
-                tag(i,j,k) = TagBox::SET;
-
-            }
-
-        }
-        else {
-
-            if (level == 0) {
-
-                // On the coarse grid, tag all regions within the Roche radii of each star.
-                // We'll add a buffer around each star to double the Roche
-                // radius to ensure there aren't any sharp gradients in regions of
-                // greater than ambient density.
-
-                Real r_P = std::sqrt((loc[0] - problem::com_P[0]) * (loc[0] - problem::com_P[0]) +
-                                     (loc[1] - problem::com_P[1]) * (loc[1] - problem::com_P[1]) +
-                                     (loc[2] - problem::com_P[2]) * (loc[2] - problem::com_P[2]));
-
-                Real r_S = std::sqrt((loc[0] - problem::com_S[0]) * (loc[0] - problem::com_S[0]) +
-                                     (loc[1] - problem::com_S[1]) * (loc[1] - problem::com_S[1]) +
-                                     (loc[2] - problem::com_S[2]) * (loc[2] - problem::com_S[2]));
-
-                if (r_P <= problem::roche_tagging_factor * problem::roche_rad_P) {
-                    tag(i,j,k) = TagBox::SET;
-                }
-
-                if (r_S <= problem::roche_tagging_factor * problem::roche_rad_S) {
-                    tag(i,j,k) = TagBox::SET;
-                }
-
-            }
-            else if (level >= 1) {
-
-                // On more refined levels, tag all regions within the stars themselves (defined as
-                // areas where the density is greater than some threshold).
-
-                if (state(i,j,k,URHO) > problem::stellar_density_threshold) {
-
-                    tag(i,j,k) = TagBox::SET;
-
-                }
-
-            }
-
-        }
-
-        // Clear all tagging that occurs outside the radius set by max_tagging_radius.
-
-        Real r = std::sqrt((loc[0] - problem::center[0]) * (loc[0] - problem::center[0]) +
-                           (loc[1] - problem::center[1]) * (loc[1] - problem::center[1]) +
-                           (loc[2] - problem::center[2]) * (loc[2] - problem::center[2]));
-
-        Real max_dist_lo = 0.0;
-        Real max_dist_hi = 0.0;
-
-        for (int dim = 0; dim < AMREX_SPACEDIM; ++dim) {
-            max_dist_lo = amrex::max(max_dist_lo, std::abs(problo[dim] - problem::center[dim]));
-            max_dist_hi = amrex::max(max_dist_hi, std::abs(probhi[dim] - problem::center[dim]));
-        }
-
-        if (r > problem::max_tagging_radius * amrex::max(max_dist_lo, max_dist_hi)) {
-
-            tag(i,j,k) = TagBox::CLEAR;
-
-        }
-
+    if (r > problem::max_tagging_radius * amrex::max(max_dist_lo, max_dist_hi)) {
+        tag(i,j,k) = TagBox::CLEAR;
     }
 }
 

--- a/Exec/science/wdmerger/tests/tde/inputs
+++ b/Exec/science/wdmerger/tests/tde/inputs
@@ -15,6 +15,8 @@ amr.n_error_buf = 2 2 2 2 2 2 2 2 2 2
 amr.max_grid_size = 128
 amr.blocking_factor = 32
 
+amr.refine.density.value_greater = 1.0e4
+
 castro.init_shrink = 0.1
 castro.change_max = 1.1
 castro.max_subcycles = 64
@@ -48,5 +50,4 @@ problem.tde_beta = 6.0e0
 
 problem.nsub = 16
 
-problem.max_stellar_tagging_level = 20
 problem.stellar_density_threshold = 1.0e4

--- a/Exec/science/wdmerger/tests/tde/inputs.test
+++ b/Exec/science/wdmerger/tests/tde/inputs.test
@@ -73,6 +73,14 @@ amr.max_grid_size = 32
 # Grid sizes must be a multiple of blocking factor
 amr.blocking_factor = 16
 
+# Add refinement indicators
+amr.refinement_indicators = density
+
+# Density refinement criterion
+amr.refine.density.value_greater = 1.0e4
+amr.refine.density.field_name = density
+amr.refine.density.max_level = 20
+
 ############################################################################################
 # Physics to include
 ############################################################################################
@@ -228,5 +236,4 @@ problem.tde_beta = 6.0e0
 
 problem.nsub = 16
 
-problem.max_stellar_tagging_level = 20
 problem.stellar_density_threshold = 1.0e0

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
@@ -101,6 +101,14 @@ castro.state_interp_order = 0
 # Limiting on state data interpolation (preserve linear combinations)
 castro.lin_limit_state_interp = 1
 
+# Add refinement indicators
+amr.refinement_indicators = density
+
+# Density refinement criterion
+amr.refine.density.value_greater = 1.0e2
+amr.refine.density.field_name = density
+amr.refine.density.max_level = 20
+
 ############################################################################################
 # Physics to include
 ############################################################################################
@@ -379,10 +387,8 @@ problem.orbital_angle = 0.0e0
 problem.axis_1 = 1
 problem.axis_2 = 2
 
-problem.max_stellar_tagging_level = 20
 problem.stellar_density_threshold = 1.0e2
 problem.max_tagging_radius = 0.75e0
-problem.roche_tagging_factor = 2.0e0
 
 problem.center_fracx = 0.5e0
 problem.center_fracy = 0.5e0

--- a/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
+++ b/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
@@ -336,5 +336,3 @@ problem.collision_impact_parameter = 0.0
 
 problem.orbital_eccentricity = 0.0e0
 problem.orbital_angle = 0.0e0
-
-problem.max_stellar_tagging_level = 0

--- a/Exec/science/wdmerger/tests/wdmerger_relaxation/inputs
+++ b/Exec/science/wdmerger/tests/wdmerger_relaxation/inputs
@@ -43,5 +43,4 @@ problem.relaxation_cutoff_time = -1.0e2
 problem.radial_damping_factor = 1.0e-1
 problem.initial_radial_velocity_factor = -1.0e-3
 
-problem.max_stellar_tagging_level = 20
 problem.stellar_density_threshold = 1.0e0

--- a/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
@@ -378,10 +378,8 @@ problem.orbital_angle = 0.0e0
 problem.axis_1 = 1
 problem.axis_2 = 2
 
-problem.max_stellar_tagging_level = 0
 problem.stellar_density_threshold = 1.0e0
 problem.max_tagging_radius = 0.75e0
-problem.roche_tagging_factor = 2.0e0
 
 problem.bulk_velx = 0.0e0
 problem.bulk_vely = 0.0e0


### PR DESCRIPTION

## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
