### PR TITLE
Use new AMR plot max level capability

### DIFF
--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -907,6 +907,20 @@ Castro::plotFileOutput(const std::string& dir,
                        VisMF::How how,
                        const int is_small)
 {
+    // We have nothing to do if we're on a level that
+    // we are not plotting.
+
+    if (is_small) {
+        if (level > parent->smallplotMaxLevel()) {
+            return;
+        }
+    }
+    else {
+        if (level > parent->plotMaxLevel()) {
+            return;
+        }
+    }
+
 #ifdef AMREX_PARTICLES
   ParticlePlotFile(dir);
 #endif
@@ -1025,6 +1039,13 @@ Castro::plotFileOutput(const std::string& dir,
         os << AMREX_SPACEDIM << '\n';
         os << parent->cumTime() << '\n';
         int f_lev = parent->finestLevel();
+        if (is_small) {
+            f_lev = std::min(f_lev, parent->smallplotMaxLevel());
+        }
+        else {
+            f_lev = std::min(f_lev, parent->plotMaxLevel());
+        }
+
         os << f_lev << '\n';
         for (int i = 0; i < AMREX_SPACEDIM; i++) {
             os << geom.ProbLo(i) << ' ';


### PR DESCRIPTION

## PR summary

The support for `amr.plot_max_level` and `amr.small_plot_max_level` is added in AMReX-Codes/amrex#2825.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
