### PR TITLE
fix PPM use_pslope at the top of an atmosphere

### DIFF
--- a/Exec/science/flame_wave/inputs_He/inputs.He.25cm.static.1000Hz.pslope
+++ b/Exec/science/flame_wave/inputs_He/inputs.He.25cm.static.1000Hz.pslope
@@ -1,0 +1,181 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 250000000
+stop_time =  3.0
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic = 0       0        0
+geometry.prob_lo     = 0       0       0
+
+#if AMREX_SPACEDIM == 3
+  geometry.coord_sys   = 0                  # 0 => cart, 1 => RZ  2=>spherical
+
+  geometry.prob_hi     = 2.048e5      2.048e5    2.56e4
+  amr.n_cell           = 1024         1024        128
+
+  # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+  # 0 = Interior           3 = Symmetry
+  # 1 = Inflow             4 = SlipWall
+  # 2 = Outflow            5 = NoSlipWall
+  # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+  castro.lo_bc       =  2   2   1
+  castro.hi_bc       =  2   2   2
+
+  castro.zl_ext_bc_type = 1
+  castro.hse_interp_temp = 0
+  castro.hse_fixed_temp = 3.e8   # this should match problem.T_star
+  castro.hse_reflect_vels = 1
+
+  castro.fill_ambient_bc = 1
+  castro.ambient_fill_dir = 2
+  castro.ambient_outflow_vel = 1
+
+#elif AMREX_SPACEDIM == 2
+  geometry.coord_sys   = 1                  # 0 => cart, 1 => RZ  2=>spherical
+
+  geometry.prob_hi     = 2.048e5      2.56e4
+  amr.n_cell           = 1024         128
+
+  # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+  # 0 = Interior           3 = Symmetry
+  # 1 = Inflow             4 = SlipWall
+  # 2 = Outflow            5 = NoSlipWall
+  # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+  castro.lo_bc       =  3   3
+  castro.hi_bc       =  2   2
+
+  castro.yl_ext_bc_type = 1
+  castro.hse_interp_temp = 0
+  castro.hse_fixed_temp = 3.e8   # this should match problem.T_star
+  castro.hse_reflect_vels = 1
+
+  castro.fill_ambient_bc = 1
+  castro.ambient_fill_dir = 1
+  castro.ambient_outflow_vel = 1
+
+#endif
+
+castro.domain_is_plane_parallel = 1
+
+# WHICH PHYSICS
+castro.do_hydro = 1
+castro.do_react = 1
+castro.do_rotation = 1
+castro.do_grav = 1
+castro.do_sponge = 1
+
+castro.small_temp = 1.e6
+castro.small_dens = 1.e-5
+
+castro.ppm_type = 1
+castro.grav_source_type = 2
+castro.use_pslope = 1
+castro.pslope_cutoff_density = 1.e4
+
+gravity.gravity_type = ConstantGrav
+gravity.const_grav   = -1.5e14
+
+castro.rotational_period = 0.001
+castro.rotation_include_centrifugal = 0
+
+castro.diffuse_temp = 1
+castro.diffuse_cutoff_density_hi = 5.e4
+castro.diffuse_cutoff_density = 2.e4
+
+castro.diffuse_cond_scale_fac = 1.0
+
+castro.react_rho_min = 1.e2
+castro.react_rho_max = 5.e6
+
+castro.react_T_min = 6.e7
+
+castro.sponge_upper_density = 1.e2
+castro.sponge_lower_density = 1.e0
+castro.sponge_timescale     = 1.e-7
+
+# TIME STEP CONTROL
+castro.cfl            = 0.8     # cfl number for hyperbolic system
+castro.init_shrink    = 0.1     # scale back initial timestep
+castro.change_max     = 1.1     # max time step growth
+
+castro.use_retry      = 1
+castro.max_subcycles = 16
+
+castro.retry_small_density_cutoff = 10.0
+
+castro.abundance_failure_tolerance = 0.1
+castro.abundance_failure_rho_cutoff = 1.0
+
+# DIAGNOSTICS & VERBOSITY
+castro.sum_interval   = 0       # timesteps between computing mass
+castro.v              = 1       # verbosity in Castro.cpp
+amr.v                 = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 2       # maximum level number allowed
+amr.ref_ratio       = 4 2 2 2 # refinement ratio
+amr.regrid_int      = 0       # static grids ftw
+amr.blocking_factor = 32       # block factor in grid generation
+amr.max_grid_size   = 128
+amr.n_error_buf     = 2 2 2 2 # number of buffer cells in error est
+
+# CHECKPOINT FILES
+amr.check_file      = flame_wave_1000Hz_25cm_chk        # root name of checkpoint file
+amr.check_int       = 1000        # number of timesteps between checkpoints
+amr.checkpoint_files_output = 1
+
+# PLOTFILES
+amr.plot_file        = flame_wave_1000Hz_25cm_plt        # root name of plotfile
+amr.plot_per         = 5.e-3      # number of seconds between plotfiles
+amr.derive_plot_vars = ALL
+amr.plot_files_output = 1
+
+amr.small_plot_file        = flame_wave_1000Hz_25cm_smallplt        # root name of plotfile
+amr.small_plot_per         = 5.e-4      # number of seconds between plotfiles
+amr.small_plot_vars = density Temp
+
+#if AMREX_SPACEDIM == 3
+  amr.derive_small_plot_vars = abar magvel enuc
+#elif AMREX_SPACEDIM == 2
+  amr.derive_small_plot_vars = abar x_velocity y_velocity z_velocity enuc
+#endif
+
+fab.format = NATIVE_32
+
+
+# problem initialization
+
+problem.dtemp = 1.1e9
+problem.x_half_max = 4.096e4
+problem.x_half_width = 2048.e0
+
+problem.dx_model = 25.e0
+
+problem.dens_base = 3.43e6
+
+problem.T_star = 3.e8
+problem.T_hi = 3.e8
+problem.T_lo = 8.e6
+
+problem.H_star = 2000.e0
+problem.atm_delta  = 50.0
+
+problem.fuel1_name = "helium-4"
+problem.fuel1_frac = 1.0
+
+problem.ash1_name  = "nickel-56"
+problem.ash1_frac = 1.0
+
+problem.low_density_cutoff = 1.e-4
+
+problem.tag_by_density = 0
+problem.refine_height = 3600.0
+problem.max_base_tagging_level = 3
+
+# Microphysics
+
+integrator.rtol_spec = 1.e-6
+integrator.atol_spec = 1.e-6
+
+network.use_tables = 1
+
+integrator.abort_on_failure = 0

