### PR TITLE
Only access old data when needed in GetCrsePhi

### DIFF
--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -652,21 +652,31 @@ Gravity::GetCrsePhi(int level,
     
     BL_ASSERT(level!=0);
 
-    const Real t_old = LevelData[level-1]->get_state_data(PhiGrav_Type).prevTime();
-    const Real t_new = LevelData[level-1]->get_state_data(PhiGrav_Type).curTime();
-    Real alpha = (time - t_old)/(t_new - t_old);
-    Real omalpha = 1.0 - alpha;
-
-    MultiFab const& phi_old = LevelData[level-1]->get_old_data(PhiGrav_Type);
-    MultiFab const& phi_new = LevelData[level-1]->get_new_data(PhiGrav_Type);
-
     phi_crse.clear();
     phi_crse.define(grids[level-1], dmap[level-1], 1, 1); // BUT NOTE we don't trust phi's ghost cells.
 
-    MultiFab::LinComb(phi_crse,
-                      alpha  , phi_new, 0,
-                      omalpha, phi_old, 0,
-                      0, 1, 1);
+    const Real t_old = LevelData[level-1]->get_state_data(PhiGrav_Type).prevTime();
+    const Real t_new = LevelData[level-1]->get_state_data(PhiGrav_Type).curTime();
+    Real alpha = (time - t_old) / (t_new - t_old);
+    Real omalpha = 1.0_rt - alpha;
+    const Real threshold = 1.e-6_rt;
+
+    MultiFab const& phi_new = LevelData[level-1]->get_new_data(PhiGrav_Type);
+
+    if (std::abs(omalpha) < threshold) {
+        MultiFab::Copy(phi_crse, phi_new, 0, 0, 1, 1);
+    }
+    else if (std::abs(alpha) < threshold) {
+        // Note we only access the old time if it's actually needed, to guard against
+        // scenarios where it may not be allocated yet, for example after a restart when
+        // the old time was not dumped to the checkpoint.
+        MultiFab const& phi_old = LevelData[level-1]->get_old_data(PhiGrav_Type);
+        MultiFab::Copy(phi_crse, phi_old, 0, 0, 1, 1);
+    }
+    else {
+        MultiFab const& phi_old = LevelData[level-1]->get_old_data(PhiGrav_Type);
+        MultiFab::LinComb(phi_crse, alpha, phi_new, 0, omalpha, phi_old, 0, 0, 1, 1);
+    }
 
     const Geometry& geom = parent->Geom(level-1);
     phi_crse.FillBoundary(geom.periodicity());


### PR DESCRIPTION

## PR summary

On a restart, if `castro.dump_old` is not set to 1, there will not be old time data saved, including for PhiGrav_Type. But the code was attempting to access the old data on the multilevel Poisson solve after a restart in the linear interpolation in GetCrsePhi. This is unnecessary because in this solve after a restart, all levels are at the same time, so we can skip the interpolation and copy directly from the new-time state (using the same logic found in make_radial_gravity). So this works around the issue.

## PR motivation

Fixes #2251

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
