### PR TITLE
Disable transverse correction if it causes invalid X

### DIFF
--- a/Source/hydro/trans.cpp
+++ b/Source/hydro/trans.cpp
@@ -361,6 +361,30 @@ Castro::actual_trans_single(const Box& bx,
             reset_state = true;
         }
 
+        // Reset to original value if adding transverse terms made any mass fraction invalid.
+
+        for (int n = 0; n < NumSpec; ++n) {
+            if (qo_arr(i,j,k,n+QFS) > 1.0_rt + castro::abundance_failure_tolerance ||
+                qo_arr(i,j,k,n+QFS) < -castro::abundance_failure_tolerance) {
+                rrnewn = rrn;
+                runewn = run;
+                rvnewn = rvn;
+                rwnewn = rwn;
+                renewn = ren;
+                for (int ipassive = 0; ipassive < npassive; ++ipassive) {
+                    int nqp = qpassmap(ipassive);
+                    qo_arr(i,j,k,nqp) = q_arr(i,j,k,nqp);
+                }
+#ifdef RADIATION
+                for (int g = 0; g < NGROUPS; ++g) {
+                    ernewn[g] = ern[g];
+                }
+#endif
+                reset_state = true;
+                break;
+            }
+        }
+
         // Convert back to primitive form
         qo_arr(i,j,k,QRHO) = rrnewn;
         Real rhoinv = 1.0_rt / rrnewn;
@@ -790,6 +814,30 @@ Castro::actual_trans_final(const Box& bx,
             }
 #endif
             reset_state = true;
+        }
+
+        // Reset to original value if adding transverse terms made any mass fraction invalid.
+
+        for (int n = 0; n < NumSpec; ++n) {
+            if (qo_arr(i,j,k,n+QFS) > 1.0_rt + castro::abundance_failure_tolerance ||
+                qo_arr(i,j,k,n+QFS) < -castro::abundance_failure_tolerance) {
+                rrnewn = rrn;
+                runewn = run;
+                rvnewn = rvn;
+                rwnewn = rwn;
+                renewn = ren;
+                for (int ipassive = 0; ipassive < npassive; ++ipassive) {
+                    int nqp = qpassmap(ipassive);
+                    qo_arr(i,j,k,nqp) = q_arr(i,j,k,nqp);
+                }
+#ifdef RADIATION
+                for (int g = 0; g < NGROUPS; ++g) {
+                    ernewn[g] = ern[g];
+                }
+#endif
+                reset_state = true;
+                break;
+            }
         }
 
         qo_arr(i,j,k,QRHO) = rrnewn;


### PR DESCRIPTION

## PR summary

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
