### PR TITLE
Check validity of dt prior to advance

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -68,6 +68,26 @@ Castro::do_advance_ctu(Real time,
 
     check_for_nan(S_old);
 
+    // If we're doing a step later than the first on each level, the fluid
+    // state might have evolved to the point where the AMR timestep could be
+    // significantly too large, but we don't have freedom to adjust the AMR
+    // timestep at that point. Trying to evolve with a dt that is too large
+    // could result in catastrophic behavior such that we don't even get to
+    // the point where we can bail out later in the advance, so let's just
+    // go directly into a retry now if we're too far away from the needed dt.
+
+    if (castro::check_dt_before_advance && amr_iteration > 1) {
+
+        Real old_dt = estTimeStep();
+
+        if (castro::change_max * old_dt < dt) {
+            status.success = false;
+            status.reason = "pre-advance timestep validity check failed";
+            return status;
+        }
+
+    }
+
     // Since we are Strang splitting the reactions, do them now
 
 #ifdef REACTIONS
@@ -411,7 +431,7 @@ Castro::do_advance_ctu(Real time,
 
         if (castro::change_max * new_dt < dt) {
             status.success = false;
-            status.reason = "timestep validity check failed";
+            status.reason = "post-advance timestep validity check failed";
             return status;
         }
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -347,6 +347,9 @@ init_shrink                  Real          1.0
 # on the timestep.
 change_max                   Real          1.1
 
+# whether to check that we will take a valid timestep before the advance
+check_dt_before_advance      int           1
+
 # whether to check that we took a valid timestep after the advance
 check_dt_after_advance       int           1
 


### PR DESCRIPTION

## PR summary

This helps catch issues with subcycling where the AMR advance dt drifts very far away from the current local stable timestep.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
