### PR TITLE
Don't use show_center_of_mass in wdmerger

### DIFF
--- a/Exec/science/wdmerger/inputs
+++ b/Exec/science/wdmerger/inputs
@@ -341,9 +341,6 @@ DistributionMapping.efficiency = 0.9
 # Diagnostics and I/O
 ############################################################################################
 
-# Calculate and print the center of mass at each time step
-castro.show_center_of_mass = 1
-
 # Timesteps between computing and printing volume averaged diagnostic quantities
 castro.sum_interval = 1
 


### PR DESCRIPTION

## PR summary

This is already handled by the diagnostic file output, no need to duplicate.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
