### PR TITLE
Make sure generated code is identical between make runs

### DIFF
--- a/Source/driver/parse_castro_params.py
+++ b/Source/driver/parse_castro_params.py
@@ -148,7 +148,8 @@ def parse_params(infile, out_directory):
     for nm in namespaces:
 
         params_nm = [q for q in params if q.namespace == nm]
-        ifdefs = {q.ifdef for q in params_nm}
+        # sort by repr since None may be present
+        ifdefs = sorted({q.ifdef for q in params_nm}, key=repr)
 
         # write name_declares.H
         try:

--- a/Source/driver/set_variables.py
+++ b/Source/driver/set_variables.py
@@ -183,7 +183,7 @@ def doit(variables_file, odir, defines, nadv):
                 for v in q.adds_to:
                     adds_to.append(v)
 
-        adds_to = set(adds_to)
+        adds_to = sorted(set(adds_to))
 
         # initialize the counters
         counter_main = Counter(default_set[s])
@@ -227,7 +227,7 @@ def doit(variables_file, odir, defines, nadv):
 
         # we only loop over the default sets for setting indices, not the
         # "adds to", so we don't set the same index twice
-        for s in unique_sets:
+        for s in sorted(unique_sets):
             set_indices = [q for q in indices if q.iset == s]
             f.write("\n   // {}\n".format(s))
             for i in set_indices:


### PR DESCRIPTION
This fixes cache misses when using ccache, along with AMReX-Astro/Microphysics#1165.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
