### PR TITLE
Remove old do_constant_volume_burn from inputs

### DIFF
--- a/Exec/science/wdmerger/inputs
+++ b/Exec/science/wdmerger/inputs
@@ -259,9 +259,6 @@ castro.react_rho_max = 1.0e12
 # Smallest allowable mass fraction
 network.small_x = 1.0e-12
 
-# Burn at constant volume
-integrator.do_constant_volume_burn = 1
-
 # Evaluate the RHS during the burn
 integrator.call_eos_in_rhs = 1
 

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
@@ -220,9 +220,6 @@ castro.react_rho_max = 1.0e12
 # Smallest allowable mass fraction
 network.small_x = 1.0e-12
 
-# Burn at constant volume
-integrator.do_constant_volume_burn = 1
-
 # Evaluate the RHS during the burn
 integrator.call_eos_in_rhs = 1
 

--- a/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
+++ b/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
@@ -206,9 +206,6 @@ castro.react_rho_max = 1.0e12
 # Smallest allowable mass fraction
 network.small_x = 1.0e-12
 
-# Burn at constant volume
-integrator.do_constant_volume_burn = 1
-
 # Evaluate the RHS during the burn
 integrator.call_eos_in_rhs = 1
 

--- a/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
@@ -206,9 +206,6 @@ castro.react_rho_max = 1.0e12
 # Smallest allowable mass fraction
 network.small_x = 1.0e-12
 
-# Burn at constant volume
-integrator.do_constant_volume_burn = 1
-
 # Evaluate the RHS during the burn
 integrator.call_eos_in_rhs = 1
 

--- a/Exec/science/xrb_mixed/inputs_2d
+++ b/Exec/science/xrb_mixed/inputs_2d
@@ -72,7 +72,6 @@ problem.num_vortices = 16
 
 # MICROPHYSICS
 integrator.jacobian = 1
-integrator.do_constant_volume_burn = 0
 
 integrator.call_eos_in_rhs = 0
 


### PR DESCRIPTION

## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
