### PR TITLE
Add a parameter for whether to check dt validity after advance

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -405,12 +405,16 @@ Castro::do_advance_ctu(Real time,
     // whereas in computeNewDt change_max prevents the timestep from growing
     // too much. The same reasoning applies for the other timestep limiters.
 
-    Real new_dt = estTimeStep();
+    if (castro::check_dt_after_advance) {
 
-    if (castro::change_max * new_dt < dt) {
-        status.success = false;
-        status.reason = "timestep validity check failed";
-        return status;
+        Real new_dt = estTimeStep();
+
+        if (castro::change_max * new_dt < dt) {
+            status.success = false;
+            status.reason = "timestep validity check failed";
+            return status;
+        }
+
     }
 
     finalize_do_advance();

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -347,6 +347,9 @@ init_shrink                  Real          1.0
 # on the timestep.
 change_max                   Real          1.1
 
+# whether to check that we took a valid timestep after the advance
+check_dt_after_advance       int           1
+
 # enforce that the AMR plot interval must be hit exactly
 plot_per_is_exact            int           0
 


### PR DESCRIPTION


## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
