### PR TITLE
Add sum_utils variants that operate on MultiFab

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -894,6 +894,16 @@ public:
 ///
 /// Volume weighted sum of given quantity
 ///
+/// @param mf           MultiFab containing quantity
+/// @param comp         integer index of quantity in MultiFab
+/// @param local        boolean, is sum local (over each patch) or over entire MultiFab?
+/// @param finemask     boolean, should we build a mask to exclude finer levels?
+///
+    amrex::Real volWgtSum (const MultiFab& mf, int comp, bool local=false, bool finemask=true);
+
+///
+/// Volume weighted sum of given quantity
+///
 /// @param name         Name of quantity
 /// @param time         current time
 /// @param local        boolean, is sum local (over each patch) or over entire MultiFab?
@@ -901,16 +911,15 @@ public:
 ///
     amrex::Real volWgtSum (const std::string& name, amrex::Real time, bool local=false, bool finemask=true);
 
-
 ///
-/// Volume weight sum of (given quantity) squared
+/// Sum weighted by volume multiplied by distance from center in given direction
 ///
-/// @param name     Name of quantity
-/// @param time     current time
+/// @param mf       MultiFab containing quantity
+/// @param comp     integer index of quantity in MultiFab
+/// @param idir     Axis along which to compute distance from center
 /// @param local    boolean, is sum local (over each patch) or over entire MultiFab?
 ///
-    amrex::Real volWgtSquaredSum (const std::string& name, amrex::Real time, bool local=false);
-
+    amrex::Real locWgtSum (const MultiFab& mf, int comp, int idir, bool local=false);
 
 ///
 /// Sum weighted by volume multiplied by distance from center in given direction
@@ -922,6 +931,16 @@ public:
 ///
     amrex::Real locWgtSum (const std::string& name, amrex::Real time, int idir, bool local=false);
 
+///
+/// Volume weighted sum of the product of two quantities
+///
+/// @param mf1      MultiFab containing first quantity
+/// @param mf2      MultiFab containing second quantity
+/// @param comp1    integer index of quantity in first MultiFab
+/// @param comp2    integer index of quantity in second MultiFab
+/// @param local    boolean, is sum local (over each patch) or over entire MultiFab?
+///
+    amrex::Real volProductSum (const MultiFab& mf1, const MultiFab& mf2, int comp1, int comp2, bool local=false);
 
 ///
 /// Volume weighted sum of the product of two quantities

--- a/Source/driver/sum_integrated_quantities.cpp
+++ b/Source/driver/sum_integrated_quantities.cpp
@@ -412,8 +412,9 @@ Castro::sum_integrated_quantities ()
         // Integrated mass of all species on the domain
 
         for (int lev = 0; lev <= finest_level; ++lev) {
+            MultiFab& S_new = getLevel(lev).get_new_data(State_Type);
             for (int i = 0; i < NumSpec; ++i) {
-                species_mass[i] += getLevel(lev).volWgtSum("rho_" + species_names[i], time, local_flag) / C::M_solar;
+                species_mass[i] += getLevel(lev).volWgtSum(S_new, UFS + i, local_flag) / C::M_solar;
             }
         }
 

--- a/Source/driver/sum_integrated_quantities.cpp
+++ b/Source/driver/sum_integrated_quantities.cpp
@@ -14,8 +14,9 @@ using namespace amrex;
 void
 Castro::sum_integrated_quantities ()
 {
-
     if (verbose <= 0) return;
+
+    BL_PROFILE("Castro::sum_integrated_quantities()");
 
     bool local_flag = true;
 
@@ -51,34 +52,38 @@ Castro::sum_integrated_quantities ()
     for (int lev = 0; lev <= finest_level; lev++)
     {
         Castro& ca_lev = getLevel(lev);
+        MultiFab& S_new = ca_lev.get_new_data(State_Type);
+#ifdef GRAVITY
+        MultiFab& phi_new = ca_lev.get_new_data(PhiGrav_Type);
+#endif
 
-        mass   += ca_lev.volWgtSum("density", time, local_flag);
-        mom[0] += ca_lev.volWgtSum("xmom", time, local_flag);
-        mom[1] += ca_lev.volWgtSum("ymom", time, local_flag);
-        mom[2] += ca_lev.volWgtSum("zmom", time, local_flag);
+        mass   += ca_lev.volWgtSum(S_new, URHO, local_flag);
+        mom[0] += ca_lev.volWgtSum(S_new, UMX, local_flag);
+        mom[1] += ca_lev.volWgtSum(S_new, UMY, local_flag);
+        mom[2] += ca_lev.volWgtSum(S_new, UMZ, local_flag);
 
         ang_mom[0] += ca_lev.volWgtSum("angular_momentum_x", time, local_flag);
         ang_mom[1] += ca_lev.volWgtSum("angular_momentum_y", time, local_flag);
         ang_mom[2] += ca_lev.volWgtSum("angular_momentum_z", time, local_flag);
 
 #ifdef HYBRID_MOMENTUM
-        hyb_mom[0] += ca_lev.volWgtSum("rmom", time, local_flag);
-        hyb_mom[1] += ca_lev.volWgtSum("lmom", time, local_flag);
-        hyb_mom[2] += ca_lev.volWgtSum("zmom", time, local_flag);
+        hyb_mom[0] += ca_lev.volWgtSum(S_new, UMR, time, local_flag);
+        hyb_mom[1] += ca_lev.volWgtSum(S_new, UML, time, local_flag);
+        hyb_mom[2] += ca_lev.volWgtSum(S_new, UMP, time, local_flag);
 #endif
 
         if (show_center_of_mass) {
-           com[0] += ca_lev.locWgtSum("density", time, 0, local_flag);
-           com[1] += ca_lev.locWgtSum("density", time, 1, local_flag);
-           com[2] += ca_lev.locWgtSum("density", time, 2, local_flag);
+           com[0] += ca_lev.locWgtSum(S_new, URHO, 0, local_flag);
+           com[1] += ca_lev.locWgtSum(S_new, URHO, 1, local_flag);
+           com[2] += ca_lev.locWgtSum(S_new, URHO, 2, local_flag);
         }
 
-       rho_e += ca_lev.volWgtSum("rho_e", time, local_flag);
+       rho_e += ca_lev.volWgtSum(S_new, UEINT, local_flag);
        rho_K += ca_lev.volWgtSum("kineng", time, local_flag);
-       rho_E += ca_lev.volWgtSum("rho_E", time, local_flag);
+       rho_E += ca_lev.volWgtSum(S_new, UEDEN, local_flag);
 #ifdef GRAVITY
         if (gravity->get_gravity_type() == "PoissonGrav")
-               rho_phi += ca_lev.volProductSum("density", "phiGrav", time, local_flag);
+            rho_phi += ca_lev.volProductSum(S_new, phi_new, URHO, 0, local_flag);
 #endif
 
     }


### PR DESCRIPTION

## PR summary

This allows us to avoid calling `Derive()` in cases where that's unnecessary because the data is already in StateData.

Also, volWgtSquaredSum is removed since that appeared to be unused.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [x] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
