### PR TITLE
Add parameter for controlling GPU memory footprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # 22.05
 
+   * A new option castro.hydro_memory_footprint_ratio has been added which
+     can help limit the amount of RAM used in GPU builds. (#2153)
+
    * In #1379, for the 21.04 release, Castro added a check that issued
      an abort if any species mass fraction was found to be invalid (defined
      by being less than -0.01 or greater than 1.01). This helps us catch

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # 22.05
 
    * A new option castro.hydro_memory_footprint_ratio has been added which
-     can help limit the amount of RAM used in GPU builds. (#2153)
+     can help limit the amount of memory used in GPU builds. (#2153)
 
    * In #1379, for the 21.04 release, Castro added a check that issued
      an abort if any species mass fraction was found to be invalid (defined

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -1482,6 +1482,7 @@ protected:
     static amrex::IntVect no_tile_size;
 
     static int hydro_tile_size_has_been_tuned;
+    static Long largest_box_from_hydro_tile_size_tuning;
 
     static int SDC_Source_Type;
     static int num_state_type;

--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -1481,6 +1481,8 @@ protected:
     static amrex::IntVect hydro_tile_size;
     static amrex::IntVect no_tile_size;
 
+    static int hydro_tile_size_has_been_tuned;
+
     static int SDC_Source_Type;
     static int num_state_type;
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -134,9 +134,9 @@ IntVect      Castro::hydro_tile_size(1048576,1048576,1048576);
 IntVect      Castro::no_tile_size(1024,1024,1024);
 #endif
 
-// this records whether we have done tuning on the hydro
-// tile size for any options that may require this
+// this records whether we have done tuning on the hydro tile size
 int          Castro::hydro_tile_size_has_been_tuned = 0;
+Long         Castro::largest_box_from_hydro_tile_size_tuning = 0;
 
 // this will be reset upon restart
 Real         Castro::previousCPUTimeUsed = 0.0;

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -134,6 +134,10 @@ IntVect      Castro::hydro_tile_size(1048576,1048576,1048576);
 IntVect      Castro::no_tile_size(1024,1024,1024);
 #endif
 
+// this records whether we have done tuning on the hydro
+// tile size for any options that may require this
+int          Castro::hydro_tile_size_has_been_tuned = 0;
+
 // this will be reset upon restart
 Real         Castro::previousCPUTimeUsed = 0.0;
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -306,13 +306,14 @@ add_sdc_react_source_to_advection  int     1
 # of throughput, set the following parameter to some number greater than 0. This controls
 # the ratio of additional extra memory that can be allocated by the hydro relative to the
 # size of the base state (indirectly, by controlling the hydro tile size and then
-# synchronizing after every tile). Choosing a value only slightly larger than 0 means that
-# you want very little additional memory allocated, and you will take a relatively large
-# performance hit, while choosing a value much greater than 1.0 would result in maximum
-# throughput but also maximum memory footprint. You will likely have to experimentally
-# find a good ratio for your use case, but a ratio around 2.0 - 4.0 is likely to yield a
-# reasonable balance between memory footprint and throughput. Note: the first timestep
-# will be very slow when using this option.
+# synchronizing each time the amount of currently allocated fab memory reaches the
+# target limit). Choosing a value only slightly larger than 0 means that you want very
+# little additional memory allocated, and you will take a relatively large performance
+# hit, while choosing a value much greater than 1.0 would result in maximum throughput
+# but also maximum memory footprint. You will likely have to experimentally find a good
+# ratio for your use case, but a ratio around 2.0 - 4.0 is likely to yield a reasonable
+# balance between memory footprint and throughput. Note: the first timestep will be very
+# slow when using this option.
 hydro_memory_footprint_ratio       real    -1.0
 
 #-----------------------------------------------------------------------------

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -300,6 +300,20 @@ use_axisymmetric_geom_source int           1
 # used in the advective source construction?
 add_sdc_react_source_to_advection  int     1
 
+# In GPU builds, the hydro advance typically results in a large amount of extra
+# temporary memory allocated due to the large tile sizes that are used for computational
+# efficiency. If you want to constrain the code's GPU memory footprint at the expense
+# of throughput, set the following parameter to some number greater than 0. This controls
+# the ratio of additional extra memory that can be allocated by the hydro relative to the
+# size of the base state (indirectly, by controlling the hydro tile size and then
+# synchronizing after every tile). Choosing a value only slightly larger than 0 means that
+# you want very little additional memory allocated, and you will take a relatively large
+# performance hit, while choosing a value much greater than 1.0 would result in maximum
+# throughput but also maximum memory footprint. You will likely have to experimentally
+# find a good ratio for your use case, but a ratio around 2.0 - 4.0 is likely to yield a
+# reasonable balance between memory footprint and throughput. Note: the first timestep
+# will be very slow when using this option.
+hydro_memory_footprint_ratio       real    -1.0
 
 #-----------------------------------------------------------------------------
 # category: timestep control

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -83,9 +83,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
   amrex::Error("USE_OMP=TRUE and USE_GPU=TRUE are not concurrently supported in Castro");
 #endif
 
-  // Set the tile size to a small number if we're about to tune it,
-  // and allow it to grow upward as needed.
-
 #ifdef AMREX_USE_GPU
    if (castro::hydro_memory_footprint_ratio > 0.0) {
        // If we haven't done any tuning yet, set the tile size to an arbitrary

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -88,6 +88,19 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
 #ifdef AMREX_USE_GPU
    if (castro::hydro_memory_footprint_ratio > 0.0) {
+       // If we haven't done any tuning yet, set the tile size to an arbitrary
+       // small value to start with.
+
+       if (hydro_tile_size_has_been_tuned == 0) {
+           hydro_tile_size[0] = 16;
+#if AMREX_SPACEDIM >= 2
+           hydro_tile_size[1] = 16;
+#endif
+#if AMREX_SPACEDIM == 3
+           hydro_tile_size[2] = 16;
+#endif
+       }
+
        // Run through boxes on this level and see if any of them are
        // bigger than the biggest box from our previous tuning. If so,
        // we need to re-compute the tile size.
@@ -98,18 +111,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
            // Also, sum up the number of bytes in the state data.
            mf_size += S_new[mfi].nBytes();
-       }
-
-       if (hydro_tile_size_has_been_tuned == 0) {
-           // Reset hydro tile size to a fairly small value
-           // for the tuning process to work with.
-           hydro_tile_size[0] = 16;
-#if AMREX_SPACEDIM >= 2
-           hydro_tile_size[1] = 16;
-#endif
-#if AMREX_SPACEDIM == 3
-           hydro_tile_size[2] = 16;
-#endif
        }
    }
 #endif


### PR DESCRIPTION

## PR summary

The CTU hydro allocates a lot of temporary Fab data for its computation. This can result in a memory footprint on GPU builds that is significantly higher than the memory of the StateData itself. A new option, castro.hydro_memory_footprint_ratio, is added which can help limit the amount of temporary Fab data active at any one time.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
