### PR TITLE
remove the old Castro state indices

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -23,21 +23,6 @@ using namespace castro;
 constexpr int HISTORY_SIZE=40;
 constexpr int PSTAR_BISECT_FACTOR = 5;
 
-// for backwards compatibility with the old way of naming variables
-// these keys are deprecated and may be removed in the future
-constexpr int Density = URHO;
-constexpr int Xmom = UMX;
-constexpr int Ymom = UMY;
-constexpr int Zmom = UMZ;
-constexpr int Eden = UEDEN;
-constexpr int Eint = UEINT;
-constexpr int Temp = UTEMP;
-constexpr int FirstAdv = UFA;
-constexpr int FirstSpec = UFS;
-constexpr int FirstAux = UFX;
-#ifdef SHOCK_VAR
-constexpr int Shock = USHK;
-#endif
 
 #include <AMReX_BC_TYPES.H>
 #include <AMReX_AmrLevel.H>


### PR DESCRIPTION
these have long been replaced by the versions from _variables

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
