### PR TITLE
change abundance tolerance to fix mass fraction not summing up to 1

### DIFF
--- a/Exec/science/flame_wave/inputs_He/inputs.He.1000Hz
+++ b/Exec/science/flame_wave/inputs_He/inputs.He.1000Hz
@@ -59,6 +59,7 @@ castro.sponge_upper_density = 1.e2
 castro.sponge_lower_density = 1.e0
 castro.sponge_timescale     = 1.e-7
 
+castro.abundance_failure_tolerance=0.1
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep

--- a/Exec/science/flame_wave/inputs_He/inputs.He.250Hz
+++ b/Exec/science/flame_wave/inputs_He/inputs.He.250Hz
@@ -59,6 +59,7 @@ castro.sponge_upper_density = 1.e2
 castro.sponge_lower_density = 1.e0
 castro.sponge_timescale     = 1.e-7
 
+castro.abundance_failure_tolerance = 0.1
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep

--- a/Exec/science/flame_wave/inputs_He/inputs.He.500Hz
+++ b/Exec/science/flame_wave/inputs_He/inputs.He.500Hz
@@ -59,6 +59,7 @@ castro.sponge_upper_density = 1.e2
 castro.sponge_lower_density = 1.e0
 castro.sponge_timescale     = 1.e-7
 
+castro.abundance_failure_tolerance = 0.1
 # TIME STEP CONTROL
 castro.cfl            = 0.8     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

change the abundance failure tolerance in the input file to 0.1 for the flame wave problem to fix the invalid mass fraction error (mass fraction not summing up to 1). 

## PR motivation

To fix invalid mass fraction error when running flame wave problem.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
