### PR TITLE
Revert to managed memory for radiation builds

### DIFF
--- a/Source/driver/main.cpp
+++ b/Source/driver/main.cpp
@@ -35,10 +35,12 @@ amrex::LevelBld* getLevelBld ();
 void override_parameters ()
 {
     ParmParse pp("amrex");
+#ifndef RADIATION // Radiation is not yet ready to stop using managed memory
     if (!pp.contains("the_arena_is_managed")) {
         // Use device memory allocations, not managed memory.
         pp.add("the_arena_is_managed", false);
     }
+#endif
     if (!pp.contains("abort_on_out_of_gpu_memory")) {
         // Abort if we run out of GPU memory.
         pp.add("abort_on_out_of_gpu_memory", true);


### PR DESCRIPTION

## PR summary

The GPU build of radiation isn't ready to avoid managed memory yet (there are still some Fab operations which explicitly run on the host).

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
