### PR TITLE
don't do source correction with SDC on the first iteration

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3999,16 +3999,16 @@ Castro::create_source_corrector()
     }
     else if (time_integration_method == SimplifiedSpectralDeferredCorrections && source_term_predictor == 1) {
 
-        // If we're doing simplified SDC, time-center the source term (using the
-        // current iteration's old sources and the last iteration's new
-        // sources). Since the "new-time" sources are just the corrector step
-        // of the predictor-corrector formalism, we want to add the full
-        // value of the "new-time" sources to the old-time sources to get a
-        // time-centered value. Note that, as above, the "new" data from the
-        // last step is currently residing in the "old" StateData since we
-        // have already done the swap.
+        // If we're doing simplified SDC, time-center the source terms for all
+        // but the first iteration.  We will use the last iteration's "new" source
+        // (which is of the form (S^{n+1,k-1} - S^n)/2) as the corrector to the
+        // current iteration's source, which will result in a source in the hydro
+        // prediction of the form: 1/2 (S^n + S^{n+1,k-1}).
+        //
+        // Since we are not doing this for the first iteration, we access the new-time
+        // data, which is the previous iteration's new source corrector.
 
-        const Real time = get_state_data(Source_Type).prevTime();
+        const Real time = get_state_data(Source_Type).curTime();
         if (sdc_iteration > 0) {
             AmrLevel::FillPatch(*this, source_corrector, NUM_GROW_SRC, time, Source_Type, 0, NSRC);
         } else {

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -4016,7 +4016,7 @@ Castro::create_source_corrector()
             // step, so it is not centered for this current step, so we 
             // zero things out
 
-            source_corrector.clear();
+            source_corrector.setVal(0.0, source_corrector.nGrow());
         }
     }
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -4009,9 +4009,15 @@ Castro::create_source_corrector()
         // have already done the swap.
 
         const Real time = get_state_data(Source_Type).prevTime();
+        if (sdc_iteration > 0) {
+            AmrLevel::FillPatch(*this, source_corrector, NUM_GROW_SRC, time, Source_Type, 0, NSRC);
+        } else {
+            // the first SDC iteration is using information from the previous
+            // step, so it is not centered for this current step, so we 
+            // zero things out
 
-        AmrLevel::FillPatch(*this, source_corrector, NUM_GROW_SRC, time, Source_Type, 0, NSRC);
-
+            source_corrector.clear();
+        }
     }
 
 }


### PR DESCRIPTION
this will now only use the information from the old iteration
of the current timestep, if available.  Also note that we were
accessing the wrong time-level of the Source_Type.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
