### PR TITLE
Add new advecting white dwarf problem setup

### DIFF
--- a/Exec/gravity_tests/advecting_white_dwarf/GNUmakefile
+++ b/Exec/gravity_tests/advecting_white_dwarf/GNUmakefile
@@ -1,0 +1,29 @@
+PRECISION ?= DOUBLE
+PROFILE ?= FALSE
+
+DEBUG ?= FALSE
+BACKTRACE ?= FALSE
+TEST ?= FALSE
+
+USE_MPI ?= TRUE
+USE_OMP ?= FALSE
+
+DIM ?= 3
+
+USE_GRAV ?= TRUE
+
+USE_CXX_MODEL_PARSER = TRUE
+NUM_MODELS = 1
+
+COMP ?= gnu
+
+EOS_DIR ?= helmholtz
+
+NETWORK_DIR ?= aprox13
+
+PROBLEM_DIR ?= $(CASTRO_HOME)/Exec/gravity_tests/advecting_white_dwarf
+
+Blocs = $(PROBLEM_DIR)
+Bpack = $(PROBLEM_DIR)/Make.package
+
+include $(CASTRO_HOME)/Exec/Make.Castro

--- a/Exec/gravity_tests/advecting_white_dwarf/_prob_params
+++ b/Exec/gravity_tests/advecting_white_dwarf/_prob_params
@@ -1,0 +1,6 @@
+# name                          data type             default                  in runtime params?     size
+wd_mass                         real                  1.0e0_rt                 y
+wd_central_density              real                 -1.0e0_rt                 n
+wd_radius                       real                 -1.0e0_rt                 n
+wd_temperature                  real                  1.0e7_rt                 y
+wd_speed                        real                  1.0e8_rt                 y

--- a/Exec/gravity_tests/advecting_white_dwarf/inputs
+++ b/Exec/gravity_tests/advecting_white_dwarf/inputs
@@ -1,0 +1,224 @@
+
+############################## CASTRO INPUTS ###############################################
+
+############################################################################################
+# Geometry
+############################################################################################
+
+# Non-periodic boundary conditions
+geometry.is_periodic = 0 0 0
+
+# Cartesian coordinate system
+geometry.coord_sys = 0
+
+# Lower boundary limits in physical space
+geometry.prob_lo = -2.56e9 -1.28e9 -1.28e9
+
+# Upper boundary limits in physical space
+geometry.prob_hi =  2.56e9  1.28e9  1.28e9
+
+############################################################################################
+# Boundary conditions
+# 0 = Interior           3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+############################################################################################
+
+# Boundary conditions on lo x, y, and z edges
+castro.lo_bc = 2 2 2
+
+# Boundary conditions on hi x, y, and z edges
+castro.hi_bc = 2 2 2
+
+############################################################################################ 
+# Timestepping
+############################################################################################
+
+# Maximum coarse timestep
+max_step = 10000000
+
+# Simulation time to stop at (using the default speed, this should
+# be when the WD crosses half the domain)
+stop_time = 25.6
+
+# CFL number for hyperbolic system
+castro.cfl = 0.8
+
+# Scale back initial timestep by this factor
+castro.init_shrink = 0.01
+
+# Factor by which dt is allowed to change each timestep
+castro.change_max = 1.25
+
+# If we regrid on Level 0, compute a new timestep afterward
+amr.compute_new_dt_on_regrid = 1
+
+############################################################################################ 
+# Resolution, gridding and AMR
+############################################################################################
+
+# Number of cells on the coarse grid
+amr.n_cell = 128 64 64
+
+# Maximum level number allowed
+amr.max_level = 0
+
+# Refinement ratio
+amr.ref_ratio = 4
+
+# How many coarse timesteps between regridding
+amr.regrid_int = 2
+
+# Number of buffer cells in error estimation
+amr.n_error_buf = 2
+
+# Maximum grid size at each level
+amr.max_grid_size = 64
+
+# Grid sizes must be a multiple of blocking factor
+amr.blocking_factor = 16
+
+# Add refinement indicators
+amr.refinement_indicators = density
+
+# Density refinement criterion
+amr.refine.density.value_greater = 1.0e3
+amr.refine.density.field_name = density
+amr.refine.density.max_level = 20
+
+############################################################################################
+# Physics to include
+############################################################################################
+
+# Whether or not to do hydrodynamics
+castro.do_hydro = 1
+
+# Whether or not to do gravity
+castro.do_grav = 1
+
+# Whether or not to apply the sponge
+castro.do_sponge = 1
+
+############################################################################################
+# PPM/Hydro options
+############################################################################################
+
+# Use a lagged predictor estimate of the source terms in the hydro
+castro.source_term_predictor = 1
+
+# Reset (rho*e) if it goes negative in the transverse terms
+castro.transverse_reset_rhoe = 1
+
+# Reset rho if it goes negative in the transverse terms
+castro.transverse_reset_density = 1
+
+# Explicitly limit fluxes to avoid hitting a negative density
+castro.limit_fluxes_on_small_dens = 1
+
+############################################################################################
+# Thermodynamics
+############################################################################################
+
+# Minimum allowable temperature (K)
+castro.small_temp = 1.e5
+
+# Minimum allowable density (g / cm**3)
+castro.small_dens = 1.e-5
+
+# Ambient temperature (K)
+castro.ambient_temp = 1.0e7
+
+# Ambient density (g / cm**3)
+castro.ambient_density = 1.0e-4
+
+# Clamp temperature in ambient zones to its initial value
+castro.clamp_ambient_temp = 1
+
+# Smallest allowable mass fraction
+network.small_x = 1.0e-12
+
+############################################################################################
+# Gravity
+############################################################################################
+
+# Full self-gravity with the Poisson equation
+gravity.gravity_type = PoissonGrav
+
+# Multipole expansion includes terms up to r**(-max_multipole_order)
+gravity.max_multipole_order = 6
+
+# Tolerance for multigrid solver for phi solves
+gravity.abs_tol = 1.e-10
+
+# Use sync solve for gravity after refluxing
+gravity.no_sync = 0
+
+# Disable the use of the lagged composite correction for the potential
+gravity.do_composite_phi_correction = 0
+
+# Track the moving center of the problem
+castro.moving_center = 1
+
+############################################################################################
+# Sponge
+############################################################################################
+
+castro.sponge_lower_density = 1.0e0
+castro.sponge_upper_density = 1.0e0
+castro.sponge_timescale     = 0.01e0
+
+############################################################################################
+# Diagnostics and I/O
+############################################################################################
+
+# Name the job
+castro.job_name = advecting_white_dwarf
+
+# Verbosity
+amr.v = 1
+castro.v = 1
+
+# Whether or not to output plotfiles
+amr.plot_files_output = 1
+
+# Whether or not to output checkpoints
+amr.checkpoint_files_output = 1
+
+# Root name of checkpoint files
+amr.check_file = chk
+
+# Simulation time between checkpoints
+amr.check_per = 1.0
+
+# Number of timesteps between checkpoints
+amr.check_int = -1
+
+# Root name of plot files
+amr.plot_file = plt
+
+# Simulation time between plotfiles
+amr.plot_per = 1.0
+
+# Number of timesteps between plotfiles
+amr.plot_int = -1
+
+# Root name of small plot files
+amr.small_plot_file = smallplt
+
+# Simulation time between small plotfiles
+amr.small_plot_per = 0.1
+
+# Number of timesteps between small plotfiles
+amr.small_plot_int = -1
+
+# How often to check whether the run script asked for a checkpoint dump
+amr.message_int = 1
+
+# State variables to add to plot files
+amr.plot_vars = ALL
+
+# Derived variables to add to plot files
+amr.derive_plot_vars = NONE
+
+# State variables to add to small plot files
+amr.small_plot_vars = density Temp

