### PR TITLE
Add a per-zone flattening implementation and use it in PPM

### DIFF
--- a/Source/hydro/Make.package
+++ b/Source/hydro/Make.package
@@ -9,6 +9,7 @@ CEXE_sources += Castro_ctu.cpp
 CEXE_sources += Castro_mol.cpp
 CEXE_headers += advection_util.H
 CEXE_sources += advection_util.cpp
+CEXE_headers += flatten.H
 CEXE_sources += flatten.cpp
 
 ifeq ($(USE_TRUE_SDC),TRUE)

--- a/Source/hydro/flatten.H
+++ b/Source/hydro/flatten.H
@@ -1,0 +1,159 @@
+#ifndef flatten_H
+#define flatten_H
+
+namespace hydro {
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+Real flatten(int i, int j, int k,
+             Array4<Real const> const& q_arr,
+             const int pres_comp)
+{
+    constexpr Real small_pres = 1.e-200_rt;
+
+    // Knobs for detection of strong shock
+    constexpr Real shktst = 0.33_rt;
+    constexpr Real zcut1 = 0.75_rt;
+    constexpr Real zcut2 = 0.85_rt;
+    constexpr Real dzcut = 1.0_rt / (zcut2-zcut1);
+
+    // x-direction flattening coef
+
+    Real dp = q_arr(i+1,j,k,pres_comp) - q_arr(i-1,j,k,pres_comp);
+
+    int ishft = dp > 0.0_rt ? 1 : -1;
+
+    Real denom = amrex::max(small_pres, std::abs(q_arr(i+2,j,k,pres_comp) - q_arr(i-2,j,k,pres_comp)));
+    Real zeta = std::abs(dp) / denom;
+    Real z = amrex::min(1.0_rt, amrex::max(0.0_rt, dzcut * (zeta - zcut1)));
+
+    Real tst = 0.0_rt;
+    if (q_arr(i-1,j,k,QU) - q_arr(i+1,j,k,QU) >= 0.0_rt) {
+      tst = 1.0_rt;
+    }
+
+    Real tmp = amrex::min(q_arr(i+1,j,k,pres_comp), q_arr(i-1,j,k,pres_comp));
+
+    Real chi = 0.0_rt;
+    if (std::abs(dp) > shktst*tmp) {
+      chi = tst;
+    }
+
+
+    dp = q_arr(i+1-ishft,j,k,pres_comp) - q_arr(i-1-ishft,j,k,pres_comp);
+
+    denom = amrex::max(small_pres, std::abs(q_arr(i+2-ishft,j,k,pres_comp)-q_arr(i-2-ishft,j,k,pres_comp)));
+    zeta = std::abs(dp) / denom;
+    Real z2 = amrex::min(1.0_rt, amrex::max(0.0_rt, dzcut * (zeta - zcut1)));
+
+    tst = 0.0_rt;
+    if (q_arr(i-1-ishft,j,k,QU) - q_arr(i+1-ishft,j,k,QU) >= 0.0_rt) {
+      tst = 1.0_rt;
+    }
+
+    tmp = amrex::min(q_arr(i+1-ishft,j,k,pres_comp), q_arr(i-1-ishft,j,k,pres_comp));
+
+    Real chi2 = 0.0_rt;
+    if (std::abs(dp) > shktst*tmp) {
+      chi2 = tst;
+    }
+
+    Real flatn = 1.0_rt - amrex::max(chi2 * z2, chi * z);
+
+
+#if AMREX_SPACEDIM >= 2
+    // y-direction flattening coef
+
+    dp = q_arr(i,j+1,k,pres_comp) - q_arr(i,j-1,k,pres_comp);
+
+    ishft = dp > 0.0_rt ? 1 : -1;
+
+    denom = amrex::max(small_pres, std::abs(q_arr(i,j+2,k,pres_comp) - q_arr(i,j-2,k,pres_comp)));
+    zeta = std::abs(dp) / denom;
+    z = amrex::min(1.0_rt, amrex::max(0.0_rt, dzcut * (zeta - zcut1)));
+
+    tst = 0.0_rt;
+    if (q_arr(i,j-1,k,QV) - q_arr(i,j+1,k,QV) >= 0.0_rt) {
+      tst = 1.0_rt;
+    }
+
+    tmp = amrex::min(q_arr(i,j+1,k,pres_comp), q_arr(i,j-1,k,pres_comp));
+
+    chi = 0.0_rt;
+    if (std::abs(dp) > shktst*tmp) {
+      chi = tst;
+    }
+
+
+    dp = q_arr(i,j+1-ishft,k,pres_comp) - q_arr(i,j-1-ishft,k,pres_comp);
+
+    denom = amrex::max(small_pres, std::abs(q_arr(i,j+2-ishft,k,pres_comp) - q_arr(i,j-2-ishft,k,pres_comp)));
+    zeta = std::abs(dp) / denom;
+    z2 = amrex::min(1.0_rt, amrex::max(0.0_rt, dzcut * (zeta - zcut1)));
+
+    tst = 0.0_rt;
+    if (q_arr(i,j-1-ishft,k,QV) - q_arr(i,j+1-ishft,k,QV) >= 0.0_rt) {
+      tst = 1.0_rt;
+    }
+
+    tmp = amrex::min(q_arr(i,j+1-ishft,k,pres_comp), q_arr(i,j-1-ishft,k,pres_comp));
+
+    chi2 = 0.0_rt;
+    if (std::abs(dp) > shktst*tmp) {
+      chi2 = tst;
+    }
+
+    flatn = amrex::min(flatn, 1.0_rt - amrex::max(chi2 * z2, chi * z));
+#endif
+
+
+#if AMREX_SPACEDIM == 3
+    // z-direction flattening coef
+
+    dp = q_arr(i,j,k+1,pres_comp) - q_arr(i,j,k-1,pres_comp);
+
+    ishft = dp > 0.0_rt ? 1: -1;
+
+    denom = amrex::max(small_pres, std::abs(q_arr(i,j,k+2,pres_comp) - q_arr(i,j,k-2,pres_comp)));
+    zeta = std::abs(dp) / denom;
+    z = amrex::min(1.0_rt, amrex::max(0.0_rt, dzcut * (zeta - zcut1)));
+
+    tst = 0.0_rt;
+    if (q_arr(i,j,k-1,QW) - q_arr(i,j,k+1,QW) >= 0.0_rt) {
+      tst = 1.0_rt;
+    }
+
+    tmp = amrex::min(q_arr(i,j,k+1,pres_comp), q_arr(i,j,k-1,pres_comp));
+
+    chi = 0.0_rt;
+    if (std::abs(dp) > shktst*tmp) {
+      chi = tst;
+    }
+
+
+    dp = q_arr(i,j,k+1-ishft,pres_comp) - q_arr(i,j,k-1-ishft,pres_comp);
+
+    denom = amrex::max(small_pres, std::abs(q_arr(i,j,k+2-ishft,pres_comp) - q_arr(i,j,k-2-ishft,pres_comp)));
+    zeta = std::abs(dp) / denom;
+    z2 = amrex::min(1.0_rt, amrex::max(0.0_rt, dzcut * (zeta - zcut1)));
+
+    tst = 0.0_rt;
+    if (q_arr(i,j,k-1-ishft,QW) - q_arr(i,j,k+1-ishft,QW) >= 0.0_rt) {
+      tst = 1.0_rt;
+    }
+
+    tmp = amrex::min(q_arr(i,j,k+1-ishft,pres_comp), q_arr(i,j,k-1-ishft,pres_comp));
+
+    chi2 = 0.0_rt;
+    if (std::abs(dp) > shktst*tmp) {
+      chi2 = tst;
+    }
+
+    flatn = amrex::min(flatn,  1.0_rt - amrex::max(chi2 * z2, chi * z));
+#endif
+
+    return flatn;
+}
+
+}
+
+#endif

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include <ppm.H>
+#include <flatten.H>
 
 using namespace amrex;
 
