### PR TITLE
Negative density retry issue in T7

### DIFF
--- a/Exec/science/nova/inputs_nova_t7
+++ b/Exec/science/nova/inputs_nova_t7
@@ -33,22 +33,23 @@ castro.do_sponge = 0          #using sponge
 castro.ppm_type = 1
 castro.grav_source_type = 2
 castro.use_pslope = 1
-castro.pslope_cutoff_density = 1.0e2
+castro.pslope_cutoff_density = 6.0e1
 
 castro.use_flattening = 1
 
-castro.small_temp = 1.0e5
+castro.small_temp = 5.0e5
 castro.small_dens = 1.0e-6
-#castro.retry_small_density_cutoff = 1.0
+castro.retry_small_density_cutoff = 2.0e-5
+castro.limit_fluxes_on_small_dens = 1
 
 gravity.gravity_type = ConstantGrav
 gravity.const_grav   = -7.06e8
 
-castro.react_rho_min = 1.0e2
-castro.react_T_min = 1.0e7
+castro.react_rho_min = 6.0e1
+castro.react_T_min = 5.0e6
 
 # TIME STEP CONTROL
-castro.cfl            = 0.8     # cfl number for hyperbolic system
+castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.1     # max time step growth
 


### PR DESCRIPTION
In this PR, I finally committed the required changes to run our T7 model. It is important to mention that:

- Our T7 model supports up to 5 levels of refinement, with a max resolution of ~0.14km .
- The model is now running within all the levels for further post-processing.
- We plan to apply the same changes to the remaining models.
