### PR TITLE
Fix test for pre-advance timestep check

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -548,39 +548,39 @@ public:
 ///
 /// Estimate time step.
 ///
-    amrex::Real estTimeStep ();
+    amrex::Real estTimeStep (int is_new = 1);
 
 
 ///
 /// Compute the CFL timestep
 ///
-    amrex::Real estdt_cfl(const amrex::Real time);
+    amrex::Real estdt_cfl (int is_new = 1);
 
 
 #ifdef MHD
 ///
 /// Compute the CFL timestep
 ///
-    amrex::Real estdt_mhd();
+    amrex::Real estdt_mhd (int is_new = 1);
 #endif
 
 ///
 /// Diffusion-limited timestep
 ///
-    amrex::Real estdt_temp_diffusion();
+    amrex::Real estdt_temp_diffusion (int is_new = 1);
 
 #ifdef REACTIONS
 ///
 /// Reactions-limited timestep
 ///
-    amrex::Real estdt_burning();
+    amrex::Real estdt_burning (int is_new = 1);
 #endif
 
 #ifdef RADIATION
 ///
 /// Radiation hydro timestep
 ///
-    amrex::Real estdt_rad ();
+    amrex::Real estdt_rad (int is_new = 1);
 #endif
 
 ///

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1511,7 +1511,7 @@ Castro::initialTimeStep ()
 }
 
 Real
-Castro::estTimeStep ()
+Castro::estTimeStep (int is_new)
 {
     BL_PROFILE("Castro::estTimeStep()");
 
@@ -1520,8 +1520,6 @@ Castro::estTimeStep ()
     }
 
     Real estdt = max_dt;
-
-    Real time = state[State_Type].curTime();
 
     std::string limiter = "castro.max_dt";
 
@@ -1538,7 +1536,7 @@ Castro::estTimeStep ()
 #ifdef RADIATION
         if (Radiation::rad_hydro_combined) {
 
-            estdt_hydro = estdt_rad();
+            estdt_hydro = estdt_rad(is_new);
 
         }
         else
@@ -1546,9 +1544,9 @@ Castro::estTimeStep ()
 #endif
 
 #ifdef MHD
-          estdt_hydro = estdt_mhd();
+          estdt_hydro = estdt_mhd(is_new);
 #else
-          estdt_hydro = estdt_cfl(time);
+          estdt_hydro = estdt_cfl(is_new);
 #endif
 
 #ifdef RADIATION
@@ -1579,7 +1577,7 @@ Castro::estTimeStep ()
 
     if (diffuse_temp)
     {
-      estdt_diffusion = estdt_temp_diffusion();
+      estdt_diffusion = estdt_temp_diffusion(is_new);
     }
 
     ParallelDescriptor::ReduceRealMin(estdt_diffusion);
@@ -1604,7 +1602,7 @@ Castro::estTimeStep ()
 
         // Compute burning-limited timestep.
 
