### PR TITLE
if we are using use_retry don't abort in the burner

### DIFF
--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -288,6 +288,10 @@ Castro::variableSetUp ()
   if (!use_retry && !abort_on_failure) {
     amrex::Error("use_retry = 0 and abort_on_failure = F is dangerous and not supported");
   }
+  if (use_retry && abort_on_failure) {
+      amrex::Warning("use_retry = 1, so disabling abort_on_failure");
+      abort_on_failure = 0;
+  }
 #endif
 #endif
 


### PR DESCRIPTION
if abort is set, then we warn and disable it.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
