### PR TITLE
Remove some erroneous includes of Castro_hydro.H

### DIFF
--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1,7 +1,6 @@
 #include <Castro.H>
 #include <Castro_util.H>
 #include <Castro_F.H>
-#include <Castro_hydro.H>
 
 #ifdef RADIATION
 #include <Radiation.H>

--- a/Source/hydro/Castro_ctu_rad.cpp
+++ b/Source/hydro/Castro_ctu_rad.cpp
@@ -1,7 +1,6 @@
 #include "Castro.H"
 #include "Castro_F.H"
 #include "Castro_util.H"
-#include "Castro_hydro.H"
 
 #include "Radiation.H"
 #include "RadHydro.H"

--- a/Source/hydro/edge_util.cpp
+++ b/Source/hydro/edge_util.cpp
@@ -1,5 +1,4 @@
 #include <Castro.H>
-#include <Castro_hydro.H>
 
 using namespace amrex;
 


### PR DESCRIPTION
This header should only be included from within the Castro class in Castro.H.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