-        estdt_burn = estdt_burning();
+        estdt_burn = estdt_burning(is_new);
 
         ParallelDescriptor::ReduceRealMin(estdt_burn);
 

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -87,7 +87,8 @@ Castro::do_advance_ctu(Real time,
 
     if (castro::check_dt_before_advance && !is_first_step_on_this_level) {
 
-        Real old_dt = estTimeStep();
+        int is_new = 0;
+        Real old_dt = estTimeStep(is_new);
 
         if (castro::change_max * old_dt < dt) {
             status.success = false;
@@ -436,7 +437,8 @@ Castro::do_advance_ctu(Real time,
 
     if (castro::check_dt_after_advance) {
 
-        Real new_dt = estTimeStep();
+        int is_new = 1;
+        Real new_dt = estTimeStep(is_new);
 
         if (castro::change_max * new_dt < dt) {
             status.success = false;

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -76,7 +76,16 @@ Castro::do_advance_ctu(Real time,
     // the point where we can bail out later in the advance, so let's just
     // go directly into a retry now if we're too far away from the needed dt.
 
-    if (castro::check_dt_before_advance && amr_iteration > 1) {
+    bool is_first_step_on_this_level = true;
+
+    for (int lev = level; lev >= 0; --lev) {
+        if (getLevel(lev).iteration > 1) {
+            is_first_step_on_this_level = false;
+            break;
+        }
+    }
+
+    if (castro::check_dt_before_advance && !is_first_step_on_this_level) {
 
         Real old_dt = estTimeStep();
 

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -29,7 +29,7 @@
 using namespace amrex;
 
 Real
-Castro::estdt_cfl(const Real time)
+Castro::estdt_cfl (int is_new)
 {
 
   // Courant-condition limited timestep
@@ -40,7 +40,7 @@ Castro::estdt_cfl(const Real time)
   ReduceData<Real> reduce_data(reduce_op);
   using ReduceTuple = typename decltype(reduce_data)::Type;
 
-  const MultiFab& stateMF = get_new_data(State_Type);
+  const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
 #ifdef _OPENMP
 #pragma omp parallel
@@ -127,7 +127,7 @@ Castro::estdt_cfl(const Real time)
 
 #ifdef MHD
 Real
-Castro::estdt_mhd()
+Castro::estdt_mhd (int is_new)
 {
 
   // MHD timestep limiter
@@ -137,11 +137,11 @@ Castro::estdt_mhd()
   ReduceData<Real> reduce_data(reduce_op);
   using ReduceTuple = typename decltype(reduce_data)::Type;
 
-  const MultiFab& state = get_new_data(State_Type);
+  const MultiFab& state = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
-  const MultiFab& bx = get_new_data(Mag_Type_x);
-  const MultiFab& by = get_new_data(Mag_Type_y);
-  const MultiFab& bz = get_new_data(Mag_Type_z);
+  const MultiFab& bx = is_new ? get_new_data(Mag_Type_x) : get_old_data(Mag_Type_x);
+  const MultiFab& by = is_new ? get_new_data(Mag_Type_y) : get_old_data(Mag_Type_y);
+  const MultiFab& bz = is_new ? get_new_data(Mag_Type_z) : get_old_data(Mag_Type_z);
 
 #ifdef _OPENMP
 #pragma omp parallel
@@ -241,7 +241,7 @@ Castro::estdt_mhd()
 #ifdef DIFFUSION
 
 Real
-Castro::estdt_temp_diffusion(void)
+Castro::estdt_temp_diffusion (int is_new)
 {
 
   // Diffusion-limited timestep
@@ -255,7 +255,7 @@ Castro::estdt_temp_diffusion(void)
   ReduceData<Real> reduce_data(reduce_op);
   using ReduceTuple = typename decltype(reduce_data)::Type;
 
-  const MultiFab& stateMF = get_new_data(State_Type);
+  const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
   const Real ldiffuse_cutoff_density = diffuse_cutoff_density;
   const Real lmax_dt = max_dt;
@@ -333,7 +333,7 @@ Castro::estdt_temp_diffusion(void)
 
 #ifdef REACTIONS
 Real
-Castro::estdt_burning()
+Castro::estdt_burning (int is_new)
 {
 
     if (castro::dtnuc_e > 1.e199_rt && castro::dtnuc_X > 1.e199_rt) return 1.e200_rt;
@@ -342,7 +342,7 @@ Castro::estdt_burning()
     ReduceData<Real> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
 
-    MultiFab& S_new = get_new_data(State_Type);
+    MultiFab& S_new = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
 #ifdef _OPENMP
 #pragma omp parallel
@@ -475,12 +475,12 @@ Castro::estdt_burning()
 
 #ifdef RADIATION
 Real
-Castro::estdt_rad ()
+Castro::estdt_rad (int is_new)
 {
     auto dx = geom.CellSizeArray();
 
-    const MultiFab& stateMF = get_new_data(State_Type);
-    const MultiFab& radMF = get_new_data(Rad_Type);
+    const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
+    const MultiFab& radMF = is_new ? get_new_data(Rad_Type) : get_old_data(Rad_Type);
 
     // Compute radiation + hydro limited timestep.
 


### PR DESCRIPTION
## PR summary

This should run on everything but the very first fine timestep in a given coarse step.

Also, #2222 missed that estTimeStep always operated on the new-time state, so all of the estdt interfaces are updated to accept an `is_new` parameter and use the old-time state if it is set to zero. The pre-advance check then uses the old-time state as intended.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
