### PR TITLE
change the in_nse() check in timestep to work on burn_t

### DIFF
--- a/Source/driver/Derive.cpp
+++ b/Source/driver/Derive.cpp
@@ -1228,7 +1228,7 @@ extern "C"
       burn_state.y[SEINT] = burn_state.rho * burn_state.e;
 #endif
 
-      der(i,j,k,0) = in_nse(eos_state);
+      der(i,j,k,0) = in_nse(burn_state);
 
     });
   }

--- a/Source/driver/Derive.cpp
+++ b/Source/driver/Derive.cpp
@@ -1202,21 +1202,34 @@ extern "C"
     {
       Real rhoInv = 1.0_rt / dat(i,j,k,URHO);
 
-      eos_t eos_state;
-      eos_state.rho  = dat(i,j,k,URHO);
-      eos_state.T = dat(i,j,k,UTEMP);
-      eos_state.e = dat(i,j,k,UEINT) * rhoInv;
+      burn_t burn_state;
+      burn_state.rho  = dat(i,j,k,URHO);
+      burn_state.T = dat(i,j,k,UTEMP);
+      burn_state.e = dat(i,j,k,UEINT) * rhoInv;
       for (int n = 0; n < NumSpec; n++) {
-        eos_state.xn[n] = dat(i,j,k,UFS+n) * rhoInv;
+        burn_state.xn[n] = dat(i,j,k,UFS+n) * rhoInv;
       }
 #if NAUX_NET > 0
       for (int n = 0; n < NumAux; n++) {
-        eos_state.aux[n] = dat(i,j,k,UFX+n) * rhoInv;
+        burn_state.aux[n] = dat(i,j,k,UFX+n) * rhoInv;
       }
 #endif
 
-      eos(eos_input_re, eos_state);
+      eos(eos_input_re, burn_state);
+
+#ifdef SIMPLIFIED_SDC
+      // if we are doing simplified-SDC + NSE, then the `in_nse()`
+      // check will use burn_state.y[], so we need to ensure that
+      // those are initialized
+      for (int n = 0; n < NumSpec; ++n) {
+          burn_state.y[SFS+n] = burn_state.rho * burn_state.xn[n];
+      }
+
+      burn_state.y[SEINT] = burn_state.rho * burn_state.e;
+#endif
+
       der(i,j,k,0) = in_nse(eos_state);
+
     });
   }
 #endif

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -420,14 +420,20 @@ Castro::estdt_burning (int is_new)
         Real dt_tmp = 1.e200_rt;
 
 #ifdef NSE
-        // we need to use the eos_state interface here because for
-        // SDC, if we come in with a burn_t, it expects to
-        // evaluate the NSE criterion based on the conserved state.
 
-        eos_t eos_state;
-        burn_to_eos(burn_state, eos_state);
+#ifdef SIMPLIFIED_SDC
+        // if we are doing simplified-SDC + NSE, then the `in_nse()`
+        // check will use burn_state.y[], so we need to ensure that
+        // those are initialized
+        for (int n = 0; n < NumSpec; ++n) {
+            burn_state.y[SFS+n] = burn_state.rho * burn_state.xn[n];
+        }
 
-        if (!in_nse(eos_state)) {
+        burn_state.y[SEINT] = burn_state.rho * burn_state.e;
+
+#endif
+
+        if (!in_nse(burn_state)) {
 #endif
             dt_tmp = dtnuc_e * e / dedt;
 #ifdef NSE


### PR DESCRIPTION
this will allow us eventually to remove the in_nse(eos_t) specialization

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