@@ -151,7 +152,21 @@ Castro::trace_ppm(const Box& bx,
     // do the parabolic reconstruction and compute the
     // integrals under the characteristic waves
     Real s[5];
-    Real flat = flatn(i,j,k);
+
+    Real flat = 1.0;
+
+    if (castro::first_order_hydro) {
+        flat = 0.0;
+    }
+    else if (castro::use_flattening) {
+#ifdef RADIATION
+        const int pres_comp = QPTOT;
+#else
+        const int pres_comp = QPRES;
+#endif
+        flat = hydro::flatten(i, j, k, q_arr, pres_comp);
+    }
+
     Real sm;
     Real sp;
 

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -159,12 +159,21 @@ Castro::trace_ppm(const Box& bx,
         flat = 0.0;
     }
     else if (castro::use_flattening) {
+        flat = hydro::flatten(i, j, k, q_arr, QPRES);
+
 #ifdef RADIATION
-        const int pres_comp = QPTOT;
-#else
-        const int pres_comp = QPRES;
+        flat *= hydro::flatten(i, j, k, q_arr, QPTOT);
+
+        if (radiation::flatten_pp_threshold > 0.0) {
+            if ( q_arr(i-1,j,k,QU) + q_arr(i,j-1,k,QV) + q_arr(i,j,k-1,QW) >
+                 q_arr(i+1,j,k,QU) + q_arr(i,j+1,k,QV) + q_arr(i,j,k+1,QW) ) {
+
+                if (q_arr(i,j,k,QPRES) < radiation::flatten_pp_threshold * q_arr(i,j,k,QPTOT)) {
+                    flat = 0.0;
+                }
+            }
+        }
 #endif
-        flat = hydro::flatten(i, j, k, q_arr, pres_comp);
     }
 
     Real sm;


### PR DESCRIPTION

## PR summary

This PR adds a header implementation of the flattening routine implemented on a per-zone basis (the existing flattening routine is done on a per-box basis). This new version of the function is used in the hydro instead of the flatn array.

## PR motivation

This aligns with a goal of limiting the total number of temporary Fabs created in the hydro. At the moment, we don't actually get rid of the flatn and flatg arrays, because they will still be needed for PLM, so for the moment we will have duplicative work and redundant memory. (This helps keep the PR short and readable.) But if this PR is valid and merged, we can then do the same thing in PLM in a second PR, and then after that remove the temporary array and the call to uflatten.

In general, our strategy should be to only have temporary Fab data for things that are either (a) used more than once and/or (b) involve accesses to multiple zones in the same array in a stencil-like operation, so that the cost of accessing the data is amortized. As currently implemented the flattening satisfies neither of these properties, it's only used once and the PPM update for a zone only needs the flattening coefficient at that zone.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
