### PR TITLE
Use hydro limiter on negative density in reflux

### DIFF
--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1166,7 +1166,6 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
               limit_hydro_fluxes_on_small_dens
                   (nbx, idir,
                    Sborder.array(mfi),
-                   q.array(),
                    volume.array(mfi),
                    flux[idir].array(),
                    area[idir].array(mfi),

--- a/Source/hydro/Castro_hydro.H
+++ b/Source/hydro/Castro_hydro.H
@@ -763,11 +763,11 @@
     limit_hydro_fluxes_on_small_dens(const amrex::Box& bx,
                                      int idir,
                                      amrex::Array4<amrex::Real const> const& u,
-                                     amrex::Array4<amrex::Real const> const& q,
                                      amrex::Array4<amrex::Real const> const& vol,
                                      amrex::Array4<amrex::Real> const& flux,
                                      amrex::Array4<amrex::Real const> const& area,
-                                     amrex::Real dt);
+                                     amrex::Real dt,
+                                     bool scale_by_dAdt = true);
 
 
 

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -586,7 +586,6 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
                 limit_hydro_fluxes_on_small_dens
                   (nbx, idir,
                    Sborder.array(mfi),
-                   q.array(mfi),
                    volume.array(mfi),
                    flux[idir].array(),
                    area[idir].array(mfi),

--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -519,11 +519,11 @@ void
 Castro::limit_hydro_fluxes_on_small_dens(const Box& bx,
                                          int idir,
                                          Array4<Real const> const& u,
-                                         Array4<Real const> const& q,
                                          Array4<Real const> const& vol,
                                          Array4<Real> const& flux,
-                                         Array4<Real const> const& area_arr,
-                                         Real dt)
+                                         Array4<Real const> const& area,
+                                         Real dt,
+                                         bool scale_by_dAdt)
 {
     // Hu, Adams, and Shu (2013), JCP, 242, 169, "Positivity-preserving method for
     // high-order conservative schemes solving compressible Euler equations," proposes
@@ -572,8 +572,13 @@ Castro::limit_hydro_fluxes_on_small_dens(const Box& bx,
 
         // Coefficients of fluxes on either side of the interface.
 
-        Real flux_coefR = dt * area_arr(i,j,k) / volR;
-        Real flux_coefL = dt * area_arr(i,j,k) / volL;
+        Real flux_coefR = 1.0_rt / volR;
+        Real flux_coefL = 1.0_rt / volL;
+
+        if (scale_by_dAdt) {
+            flux_coefR *= dt * area(i,j,k);
+            flux_coefL *= dt * area(i,j,k);
+        }
 
         // Updates to the zones on either side of the interface.
 


### PR DESCRIPTION


## PR summary

Using a zone-center based limiter in the reflux ends up not working in every case. The flux lives in the cell faces, which means it is dual-valued in MultiFab storage, so both versions of the flux have to be consistent. When looping over cell centers, we might limit the flux in one direction and not another, and if the second one is the one that actually gets applied in the reflux, the limiter will be ignored. So instead we FillPatch the state to add a ghost zone and then apply an edge-based limiter on that state. This PR does it for density and a subsequent PR will apply this to the invalid X check.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
