### PR TITLE
Store rotation period in the checkpoint file

### DIFF
--- a/Exec/science/wdmerger/problem_checkpoint.H
+++ b/Exec/science/wdmerger/problem_checkpoint.H
@@ -39,18 +39,6 @@ void problem_checkpoint (std::string checkpoint_dir)
 
 
 
-    std::ofstream rotation;
-    rotation.open(checkpoint_dir + "/Rotation", std::ios::out);
-
-    rotation << std::scientific;
-    rotation.precision(19);
-
-    rotation << std::setw(30) << castro::rotational_period << std::endl;
-
-    rotation.close();
-
-
-
     std::ofstream relaxation;
     relaxation.open(checkpoint_dir + "/Relaxation", std::ios::out);
 

--- a/Exec/science/wdmerger/problem_restart.H
+++ b/Exec/science/wdmerger/problem_restart.H
@@ -24,25 +24,6 @@ void problem_restart (std::string checkpoint_dir)
 
 
 
-    if (problem::problem == 1) {
-
-        std::ifstream rotation;
-        rotation.open(checkpoint_dir + "/Rotation", std::ios::in);
-
-        if (rotation.is_open()) {
-            rotation >> castro::rotational_period;
-            amrex::Print() << "  Based on the checkpoint, updating the rotational period to "
-                           << std::setprecision(7) << std::fixed << castro::rotational_period << " s.\n";
-            rotation.close();
-        }
-        else {
-            castro::rotational_period = -1.0;
-        }
-
-    }
-
-
-
     std::ifstream relaxation;
     relaxation.open(checkpoint_dir + "/Relaxation", std::ios::in);
 

--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -188,6 +188,24 @@ Castro::restart (Amr&     papa,
     }
 #endif
 
+#ifdef ROTATION
+    if (do_rotation && level == 0)
+    {
+        // get current value of the rotation period
+        std::ifstream RotationFile;
+        std::string FullPathRotationFile = parent->theRestartFile();
+        FullPathRotationFile += "/Rotation";
+        RotationFile.open(FullPathRotationFile.c_str(), std::ios::in);
+
+        if (RotationFile.is_open()) {
+            RotationFile >> castro::rotational_period;
+            amrex::Print() << "  Based on the checkpoint, setting the rotational period to "
+                           << std::setprecision(7) << std::fixed << castro::rotational_period << " s.\n";
+            RotationFile.close();
+        }
+    }
+#endif
+
     if (level == 0)
     {
         // get problem-specific stuff -- note all processors do this,
@@ -455,6 +473,23 @@ Castro::checkPoint(const std::string& dir,
 
             PMFile.close();
 
+        }
+#endif
+
+#ifdef ROTATION
+        if (do_rotation) {
+            // store current value of the rotation period
+            std::ofstream RotationFile;
+            std::string FullPathRotationFile = dir;
+            FullPathRotationFile += "/Rotation";
+            RotationFile.open(FullPathRotationFile.c_str(), std::ios::out);
+
+            RotationFile << std::scientific;
+            RotationFile.precision(19);
+
+            RotationFile << std::setw(30) << castro::rotational_period << std::endl;
+
+            RotationFile.close();
         }
 #endif
 


### PR DESCRIPTION

## PR summary

This is upstreamed from wdmerger. For most problems it will have no effect, because most problems don't update the rotation period from the value in the inputs.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
