### PR TITLE
[WIP] implement species flattening in PPM tracing

### DIFF
--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -423,23 +423,24 @@ Castro::trace_ppm(const Box& bx,
 
     if (summ - 1.0_rt > abundance_failure_tolerance ||
         sump - 1.0_rt > abundance_failure_tolerance) {
+
         for (int n = 0; n < NumSpec; ++n) {
 
-        if ((idir == 0 && i >= vlo[0]) ||
-            (idir == 1 && j >= vlo[1]) ||
-            (idir == 2 && k >= vlo[2])) {
+            if ((idir == 0 && i >= vlo[0]) ||
+                (idir == 1 && j >= vlo[1]) ||
+                (idir == 2 && k >= vlo[2])) {
 
-            qp(i,j,k,n) =  q_arr(i,j,k,n);
+                qp(i,j,k,n) =  q_arr(i,j,k,n);
+            }
+
+            if (idir == 0 && i <= vhi[0]) {
+                qm(i+1,j,k,n) = q_arr(i,j,k,n);
+            } else if (idir == 1 && j <= vhi[1]) {
+                qm(i,j+1,k,n) = q_arr(i,j,k,n);
+            } else if (idir == 2 && k <= vhi[2]) {
+                qm(i,j,k+1,n) = q_arr(i,j,k,n);
+            }
         }
-
-        if (idir == 0 && i <= vhi[0]) {
-            qm(i+1,j,k,n) = q_arr(i,j,k,n);
-        } else if (idir == 1 && j <= vhi[1]) {
-            qm(i,j+1,k,n) = q_arr(i,j,k,n);
-        } else if (idir == 2 && k <= vhi[2]) {
-            qm(i,j,k+1,n) = q_arr(i,j,k,n);
-        }
-
     }
 
 


### PR DESCRIPTION
if clipping the species to [0, 1] causes them to no longer sum to 1
beyond our tolerance, then flatten the species profiles.  This
ensures that we remain conservative and satisfy sum(X_k) = 1

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
