### PR TITLE
for Strang burn or NSE, set T_fixed

### DIFF
--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -104,7 +104,13 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
             Real rhoInv = 1.0_rt / U(i,j,k,URHO);
 
             burn_state.rho = U(i,j,k,URHO);
+
+            // this T is consistent with UEINT because we did an EOS call before
+            // calling this function
+
             burn_state.T = U(i,j,k,UTEMP);
+
+            burn_state.T_fixed = -1.e30_rt;
 
 #ifdef CXX_MODEL_PARSER
             if (drive_initial_convection) {
@@ -126,7 +132,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
                     dist = std::sqrt(rr[0] * rr[0] + rr[1] * rr[1] + rr[2] * rr[2]);
                 }
 
-                burn_state.T = interpolate(dist, model::itemp);
+                burn_state.T_fixed = interpolate(dist, model::itemp);
 
             }
 #endif


### PR DESCRIPTION
this is needed for drive_initial_convection to ensure that the energy of the cell is not computed based on T_fixed

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
