### PR TITLE
Remove state_in_rotating_frame parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 22.06
+
+   * The option castro.state_in_rotating_frame has been removed. The default
+     behavior continues to be that when rotation is being used, fluid variables
+     are measured with respect to the rotating frame. (#2172)
+
 # 22.05
 
    * A new option castro.hydro_memory_footprint_ratio has been added which

--- a/Docs/source/rotation.rst
+++ b/Docs/source/rotation.rst
@@ -68,9 +68,6 @@ The main parameters that affect rotation are:
    include the forcing from the time derivative of the rotation
    frequency (default: 1)
 
--  ``castro.state_in_rotating_frame`` : whether state
-   variables are measured in the rotating frame (default: 1)
-
 -  ``castro.rot_source_type`` : method of updating the
    energy during a rotation update (default: 4)
 

--- a/Exec/hydro_tests/rotating_torus/problem_initialize_state_data.H
+++ b/Exec/hydro_tests/rotating_torus/problem_initialize_state_data.H
@@ -78,7 +78,7 @@ void problem_initialize_state_data (int i, int j, int k,
     }
 
     GpuArray<Real, 3> vel = {0.0};
-    if (rho > problem::ambient_density && (do_rotation == 0 || (do_rotation == 1 && state_in_rotating_frame == 0))) {
+    if (rho > problem::ambient_density && do_rotation == 0) {
         cross_product(omega, loc, vel);
     }
 

--- a/Exec/science/wdmerger/inputs
+++ b/Exec/science/wdmerger/inputs
@@ -315,9 +315,6 @@ gravity.do_composite_phi_correction = 0
 # Rotational period of the rotating reference frame
 castro.rotational_period = 100.0
 
-# Whether to evolve state variables in the inertial or rotating frame
-castro.state_in_rotating_frame = 1
-
 ############################################################################################
 # Sponge
 ############################################################################################

--- a/Exec/science/wdmerger/problem_initialize_state_data.H
+++ b/Exec/science/wdmerger/problem_initialize_state_data.H
@@ -134,7 +134,7 @@ void problem_initialize_state_data (int i, int j, int k,
 
     // If we're in the inertial reference frame, use rigid body rotation with velocity omega x r.
 
-    if (((castro::do_rotation != 1) || ((castro::do_rotation == 1) && (castro::state_in_rotating_frame != 1))) && (problem::problem == 1)) {
+    if (castro::do_rotation != 1 && problem::problem == 1) {
 
         GpuArray<Real, 3> rot_loc = {loc[0], loc[1], loc[2]};
 

--- a/Exec/science/wdmerger/problem_source.H
+++ b/Exec/science/wdmerger/problem_source.H
@@ -63,18 +63,6 @@ void problem_source (int i, int j, int k,
             mom[dir] = state(i,j,k,UMX+dir);
         }
 
-#ifdef ROTATION
-        if (do_rotation == 1 && state_in_rotating_frame == 0) {
-            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                vel[dir] = rhoInv * mom[dir];
-            }
-            inertial_to_rotational_velocity(i, j, k, geomdata, time, vel);
-            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                mom[dir] = state(i,j,k,URHO) * vel[dir];
-            }
-        }
-#endif
-
         for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
             Sr[dir] = mom[dir] * damping_factor;
             src(i,j,k,UMX+dir) += Sr[dir];

--- a/Exec/science/wdmerger/tests/wdmerger_relaxation/inputs
+++ b/Exec/science/wdmerger/tests/wdmerger_relaxation/inputs
@@ -13,7 +13,6 @@ amr.max_grid_size = 128
 amr.blocking_factor = 16
 
 castro.do_rotation = 1
-castro.state_in_rotating_frame = 1
 
 amr.check_int = -1
 amr.check_per = -1.0

--- a/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
@@ -245,9 +245,6 @@ gravity.no_sync = 0
 # Rotational period of the rotating reference frame
 castro.rotational_period = 100.0
 
-# Whether to evolve state variables in the inertial or rotating frame
-castro.state_in_rotating_frame = 1
-
 ############################################################################################
 # Sponge
 ############################################################################################

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -411,14 +411,6 @@ Castro::read_params ()
         amrex::Error();
       }
 
-#ifdef ROTATION
-    if (dgeom.IsRZ() && state_in_rotating_frame == 0 && use_axisymmetric_geom_source)
-    {
-        std::cerr << "use_axisymmetric_geom_source is not compatible with state_in_rotating_frame=0\n";
-        amrex::Error();
-    }
-#endif
-
     // Make sure not to call refluxing if we're not actually doing any hydro.
     if (do_hydro == 0) {
       do_reflux = 0;

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -483,14 +483,6 @@ rotation_include_centrifugal int           1                  n        ROTATION
 # permits the Coriolis terms in the rotation to be turned on and off
 rotation_include_coriolis    int           1                  n        ROTATION
 
-# Which reference frame to measure the state variables with respect to.
-# The standard in the literature when using a rotating reference frame
-# is to measure the state variables with respect to an observer fixed
-# in that rotating frame. If this option is disabled by setting it to 0,
-# the state variables will be measured with respect to an observer fixed
-# in the inertial frame (but the frame will still rotate).
-state_in_rotating_frame     int           1                  n        ROTATION
-
 # determines how the rotation source terms are added to the momentum and
 # energy equations
 rot_source_type              int           4                  n        ROTATION

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -34,10 +34,6 @@ Castro::estdt_cfl(const Real time)
 
   // Courant-condition limited timestep
 
-#ifdef ROTATION
-  GeometryData geomdata = geom.data();
-#endif
-
   const auto dx = geom.CellSizeArray();
 
   ReduceOps<ReduceOpMin> reduce_op;
@@ -80,21 +76,6 @@ Castro::estdt_cfl(const Real time)
       Real ux = u(i,j,k,UMX) * rhoInv;
       Real uy = u(i,j,k,UMY) * rhoInv;
       Real uz = u(i,j,k,UMZ) * rhoInv;
-
-#ifdef ROTATION
-      if (castro::do_rotation == 1 && castro::state_in_rotating_frame != 1) {
-        GpuArray<Real, 3> vel;
-        vel[0] = ux;
-        vel[1] = uy;
-        vel[2] = uz;
-
-        inertial_to_rotational_velocity(i, j, k, geomdata, time, vel);
-
-        ux = vel[0];
-        uy = vel[1];
-        uz = vel[2];
-      }
-#endif
 
       Real c = eos_state.cs;
 

--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -39,10 +39,6 @@ Castro::ctoprim(const Box& bx,
                 Array4<Real> const& q_arr,
                 Array4<Real> const& qaux_arr) {
 
-#ifdef ROTATION
-  GeometryData geomdata = geom.data();
-#endif
-
   amrex::ParallelFor(bx,
   [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
   {
@@ -91,24 +87,6 @@ Castro::ctoprim(const Box& bx,
     } else {
       q_arr(i,j,k,QREINT) = uin(i,j,k,UEINT) * rhoinv;
     }
-
-    // If we're advecting in the rotating reference frame,
-    // then subtract off the rotation component here.
-
-#ifdef ROTATION
-    if (castro::do_rotation == 1 && castro::state_in_rotating_frame != 1) {
-      GpuArray<Real, 3> vel;
-      for (int n = 0; n < 3; n++) {
-        vel[n] = uin(i,j,k,UMX+n) * rhoinv;
-      }
-
-      inertial_to_rotational_velocity(i, j, k, geomdata, time, vel);
-
-      q_arr(i,j,k,QU) = vel[0];
-      q_arr(i,j,k,QV) = vel[1];
-      q_arr(i,j,k,QW) = vel[2];
-    }
-#endif
 
     q_arr(i,j,k,QTEMP) = uin(i,j,k,UTEMP);
 #ifdef RADIATION

--- a/Source/hydro/hybrid.H
+++ b/Source/hydro/hybrid.H
@@ -31,11 +31,7 @@ void linear_to_hybrid(const GpuArray<Real, 3>& loc,
     // Note that we expect the linear momentum to be consistent
     // with which frame we're measuring the fluid quantities in.
     // So we're effectively always using the first form of those
-    // equalities, not the second. If state_in_rotating_frame = 1,
-    // then we're not including the centrifugal term in the angular
-    // momentum anyway, and if state_in_rotating_frame = 0, then
-    // the linear momenta are already expressed in the inertial frame,
-    // so we don't need to explicitly take rotation into account.
+    // equalities, not the second.
 
     hybrid_mom[0] = linear_mom[0] * (loc[0] * RInv) + linear_mom[1] * (loc[1] * RInv);
     hybrid_mom[1] = linear_mom[1] * loc[0] - linear_mom[0] * loc[1];

--- a/Source/rotation/Rotation.H
+++ b/Source/rotation/Rotation.H
@@ -50,25 +50,23 @@ rotational_acceleration(GpuArray<Real, 3>& r, GpuArray<Real, 3>& v,
 
   auto omega = get_omega();
 
-  if (castro::state_in_rotating_frame == 1) {
+  // Allow the various terms to be turned off.  This is often used
+  // for diagnostic purposes, but there are genuine science cases
+  // for disabling certain terms in some cases (in particular, when
+  // obtaining a system in rotational equilibrium through a
+  // relaxation process involving damping or sponging, one may want
+  // to turn off the Coriolis force during the relaxation process,
+  // on the basis that the true equilibrium state will have zero
+  // velocity anyway).
 
-    // Allow the various terms to be turned off.  This is often used
-    // for diagnostic purposes, but there are genuine science cases
-    // for disabling certain terms in some cases (in particular, when
-    // obtaining a system in rotational equilibrium through a
-    // relaxation process involving damping or sponging, one may want
-    // to turn off the Coriolis force during the relaxation process,
-    // on the basis that the true equilibrium state will have zero
-    // velocity anyway).
+  bool c1 = (castro::rotation_include_centrifugal == 1) ? true : false;
 
-    bool c1 = (castro::rotation_include_centrifugal == 1) ? true : false;
+  bool c2 = (castro::rotation_include_coriolis == 1 && coriolis) ? true : false;
 
-    bool c2 = (castro::rotation_include_coriolis == 1 && coriolis) ? true : false;
+  GpuArray<Real, 3> omega_cross_v;
+  cross_product(omega, v, omega_cross_v);
 
-    GpuArray<Real, 3> omega_cross_v;
-    cross_product(omega, v, omega_cross_v);
-
-    if (c1) {
+  if (c1) {
       GpuArray<Real, 3> omega_cross_r;
       cross_product(omega, r, omega_cross_r);
 
@@ -76,35 +74,16 @@ rotational_acceleration(GpuArray<Real, 3>& r, GpuArray<Real, 3>& v,
       cross_product(omega, omega_cross_r, omega_cross_omega_cross_r);
 
       for (int idir = 0; idir < 3; idir++) {
-        Sr[idir] -= omega_cross_omega_cross_r[idir];
+          Sr[idir] -= omega_cross_omega_cross_r[idir];
       }
-    }
-
-    if (c2) {
-      for (int idir = 0; idir < 3; idir++) {
-        Sr[idir] -= 2.0_rt * omega_cross_v[idir];
-      }
-    }
-
-  } else {
-
-    // The source term for the momenta when we're not measuring state
-    // variables in the rotating frame is not strictly the traditional
-    // Coriolis force, but we'll still allow it to be disabled with
-    // the same parameter.
-
-    bool c2 = (castro::rotation_include_coriolis == 1 && coriolis) ? true : false;
-
-    if (c2) {
-      GpuArray<Real, 3> omega_cross_v;
-      cross_product(omega, v, omega_cross_v);
-
-      for (int idir = 0; idir < 3; idir++) {
-        Sr[idir] -= omega_cross_v[idir];
-      }
-    }
-
   }
+
+  if (c2) {
+      for (int idir = 0; idir < 3; idir++) {
+          Sr[idir] -= 2.0_rt * omega_cross_v[idir];
+      }
+  }
+
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -118,18 +97,15 @@ rotational_potential(GpuArray<Real, 3>& r) {
 
   auto omega = get_omega();
 
-  if (state_in_rotating_frame == 1) {
-
-    if (rotation_include_centrifugal == 1) {
+  if (rotation_include_centrifugal == 1) {
 
       GpuArray<Real, 3> omega_cross_r;
       cross_product(omega, r, omega_cross_r);
 
       for (int idir = 0; idir < 3; idir++) {
-        phi -= 0.5_rt * omega_cross_r[idir] * omega_cross_r[idir];
+          phi -= 0.5_rt * omega_cross_r[idir] * omega_cross_r[idir];
       }
 
-    }
   }
 
   return phi;


### PR DESCRIPTION

## PR summary

This was an interesting experiment but ultimately did not seem to help too much.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
