### PR TITLE
Move to edge-based strategy for invalid X check in reflux

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -2676,86 +2676,47 @@ Castro::reflux(int crse_level, int fine_level)
             auto mask_arr = mask[mfi].array();
 
             // Limit fluxes that would cause a small/negative density.
+            // Also check to see whether the flux would cause invalid X. We use a
+            // safety factor of AMREX_SPACEDIM since multiple fluxes touching the
+            // same zone could be conspiring in the same direction. If we do detect
+            // a case where X would be invalid, we set that flux to zero.
 
             for (int idir = 0; idir < AMREX_SPACEDIM; ++idir) {
+                const Box& nbx = amrex::surroundingNodes(bx, idir);
                 auto F = temp_fluxes[idir][mfi].array();
                 auto A = crse_lev.area[idir][mfi].array();
                 Real dt = parent->dtLevel(crse_level);
                 bool scale_by_dAdt = false;
-                crse_lev.limit_hydro_fluxes_on_small_dens(bx, idir, U, V, F, A, dt, scale_by_dAdt);
+                crse_lev.limit_hydro_fluxes_on_small_dens(nbx, idir, U, V, F, A, dt, scale_by_dAdt);
+
+                amrex::ParallelFor(nbx,
+                                   [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                                   {
+                                       bool zero_fluxes = false;
+
+                                       Real rho = U(i,j,k,URHO);
+                                       Real drho = F(i,j,k,URHO) / V(i,j,k);
+                                       Real rhoInvNew = 1.0_rt / (rho + drho);
+
+                                       for (int n = 0; n < NumSpec; ++n) {
+                                           Real rhoX = U(i,j,k,UFS+n);
+                                           Real drhoX = F(i,j,k,UFS+n) / V(i,j,k);
+                                           Real XNew = (rhoX + AMREX_SPACEDIM * drhoX) * rhoInvNew;
+
+                                           if (XNew < -castro::abundance_failure_tolerance ||
+                                               XNew > 1.0_rt + castro::abundance_failure_tolerance) {
+                                               zero_fluxes = true;
+                                               break;
+                                           }
+                                       }
+
+                                       if (zero_fluxes) {
+                                           for (int n = 0; n < NUM_STATE; ++n) {
+                                               F(i,j,k,n) = 0.0;
+                                           }
+                                       }
+                                   });
             }
-
-            // Loop over zones and check all adjacent fluxes to see whether
-            // the sum of them would cause invalid X.
-            // If so, set all adjacent fluxes to zero. Note that in principle this
-            // could lead to a race condition when this loop runs in parallel, but
-            // in practice this should not be a real issue because any given flux
-            // correction should only be affecting one of the two zones on either
-            // side of its associated zone face; the other zone will be covered by
-            // the fine grid, and we mask out these zones.
-
-            amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                // Skip zones which are covered by the fine grid (these can't be
-                // updated by the reflux).
-
-                if (mask_arr(i,j,k) == 0.0) {
-                    return;
-                }
-
-                bool zero_fluxes = false;
-
-                Real rho = U(i,j,k,URHO);
-                Real drho = F_x(i,j,k,URHO) - F_x(i+1,j,k,URHO);
-#if AMREX_SPACEDIM >= 2
-                drho += F_y(i,j,k,URHO) - F_y(i,j+1,k,URHO);
-#endif
-#if AMREX_SPACEDIM == 3
-                drho += F_z(i,j,k,URHO) - F_z(i,j,k+1,URHO);
-#endif
-                drho /= V(i,j,k);
-
-                if (!zero_fluxes) {
-                    Real rhoInvNew = 1.0_rt / (rho + drho);
-
-                    for (int n = 0; n < NumSpec; ++n) {
-                        Real rhoX = U(i,j,k,UFS+n);
-                        Real drhoX = F_x(i,j,k,UFS+n) - F_x(i+1,j,k,UFS+n);
-#if AMREX_SPACEDIM >= 2
-                        drhoX += F_y(i,j,k,UFS+n) - F_y(i,j+1,k,UFS+n);
-#endif
-#if AMREX_SPACEDIM == 3
-                        drhoX += F_z(i,j,k,UFS+n) - F_z(i,j,k+1,UFS+n);
-#endif
-                        drhoX /= V(i,j,k);
-
-                        Real XNew = (rhoX + drhoX) * rhoInvNew;
-
-                        if (XNew < -castro::abundance_failure_tolerance ||
-                            XNew > 1.0_rt + castro::abundance_failure_tolerance) {
-                            zero_fluxes = true;
-                            break;
-                        }
-                    }
-
-                }
-
-                if (zero_fluxes) {
-                    for (int n = 0; n < NUM_STATE; ++n) {
-                        F_x(i,  j,  k,  n) = 0.0;
-                        F_x(i+1,j,  k,  n) = 0.0;
-#if AMREX_SPACEDIM >= 2
-                        F_y(i,  j,  k,  n) = 0.0;
-                        F_y(i,  j+1,k,  n) = 0.0;
-#endif
-#if AMREX_SPACEDIM == 3
-                        F_z(i,  j,  k,  n) = 0.0;
-                        F_z(i,  j,  k+1,n) = 0.0;
-#endif
-                    }
-                }
-            });
         }
 
         for (int idir = 0; idir < AMREX_SPACEDIM; ++idir) {


### PR DESCRIPTION

## PR summary

This operates in a similar manner to the edge-based flux limiter. Similar to that, we have to use a safety factor of AMREX_SPACEDIM since up to 3 faces could be updating a given zone in the reflux.

Since the new value of X depends on the new value of rho, which will also be affected by the fluxes, it's not clear whether the factor of AMREX_SPACEDIM should also be applied to the denominator when calculating the new X (i.e. whether it should be included in drho). I've chosen not to do that, but perhaps that could be done in a later change.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