--- a/Exec/gravity_tests/advecting_white_dwarf/inputs
+++ b/Exec/gravity_tests/advecting_white_dwarf/inputs
@@ -178,6 +178,9 @@ castro.job_name = advecting_white_dwarf
 amr.v = 1
 castro.v = 1
 
+# Sum interval
+castro.sum_interval = 1
+
 # Whether or not to output plotfiles
 amr.plot_files_output = 1
 

--- a/Exec/gravity_tests/advecting_white_dwarf/problem_initialize.H
+++ b/Exec/gravity_tests/advecting_white_dwarf/problem_initialize.H
@@ -1,0 +1,70 @@
+#ifndef problem_initialize_H
+#define problem_initialize_H
+
+#include <fundamental_constants.H>
+#include <model_parser.H>
+#include <ambient.H>
+
+AMREX_INLINE
+void problem_initialize ()
+{
+    // Set the center (where the star will start) to be along the
+    // x-axis, halfway to the left edge.
+
+    const Geometry& dgeom = DefaultGeometry();
+
+    const Real* problo = dgeom.ProbLo();
+    const Real* probhi = dgeom.ProbHi();
+
+    problem::center[0] = problo[0] + 0.25_rt * (probhi[0] - problo[0]);
+    problem::center[1] = 0.0_rt;
+    problem::center[2] = 0.0_rt;
+
+    // Arbitrarily set the composition of the star to 50/50 C/O.
+
+    Real core_comp[NumSpec] = {0.0_rt};
+    core_comp[Species::C12] = 0.5_rt;
+    core_comp[Species::O16] = 0.5_rt;
+
+    Real envelope_comp[NumSpec] = {0.0_rt};
+    envelope_comp[Species::C12] = 0.5_rt;
+    envelope_comp[Species::O16] = 0.5_rt;
+
+    Real envelope_mass = 0.0_rt;
+
+    Real initial_model_dx = 1.0e6_rt;
+
+    // Generate the WD model.
+
+    problem::wd_mass *= C::M_solar;
+
+    establish_hse(problem::wd_mass, problem::wd_central_density, problem::wd_radius,
+                  core_comp, problem::wd_temperature, initial_model_dx,
+                  envelope_mass, envelope_comp, 0);
+
+    problem::wd_mass /= C::M_solar;
+
+    amrex::Print() << std::endl;
+
+    amrex::Print() << "Generated initial model for WD of mass " << std::setprecision(3) << problem::wd_mass
+                   << " solar masses, central density " << std::setprecision(3) << std::scientific << problem::wd_central_density
+                   << " g cm**-3, and radius " << std::setprecision(3) << std::scientific << problem::wd_radius << " cm."
+                   << std::endl << std::endl;
+
+    // Safety check: make sure the star is actually inside the computational domain.
+
+    if ((0.5_rt * (probhi[0] - problo[0]) < problem::wd_radius) ||
+        (0.5_rt * (probhi[1] - problo[1]) < problem::wd_radius) ||
+        (0.5_rt * (probhi[2] - problo[2]) < problem::wd_radius))
+    {
+        amrex::Error("WD does not fit inside the domain.");
+    }
+
+    // Set ambient state composition.
+
+    for (int n = 0; n < NumSpec; ++n) {
+        ambient::ambient_state[UFS+n] = ambient::ambient_state[URHO] * envelope_comp[n];
+    }
+}
+
+#endif

