### PR TITLE
Remove castro.show_center_of_mass

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # 22.06
 
+   * The option castro.show_center_of_mass has been removed. If castro.v = 1
+     and castro.sum_interval > 0, then the center of mass will automatically
+     be included with the other diagnostic sums that are displayed. (#2176)
+
    * The option castro.state_in_rotating_frame has been removed. The default
      behavior continues to be that when rotation is being used, fluid variables
      are measured with respect to the rotating frame. (#2172)

--- a/Docs/source/Hydrodynamics.rst
+++ b/Docs/source/Hydrodynamics.rst
@@ -568,7 +568,7 @@ There are four major steps in the hydrodynamics update:
 
 #. Doing the conservative update
 
-.. index:: castro.do_hydro, castro.add_ext_src, castro.do_sponge, castro.normalize_species, castro.spherical_star, castro.show_center_of_mass
+.. index:: castro.do_hydro, castro.add_ext_src, castro.do_sponge, castro.normalize_species, castro.spherical_star
 
 Each of these steps has a variety of runtime parameters that
 affect their behavior. Additionally, there are some general
@@ -596,8 +596,6 @@ runtime parameters for hydrodynamics:
    cells that are inside the domain to define a radial function. This
    function is then used to set the values outside the domain in
    implementing the boundary conditions.
-
--  ``castro.show_center_of_mass``: (0 or 1; default: 0)
 
 .. index:: castro.small_dens, castro.small_temp, castro.small_pres
 

--- a/Exec/science/flame/sum_integrated_quantities.cpp
+++ b/Exec/science/flame/sum_integrated_quantities.cpp
@@ -42,11 +42,9 @@ Castro::sum_integrated_quantities ()
       mom[1] += ca_lev.volWgtSum("ymom", time, local_flag);
       mom[2] += ca_lev.volWgtSum("zmom", time, local_flag);
 
-      if (show_center_of_mass) {
-        com[0] += ca_lev.locWgtSum("density", time, 0, local_flag);
-        com[1] += ca_lev.locWgtSum("density", time, 1, local_flag);
-        com[2] += ca_lev.locWgtSum("density", time, 2, local_flag);
-      }
+      com[0] += ca_lev.locWgtSum("density", time, 0, local_flag);
+      com[1] += ca_lev.locWgtSum("density", time, 1, local_flag);
+      com[2] += ca_lev.locWgtSum("density", time, 2, local_flag);
 
       rho_e += ca_lev.volWgtSum("rho_e", time, local_flag);
       rho_K += ca_lev.volWgtSum("kineng", time, local_flag);
@@ -73,8 +71,7 @@ Castro::sum_integrated_quantities ()
 
           ParallelDescriptor::ReduceRealSum(foo, nfoo, ParallelDescriptor::IOProcessorNumber());
 
-          if (show_center_of_mass)
-	    ParallelDescriptor::ReduceRealSum(com, 3, ParallelDescriptor::IOProcessorNumber());
+          ParallelDescriptor::ReduceRealSum(com, 3, ParallelDescriptor::IOProcessorNumber());
 
           ParallelDescriptor::ReduceRealMax(T_max);
           ParallelDescriptor::ReduceRealMin(T_min);
@@ -146,22 +143,19 @@ Castro::sum_integrated_quantities ()
 
 	    }
 
-
-	    if (show_center_of_mass) {
-              for (int i = 0; i <= 2; i++) {
+            for (int i = 0; i <= 2; i++) {
                 com[i]     = com[i] / mass;
                 com_vel[i] = mom[i] / mass;
-              }
+            }
 
-              std::cout << "TIME= " << time << " CENTER OF MASS X-LOC = " << com[0]     << '\n';
-              std::cout << "TIME= " << time << " CENTER OF MASS X-VEL = " << com_vel[0] << '\n';
+            std::cout << "TIME= " << time << " CENTER OF MASS X-LOC = " << com[0]     << '\n';
+            std::cout << "TIME= " << time << " CENTER OF MASS X-VEL = " << com_vel[0] << '\n';
 
-              std::cout << "TIME= " << time << " CENTER OF MASS Y-LOC = " << com[1]     << '\n';
-              std::cout << "TIME= " << time << " CENTER OF MASS Y-VEL = " << com_vel[1] << '\n';
+            std::cout << "TIME= " << time << " CENTER OF MASS Y-LOC = " << com[1]     << '\n';
+            std::cout << "TIME= " << time << " CENTER OF MASS Y-VEL = " << com_vel[1] << '\n';
 
-              std::cout << "TIME= " << time << " CENTER OF MASS Z-LOC = " << com[2]     << '\n';
-              std::cout << "TIME= " << time << " CENTER OF MASS Z-VEL = " << com_vel[2] << '\n';
-	    }
+            std::cout << "TIME= " << time << " CENTER OF MASS Z-LOC = " << com[2]     << '\n';
+            std::cout << "TIME= " << time << " CENTER OF MASS Z-VEL = " << com_vel[2] << '\n';
           }
 #ifdef BL_LAZY
 	});

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
@@ -286,9 +286,6 @@ DistributionMapping.efficiency = 0.9
 # Diagnostics and I/O
 ############################################################################################
 
-# Calculate and print the center of mass at each time step
-castro.show_center_of_mass = 0
-
 # Timesteps between computing and printing volume averaged diagnostic quantities
 castro.sum_interval = 1
 

--- a/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
+++ b/Exec/science/wdmerger/tests/wdmerger_collision_1D/inputs
@@ -243,9 +243,6 @@ castro.sponge_timescale     = 0.01e0
 # Diagnostics and I/O
 ############################################################################################
 
-# Calculate and print the center of mass at each time step
-castro.show_center_of_mass = 1
-
 # Timesteps between computing and printing volume averaged diagnostic quantities
 castro.sum_interval = 1
 

--- a/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
+++ b/Exec/science/wdmerger/tests/wdmerger_retry/inputs_test_wdmerger_retry
@@ -267,9 +267,6 @@ DistributionMapping.efficiency = 0.9
 # Diagnostics and I/O
 ############################################################################################
 
-# Calculate and print the center of mass at each time step
-castro.show_center_of_mass = 1
-
 # Timesteps between computing and printing volume averaged diagnostic quantities
 castro.sum_interval = 1
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -642,9 +642,6 @@ sum_interval                 int           -1
 # how often (simulation time) to compute integral sums (for runtime diagnostics)
 sum_per                      Real          -1.0e0
 
-# display center of mass diagnostics
-show_center_of_mass          int           0
-
 # a string describing the simulation that will be copied into the
 # plotfile's ``job_info`` file
 job_name                     string        "Castro"


### PR DESCRIPTION

## PR summary

The center of mass is now calculated and displayed by default if we're already doing sums. The additional marginal cost of this sum is not high, so we should just simplify the code.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
