### PR TITLE
Enable opting into new AMRErrorTag derefinement

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -580,6 +580,11 @@ Castro::read_params ()
             ppr.get("volume_weighting", volume_weighting);
             info.SetVolumeWeighting(volume_weighting);
         }
+        if (ppr.countval("derefine") > 0) {
+            int derefine;
+            ppr.get("derefine", derefine);
+            info.SetDerefine(derefine);
+        }
 
         if (ppr.countval("value_greater")) {
             Vector<Real> value;


### PR DESCRIPTION

## PR summary

This allows the user to take advantage of the new functionality in AMReX-Codes/AMReX#2875.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