--- a/Exec/gravity_tests/advecting_white_dwarf/problem_initialize_state_data.H
+++ b/Exec/gravity_tests/advecting_white_dwarf/problem_initialize_state_data.H
@@ -1,0 +1,58 @@
+#ifndef problem_initialize_state_data_H
+#define problem_initialize_state_data_H
+
+#include <model_parser.H>
+#include <ambient.H>
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void problem_initialize_state_data (int i, int j, int k,
+                                    Array4<Real> const& state,
+                                    const GeometryData& geomdata)
+{
+    GpuArray<Real, 3> loc;
+    position(i, j, k, geomdata, loc);
+
+    Real pos[3];
+    for (int n = 0; n < 3; ++n) {
+        pos[n] = loc[n] - problem::center[n];
+    }
+
+    Real dist = std::sqrt(pos[0] * pos[0] + pos[1] * pos[1] + pos[2] * pos[2]);
+
+    const Real* dx = geomdata.CellSize();
+
+    eos_t zone_state;
+
+    if (dist < problem::wd_radius) {
+        int nsub = 1;
+        zone_state.rho = interpolate_3d(pos, dx, model::idens, nsub, 0);
+        zone_state.T   = interpolate_3d(pos, dx, model::itemp, nsub, 0);
+        for (int n = 0; n < NumSpec; ++n) {
+            zone_state.xn[n] = interpolate_3d(pos, dx, model::ispec + n, nsub, 0);
+        }
+
+        eos(eos_input_rt, zone_state);
+    }
+    else {
+        zone_state.rho = ambient::ambient_state[URHO];
+        zone_state.T   = ambient::ambient_state[UTEMP];
+        zone_state.e   = ambient::ambient_state[UEINT] / ambient::ambient_state[URHO];
+        for (int n = 0; n < NumSpec; ++n) {
+            zone_state.xn[n] = ambient::ambient_state[UFS+n] / ambient::ambient_state[URHO];
+        }
+    }
+
+    state(i,j,k,URHO)  = zone_state.rho;
+    state(i,j,k,UMX)   = problem::wd_speed;
+    state(i,j,k,UMY)   = 0.0_rt;
+    state(i,j,k,UMZ)   = 0.0_rt;
+    state(i,j,k,UTEMP) = zone_state.T;
+    state(i,j,k,UEINT) = zone_state.e * zone_state.rho;
+    state(i,j,k,UEDEN) = zone_state.e * zone_state.rho +
+                         0.5_rt * state(i,j,k,URHO) * problem::wd_speed * problem::wd_speed;
+    for (int n = 0; n < NumSpec; ++n) {
+        state(i,j,k,UFS+n) = zone_state.rho * zone_state.xn[n];
+    }
+}
+
+#endif

--- a/Exec/gravity_tests/advecting_white_dwarf/problem_initialize_state_data.H
+++ b/Exec/gravity_tests/advecting_white_dwarf/problem_initialize_state_data.H
@@ -43,7 +43,7 @@ void problem_initialize_state_data (int i, int j, int k,
     }
 
     state(i,j,k,URHO)  = zone_state.rho;
-    state(i,j,k,UMX)   = problem::wd_speed;
+    state(i,j,k,UMX)   = zone_state.rho * problem::wd_speed;
     state(i,j,k,UMY)   = 0.0_rt;
     state(i,j,k,UMZ)   = 0.0_rt;
     state(i,j,k,UTEMP) = zone_state.T;


### PR DESCRIPTION

## PR summary

In this problem setup, a white dwarf is placed on a grid at a uniform translation velocity along the x-axis. The purpose of the problem is to study how well HSE is maintained in the advecting star, and also to understand the numerical issues at the edges of the star when it is moving at non-trivial speed relative to the domain. This is similar to the problem posed in Section 4.3.2 of [Katz et al. (2016)](https://arxiv.org/abs/1512.06099), which at the time was implemented as a variant of the wdmerger problem setup.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
