### PR TITLE
Add missing volume weighting in locWgtSum

### DIFF
--- a/Source/driver/sum_utils.cpp
+++ b/Source/driver/sum_utils.cpp
@@ -106,6 +106,7 @@ Castro::locWgtSum (const MultiFab& mf, int comp, int idir, bool local)
     for (MFIter mfi(mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
         auto const& fab = mf[mfi].array(comp);
+        auto const& vol = volume.array(mfi);
         auto const& mask = mask_available ? mask_mf.array(mfi) : Array4<Real>{};
     
         const Box& box = mfi.tilebox();
@@ -139,13 +140,13 @@ Castro::locWgtSum (const MultiFab& mf, int comp, int idir, bool local)
             Real ds;
 
             if (idir == 0) { // sum(mass * x)
-                ds = fab(i,j,k) * maskFactor * loc[0];
+                ds = fab(i,j,k) * vol(i,j,k) * maskFactor * loc[0];
             }
             else if (idir == 1) { // sum(mass * y)
-                ds = fab(i,j,k) * maskFactor * loc[1];
+                ds = fab(i,j,k) * vol(i,j,k) * maskFactor * loc[1];
             }
             else { // sum(mass * z)
-                ds = fab(i,j,k) * maskFactor * loc[2];
+                ds = fab(i,j,k) * vol(i,j,k) * maskFactor * loc[2];
             }
 
             return {ds};


### PR DESCRIPTION

## PR summary

This caused the center of mass to be off by a factor of the domain volume. This was correctly observed as a bug by Lupe in #800, but I misunderstood the issue and did not address it at the time.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