--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -159,7 +159,6 @@ ppm_reconstruct(const Real* s,
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void
 ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const Real flatn,
-                         bool lo_bc_test, bool hi_bc_test,
                          const Real dx,
                          Real& sm, Real& sp) {
 
@@ -183,7 +182,7 @@ ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const 
                  pm2_hse < 0.0;
 
 
-    if (use_pslope && !ptest && rho[i0] >= pslope_cutoff_density) {
+    if (!ptest && rho[i0] >= pslope_cutoff_density) {
 
         // subtract off the hydrostatic pressure
 
@@ -194,16 +193,6 @@ ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const 
 
         tp[im1] = p[im1] - pm1_hse;
         tp[im2] = p[im2] - pm2_hse;
-
-        // if (lo_bc_test && !ptest) {
-        //     tp[im1] = 0.0_rt;  // HSE is perfectly satisfied
-        //     tp[im2] = 0.0_rt;
-        // }
-
-        // if (hi_bc_test && !ptest) {
-        //     tp[ip1] = 0.0_rt;
-        //     tp[ip2] = 0.0_rt;
-        // }
 
     } else {
 
@@ -222,7 +211,7 @@ ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const 
     // now correct sm and sp to be back to the full pressure by
     // adding in the hydrostatic pressure at the interface
 
-    if (use_pslope && !ptest && rho[i0] >= pslope_cutoff_density) {
+    if (!ptest && rho[i0] >= pslope_cutoff_density) {
         sp += p[i0] + 0.5 * dx * rho[i0] * src[i0];
         sm += p[i0] - 0.5 * dx * rho[i0] * src[i0];
     }

--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -178,7 +178,13 @@ ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const 
         Real pm2_hse = pm1_hse - 0.25_rt*dx * (rho[im1] + rho[im2]) * (src[im1] + src[im2]);
 
         // this only makes sense if the pressures are positive
-        if (p0_hse < 0.0 || pp1_hse < 0.0 || pp2_hse < 0.0 || pm1_hse < 0.0 || pm2_hse < 0.0) {
+        bool ptest = p0_hse < 0.0 ||
+                     pp1_hse < 0.0 ||
+                     pp2_hse < 0.0 ||
+                     pm1_hse < 0.0 ||
+                     pm2_hse < 0.0;
+
+        if (ptest) {
             p0_hse = 0.0;
             pp1_hse = 0.0;
             pp2_hse = 0.0;
@@ -188,19 +194,20 @@ ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const 
 
         // subtract off the hydrostatic pressure
 
-        tp[i0] = 0.0_rt;
+        tp[i0] = p[i0] - p0_hse;
+
         tp[ip1] = p[ip1] - pp1_hse;
         tp[ip2] = p[ip2] - pp2_hse;
 
         tp[im1] = p[im1] - pm1_hse;
         tp[im2] = p[im2] - pm2_hse;
 
-        if (lo_bc_test) {
+        if (lo_bc_test && !ptest) {
             tp[im1] = 0.0_rt;  // HSE is perfectly satisfied
             tp[im2] = 0.0_rt;
         }
 
-        if (hi_bc_test) {
+        if (hi_bc_test && !ptest) {
             tp[ip1] = 0.0_rt;
             tp[ip2] = 0.0_rt;
         }

--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -158,9 +158,9 @@ ppm_reconstruct(const Real* s,
 ///
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void
-ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const Real flatn,
-                         const Real dx,
-                         Real& sm, Real& sp) {
+ppm_reconstruct_pslope(const Real* rho, const Real* p, const Real* src, const Real flatn,
+                       const Real dx,
+                       Real& sm, Real& sp) {
 
     Real tp[5];
 

--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -165,32 +165,25 @@ ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const 
 
     Real tp[5];
 
-    if (use_pslope && rho[i0] >= pslope_cutoff_density) {
+    // compute the hydrostatic pressure in each zone center starting with i0
 
-        // compute the hydrostatic pressure in each zone center starting with i0
+    Real p0_hse = p[i0];
 
-        Real p0_hse = p[i0];
+    Real pp1_hse = p0_hse + 0.25_rt*dx * (rho[i0] + rho[ip1]) * (src[i0] + src[ip1]);
+    Real pp2_hse = pp1_hse + 0.25_rt*dx * (rho[ip1] + rho[ip2]) * (src[ip1] + src[ip2]);
 
-        Real pp1_hse = p0_hse + 0.25_rt*dx * (rho[i0] + rho[ip1]) * (src[i0] + src[ip1]);
-        Real pp2_hse = pp1_hse + 0.25_rt*dx * (rho[ip1] + rho[ip2]) * (src[ip1] + src[ip2]);
+    Real pm1_hse = p0_hse - 0.25_rt*dx * (rho[i0] + rho[im1]) * (src[i0] + src[im1]);
+    Real pm2_hse = pm1_hse - 0.25_rt*dx * (rho[im1] + rho[im2]) * (src[im1] + src[im2]);
 
-        Real pm1_hse = p0_hse - 0.25_rt*dx * (rho[i0] + rho[im1]) * (src[i0] + src[im1]);
-        Real pm2_hse = pm1_hse - 0.25_rt*dx * (rho[im1] + rho[im2]) * (src[im1] + src[im2]);
+    // this only makes sense if the pressures are positive
+    bool ptest = p0_hse < 0.0 ||
+                 pp1_hse < 0.0 ||
+                 pp2_hse < 0.0 ||
+                 pm1_hse < 0.0 ||
+                 pm2_hse < 0.0;
 
-        // this only makes sense if the pressures are positive
-        bool ptest = p0_hse < 0.0 ||
-                     pp1_hse < 0.0 ||
-                     pp2_hse < 0.0 ||
-                     pm1_hse < 0.0 ||
-                     pm2_hse < 0.0;
 
-        if (ptest) {
-            p0_hse = 0.0;
-            pp1_hse = 0.0;
-            pp2_hse = 0.0;
-            pm1_hse = 0.0;
-            pm2_hse = 0.0;
-        }
+    if (use_pslope && !ptest && rho[i0] >= pslope_cutoff_density) {
 
         // subtract off the hydrostatic pressure
 
@@ -202,15 +195,16 @@ ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const 
         tp[im1] = p[im1] - pm1_hse;
         tp[im2] = p[im2] - pm2_hse;
 
-        if (lo_bc_test && !ptest) {
-            tp[im1] = 0.0_rt;  // HSE is perfectly satisfied
-            tp[im2] = 0.0_rt;
-        }
+        // if (lo_bc_test && !ptest) {
+        //     tp[im1] = 0.0_rt;  // HSE is perfectly satisfied
+        //     tp[im2] = 0.0_rt;
+        // }
 
-        if (hi_bc_test && !ptest) {
-            tp[ip1] = 0.0_rt;
-            tp[ip2] = 0.0_rt;
-        }
+        // if (hi_bc_test && !ptest) {
+        //     tp[ip1] = 0.0_rt;
+        //     tp[ip2] = 0.0_rt;
+        // }
+
     } else {
 
         // don't subtract off HSE
@@ -228,7 +222,7 @@ ppm_reconstruct_pressure(const Real* rho, const Real* p, const Real* src, const 
     // now correct sm and sp to be back to the full pressure by
     // adding in the hydrostatic pressure at the interface
 
-    if (use_pslope && rho[i0] >= pslope_cutoff_density) {
+    if (use_pslope && !ptest && rho[i0] >= pslope_cutoff_density) {
         sp += p[i0] + 0.5 * dx * rho[i0] * src[i0];
         sm += p[i0] - 0.5 * dx * rho[i0] * src[i0];
     }

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -53,15 +53,6 @@ Castro::trace_ppm(const Box& bx,
 
   const auto dx = geom.CellSizeArray();
 
-  const int* lo_bc = phys_bc.lo();
-  const int* hi_bc = phys_bc.hi();
-
-  bool lo_symm = lo_bc[idir] == Symmetry;
-  bool hi_symm = hi_bc[idir] == Symmetry;
-
-  const auto domlo = geom.Domain().loVect3d();
-  const auto domhi = geom.Domain().hiVect3d();
-
   Real hdt = 0.5_rt * dt;
   Real dtdx = dt / dx[idir];
 
@@ -149,14 +140,6 @@ Castro::trace_ppm(const Box& bx,
   {
 
 
-    bool lo_bc_test = lo_symm && ((idir == 0 && i == domlo[0]) ||
-                                  (idir == 1 && j == domlo[1]) ||
-                                  (idir == 2 && k == domlo[2]));
-
-    bool hi_bc_test = hi_symm && ((idir == 0 && i == domhi[0]) ||
-                                  (idir == 1 && j == domhi[1]) ||
-                                  (idir == 2 && k == domhi[2]));
-
     Real cc = qaux_arr(i,j,k,QC);
 
 #if AMREX_SPACEDIM < 3
@@ -224,13 +207,19 @@ Castro::trace_ppm(const Box& bx,
     Real Im_p[3];
 
     load_stencil(q_arr, idir, i, j, k, QPRES, s);
-    Real trho[5];
-    Real src[5];
 
-    load_stencil(q_arr, idir, i, j, k, QRHO, trho);
-    load_stencil(srcQ, idir, i, j, k, QUN, src);
+    if (use_pslope) {
+        Real trho[5];
+        Real src[5];
 
-    ppm_reconstruct_pressure(trho, s, src, flat, lo_bc_test, hi_bc_test, dx[idir], sm, sp);
+        load_stencil(q_arr, idir, i, j, k, QRHO, trho);
+        load_stencil(srcQ, idir, i, j, k, QUN, src);
+
+        ppm_reconstruct_pressure(trho, s, src, flat, dx[idir], sm, sp);
+
+    } else {
+        ppm_reconstruct(s, flat, sm, sp);
+    }
     ppm_int_profile(sm, sp, s[i0], un, cc, dtdx, Ip_p, Im_p);
 
     // reconstruct rho e

--- a/Source/hydro/trace_ppm.cpp
+++ b/Source/hydro/trace_ppm.cpp
@@ -215,7 +215,7 @@ Castro::trace_ppm(const Box& bx,
         load_stencil(q_arr, idir, i, j, k, QRHO, trho);
         load_stencil(srcQ, idir, i, j, k, QUN, src);
 
-        ppm_reconstruct_pressure(trho, s, src, flat, dx[idir], sm, sp);
+        ppm_reconstruct_pslope(trho, s, src, flat, dx[idir], sm, sp);
 
     } else {
         ppm_reconstruct(s, flat, sm, sp);


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This fixes the reconstruction at the top of the atmosphere where p_hse might go negative.  It also adds an inputs file
for flame_wave that runs with this change and reflecting BCs.

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
