### PR TITLE
Fix multipole BCs now that Fabs default to the device arena

### DIFF
--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -1996,39 +1996,105 @@ Gravity::fill_multipole_BCs(int crse_level, int fine_level, const Vector<MultiFa
 
     // Now, do a global reduce over all processes.
 
+    Real* qL0_ptr = qL0.dataPtr();
+    Real* qLC_ptr = qLC.dataPtr();
+    Real* qLS_ptr = qLS.dataPtr();
+
+    // Create temporary pinned host containers in case we need them.
+
+    FArrayBox qL0_host(The_Pinned_Arena());
+    FArrayBox qLC_host(The_Pinned_Arena());
+    FArrayBox qLS_host(The_Pinned_Arena());
+
     if (!ParallelDescriptor::UseGpuAwareMpi()) {
-        qL0.prefetchToHost();
-        qLC.prefetchToHost();
-        qLS.prefetchToHost();
+        if (The_Arena() == The_Managed_Arena()) {
+            qL0.prefetchToHost();
+            qLC.prefetchToHost();
+            qLS.prefetchToHost();
+        }
+        else if (The_Arena() == The_Device_Arena()) {
+            qL0_host.resize(boxq0);
+            qLC_host.resize(boxqC);
+            qLS_host.resize(boxqS);
+
+            qL0_host.copy<RunOn::Device>(qL0, boxq0);
+            qLC_host.copy<RunOn::Device>(qLC, boxqC);
+            qLS_host.copy<RunOn::Device>(qLS, boxqS);
+
+            qL0_ptr = qL0_host.dataPtr();
+            qLC_ptr = qLC_host.dataPtr();
+            qLS_ptr = qLS_host.dataPtr();
+        }
     }
 
-    ParallelDescriptor::ReduceRealSum(qL0.dataPtr(),boxq0.numPts());
-    ParallelDescriptor::ReduceRealSum(qLC.dataPtr(),boxqC.numPts());
-    ParallelDescriptor::ReduceRealSum(qLS.dataPtr(),boxqS.numPts());
+    Gpu::synchronize();
+
+    ParallelDescriptor::ReduceRealSum(qL0_ptr, boxq0.numPts());
+    ParallelDescriptor::ReduceRealSum(qLC_ptr, boxqC.numPts());
+    ParallelDescriptor::ReduceRealSum(qLS_ptr, boxqS.numPts());
 
     if (!ParallelDescriptor::UseGpuAwareMpi()) {
-        qL0.prefetchToDevice();
-        qLC.prefetchToDevice();
-        qLS.prefetchToDevice();
+        if (The_Arena() == The_Managed_Arena()) {
+            qL0.prefetchToDevice();
+            qLC.prefetchToDevice();
+            qLS.prefetchToDevice();
+        }
+        else if (The_Arena() == The_Device_Arena()) {
+            qL0.copy<RunOn::Device>(qL0_host, boxq0);
+            qLC.copy<RunOn::Device>(qLC_host, boxqC);
+            qLS.copy<RunOn::Device>(qLS_host, boxqS);
+        }
     }
 
     if (boundary_only != 1) {
 
-      if (!ParallelDescriptor::UseGpuAwareMpi()) {
-          qU0.prefetchToHost();
-          qUC.prefetchToHost();
-          qUS.prefetchToHost();
-      }
+        Real* qU0_ptr = qU0.dataPtr();
+        Real* qUC_ptr = qUC.dataPtr();
+        Real* qUS_ptr = qUS.dataPtr();
 
-      ParallelDescriptor::ReduceRealSum(qU0.dataPtr(),boxq0.numPts());
-      ParallelDescriptor::ReduceRealSum(qUC.dataPtr(),boxqC.numPts());
-      ParallelDescriptor::ReduceRealSum(qUS.dataPtr(),boxqS.numPts());
+        FArrayBox qU0_host(The_Pinned_Arena());
+        FArrayBox qUC_host(The_Pinned_Arena());
+        FArrayBox qUS_host(The_Pinned_Arena());
 
-      if (!ParallelDescriptor::UseGpuAwareMpi()) {
-          qU0.prefetchToDevice();
-          qUC.prefetchToDevice();
-          qUS.prefetchToDevice();
-      }
+        if (!ParallelDescriptor::UseGpuAwareMpi()) {
+            if (The_Arena() == The_Managed_Arena()) {
+                qU0.prefetchToHost();
+                qUC.prefetchToHost();
+                qUS.prefetchToHost();
+            }
+            else if (The_Arena() == The_Device_Arena()) {
+                qU0_host.resize(boxq0);
+                qUC_host.resize(boxqC);
+                qUS_host.resize(boxqS);
+
+                qU0_host.copy<RunOn::Device>(qU0, boxq0);
+                qUC_host.copy<RunOn::Device>(qUC, boxqC);
+                qUS_host.copy<RunOn::Device>(qUS, boxqS);
+
+                qU0_ptr = qU0_host.dataPtr();
+                qUC_ptr = qUC_host.dataPtr();
+                qUS_ptr = qUS_host.dataPtr();
+            }
+        }
+
+        Gpu::synchronize();
+
+        ParallelDescriptor::ReduceRealSum(qU0_ptr, boxq0.numPts());
+        ParallelDescriptor::ReduceRealSum(qUC_ptr, boxqC.numPts());
+        ParallelDescriptor::ReduceRealSum(qUS_ptr, boxqS.numPts());
+
+        if (!ParallelDescriptor::UseGpuAwareMpi()) {
+            if (The_Arena() == The_Managed_Arena()) {
+                qU0.prefetchToDevice();
+                qUC.prefetchToDevice();
+                qUS.prefetchToDevice();
+            }
+            else if (The_Arena() == The_Device_Arena()) {
+                qU0.copy<RunOn::Device>(qU0_host, boxq0);
+                qUC.copy<RunOn::Device>(qUC_host, boxqC);
+                qUS.copy<RunOn::Device>(qUS_host, boxqS);
+            }
+        }
 
     }
 


### PR DESCRIPTION

## PR summary

When CUDA-aware MPI is not enabled, we need to stage device data through the host.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
