### PR TITLE
turn off use_pslope by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
      (castro.ppm_type = 0) implementation.  Since that method is not the
      default, it is unlikely that this has been used.  This change is being
      done to allow for a PPM implementation to be added without changing
-     the default behavior of that method.
+     the default behavior of that method. (#2205)
 
 # 22.05
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@
      behavior continues to be that when rotation is being used, fluid variables
      are measured with respect to the rotating frame. (#2172)
 
+   * The default for use_pslope has been changed to 0 -- disabling this.
+     use_pslope enables reconstruction that knows about HSE for the PLM
+     (castro.ppm_type = 0) implementation.  Since that method is not the
+     default, it is unlikely that this has been used.  This change is being
+     done to allow for a PPM implementation to be added without changing
+     the default behavior of that method.
+
 # 22.05
 
    * A new option castro.hydro_memory_footprint_ratio has been added which

--- a/Exec/gravity_tests/evrard_collapse/inputs
+++ b/Exec/gravity_tests/evrard_collapse/inputs
@@ -21,6 +21,7 @@ castro.hi_bc       =  2   2   2
 castro.do_hydro = 1
 castro.do_grav  = 1
 castro.ppm_type = 0
+castro.use_pslope = 1
 castro.grav_source_type = 4
 
 castro.small_dens = 1.0e-2

--- a/Exec/gravity_tests/evrard_collapse/inputs.test
+++ b/Exec/gravity_tests/evrard_collapse/inputs.test
@@ -21,6 +21,7 @@ castro.hi_bc       =  2   2   2
 castro.do_hydro = 1
 castro.do_grav  = 1
 castro.ppm_type = 0
+castro.use_pslope = 1
 
 castro.small_dens = 1.0e-2
 castro.small_temp = 1.0e0

--- a/Exec/gravity_tests/hse_convergence/convergence_plm.sh
+++ b/Exec/gravity_tests/hse_convergence/convergence_plm.sh
@@ -10,6 +10,7 @@ ofile=plm.converge.out
 
 RUNPARAMS="
 castro.ppm_type=0
+castro.use_pslope=1
 """
 
 ${EXEC} inputs.ppm.64 ${RUNPARAMS} >& 64.out
@@ -35,6 +36,7 @@ ofile=plm-hsereflect.converge.out
 
 RUNPARAMS="
 castro.ppm_type=0
+castro.use_pslope=1
 castro.hse_interp_temp=1
 castro.hse_reflect_vels=1
 """
@@ -90,6 +92,7 @@ ofile=plm-reflect.converge.out
 
 RUNPARAMS="
 castro.ppm_type=0
+castro.use_pslope=1
 castro.lo_bc=3
 castro.hi_bc=3
 """

--- a/Exec/gravity_tests/hse_convergence/convergence_sdc.sh
+++ b/Exec/gravity_tests/hse_convergence/convergence_sdc.sh
@@ -12,6 +12,7 @@ RUNPARAMS="
 castro.time_integration_method=2
 castro.sdc_order=2
 castro.ppm_type=0
+castro.use_pslope=1
 castro.limit_fourth_order=1
 castro.use_reconstructed_gamma1=1
 castro.lo_bc=3
@@ -103,6 +104,7 @@ RUNPARAMS="
 castro.time_integration_method=2
 castro.sdc_order=2
 castro.ppm_type=0
+castro.use_pslope=1
 castro.limit_fourth_order=1
 castro.use_reconstructed_gamma1=1
 """

--- a/Exec/gravity_tests/hse_convergence/inputs.sdc2-pslope-reflect.testsuite
+++ b/Exec/gravity_tests/hse_convergence/inputs.sdc2-pslope-reflect.testsuite
@@ -1,4 +1,4 @@
-pp# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
 max_step = 10000
 stop_time =  0.1
 

--- a/Exec/gravity_tests/hse_convergence/inputs.sdc2-pslope-reflect.testsuite
+++ b/Exec/gravity_tests/hse_convergence/inputs.sdc2-pslope-reflect.testsuite
@@ -1,4 +1,4 @@
-# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+pp# ------------------  INPUTS TO MAIN PROGRAM  -------------------
 max_step = 10000
 stop_time =  0.1
 
@@ -29,6 +29,7 @@ castro.small_temp = 1.e6
 castro.time_integration_method = 2
 castro.sdc_order=2
 castro.ppm_type=0
+castro.use_pslope = 1
 castro.use_reconstructed_gamma1 = 1
 
 castro.grav_source_type = 2

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -158,7 +158,7 @@ dual_energy_eta2             Real          1.0e-4
 # for the piecewise linear reconstruction, do we subtract off :math:`(\rho g)`
 # from the pressure before limiting?  This is a well-balanced method that
 # does well with HSE
-use_pslope                   int           1
+use_pslope                   int           0
 
 # if we are using pslope, below what density to we turn off the well-balanced
 # reconstruction?


### PR DESCRIPTION
this only affects ppm_type = 0, but we will soon extend its functionality
to PPM as well.  Disabling it by default means that the behavior of most
problems will not change.  For the inputs files that use gravity and have
ppm_type = 0 currently, I've explicitly re-enabled it.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
