### PR TITLE
Insert R_min directly into functions

### DIFF
--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1247,7 +1247,8 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
           for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
               loc[dir] -= problem::center[dir];
 
-          Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]), hybrid::R_min);
+          Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]),
+                              std::numeric_limits<Real>::min());
           Real RInv = 1.0_rt / R;
 
           update_arr(i,j,k,UMR) -= dt * (loc[0] * RInv) * (qx_arr(i+1,j,k,GDPRES) - qx_arr(i,j,k,GDPRES)) / dx_arr[0];

--- a/Source/hydro/Castro_hybrid.cpp
+++ b/Source/hydro/Castro_hybrid.cpp
@@ -111,7 +111,8 @@ Castro::fill_hybrid_hydro_source(MultiFab& sources, MultiFab& state_in, Real mul
             loc[0] -= problem::center[0];
             loc[1] -= problem::center[1];
 
-            Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]), hybrid::R_min);
+            Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]),
+                                std::numeric_limits<Real>::min());
 
             Real rhoInv = 1.0_rt / u(i,j,k,URHO);
             Real RInv = 1.0_rt / R;

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -649,7 +649,8 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
           for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
             loc[dir] -= problem::center[dir];
 
-          Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]), R_min);
+          Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]),
+                              std::numeric_limits<Real>::min());
           Real RInv = 1.0_rt / R;
 
           source_out_arr(i,j,k,UMR) -= ((loc[0] * RInv) * (qx_arr(i+1,j,k,GDPRES) - qx_arr(i,j,k,GDPRES)) / dx_arr[0] +

--- a/Source/hydro/hybrid.H
+++ b/Source/hydro/hybrid.H
@@ -5,12 +5,6 @@
 
 using namespace amrex;
 
-// Avoid the singularity in cylindrical coordinates
-namespace hybrid {
-  constexpr Real R_min = std::numeric_limits<Real>::min();
-}
-
-
 ///
 /// For hybrid momentum advection, convert the linear momentum into the
 /// hybrid / angular momentum components
@@ -27,7 +21,8 @@ void linear_to_hybrid(const GpuArray<Real, 3>& loc,
     // Convert a linear momentum into the "hybrid" scheme
     // that has radial and angular components.
 
-    Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]), hybrid::R_min);
+    Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]),
+                        std::numeric_limits<Real>::min());
     Real RInv = 1.0_rt / R;
 
     // This conversion is Eqs. 25 and 26 in Byerly et al. 2014.
@@ -56,7 +51,8 @@ void hybrid_to_linear(const GpuArray<Real, 3>& loc,
 {
     // Convert a "hybrid" momentum into a linear one.
 
-    Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]), hybrid::R_min);
+    Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]),
+                        std::numeric_limits<Real>::min());
     Real RInv = 1.0_rt / R;
 
     // This is the inverse of Byerly et al., Equations 25 and 26.
@@ -80,7 +76,8 @@ void set_hybrid_momentum_source(const GpuArray<Real, 3>& loc,
                                 const GpuArray<Real, 3>& linear_source,
                                 GpuArray<Real, 3>& hybrid_source)
 {
-    Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]), hybrid::R_min);
+    Real R = amrex::max(std::sqrt(loc[0] * loc[0] + loc[1] * loc[1]),
+                        std::numeric_limits<Real>::min());
     Real RInv = 1.0_rt / R;
 
     // This is analogous to the conversion of linear momentum to hybrid momentum.


### PR DESCRIPTION

## PR summary

This resolves an issue with using R_min in CUDA.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
