### PR TITLE
[WIP] fix usage of mom_flux_has_p

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -849,7 +849,7 @@ Castro::initMFs()
     }
 
 #if (AMREX_SPACEDIM <= 2)
-    if (AMREX_SPADCE_DIM == 1 || !Geom().IsCartesian()) {
+    if (AMREX_SPACEDIM == 1 || !Geom().IsCartesian()) {
       P_radial.define(getEdgeBoxArray(0), dmap, 1, 0);
     }
 #endif

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -849,7 +849,7 @@ Castro::initMFs()
     }
 
 #if (AMREX_SPACEDIM <= 2)
-    if (!Geom().IsCartesian()) {
+    if (AMREX_SPADCE_DIM == 1 || !Geom().IsCartesian()) {
       P_radial.define(getEdgeBoxArray(0), dmap, 1, 0);
     }
 #endif
@@ -2589,7 +2589,7 @@ Castro::FluxRegCrseInit() {
     }
 
 #if (AMREX_SPACEDIM <= 2)
-    if (!Geom().IsCartesian()) {
+    if (AMREX_SPACEDIM == 1 || !Geom().IsCartesian()) {
       fine_level.pres_reg.CrseInit(P_radial, 0, 0, 0, 1, pres_crse_scale);
     }
 #endif
@@ -2619,7 +2619,7 @@ Castro::FluxRegFineAdd() {
     }
 
 #if (AMREX_SPACEDIM <= 2)
-    if (!Geom().IsCartesian()) {
+    if (AMREX_SPACEDIM == 1 || !Geom().IsCartesian()) {
       getLevel(level).pres_reg.FineAdd(P_radial, 0, 0, 0, 1, pres_fine_scale);
     }
 #endif
@@ -2832,7 +2832,7 @@ Castro::reflux(int crse_level, int fine_level)
         reg->setVal(0.0);
 
 #if (AMREX_SPACEDIM <= 2)
-        if (!Geom().IsCartesian()) {
+        if (AMREX_SPACEDIM == 1 || !Geom().IsCartesian()) {
 
             reg = &getLevel(lev).pres_reg;
 

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -470,7 +470,7 @@ Castro::initialize_advance(Real time, Real dt, int amr_iteration)
     }
 
 #if (AMREX_SPACEDIM <= 2)
-    if (!Geom().IsCartesian()) {
+    if (AMREX_SPACEDIM == 1 || !Geom().IsCartesian()) {
         P_radial.setVal(0.0);
     }
 #endif

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -501,7 +501,7 @@ Castro::retry_advance_ctu(Real dt, const advance_status& status)
         }
 
 #if (AMREX_SPACEDIM <= 2)
-        if (!Geom().IsCartesian()) {
+        if (AMREX_SPACEDIM == 1 || !Geom().IsCartesian()) {
           P_radial.setVal(0.0);
         }
 #endif

--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -75,8 +75,8 @@ Castro::consup_hydro(const Box& bx,
 #endif
 
     } else if (n == UMX) {
-      // Add gradp term to momentum equation -- only for axisymmetric
-      // coords (and only for the radial flux).
+      // Add gradp term to momentum equation if needed (only for the
+      // radial flux)
 
       if (!mom_flux_has_p(0, 0, geomdata.Coord())) {
         U_new(i,j,k,UMX) += - dt * (qx(i+1,j,k,GDPRES) - qx(i,j,k,GDPRES)) / geomdata.CellSize()[0];

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -35,7 +35,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
   GeometryData geomdata = geom.data();
 #endif
 
-#if AMREX_SPACEDIM == 2
+#if AMREX_SPACEDIM <= 2
   int coord = geom.Coord();
 #endif
 

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1309,19 +1309,13 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
             // get the scaled radial pressure -- we need to treat this specially
 #if AMREX_SPACEDIM <= 2
-
-#if AMREX_SPACEDIM == 1
-            if (!Geom().IsCartesian()) {
-#elif AMREX_SPACEDIM == 2
             if (!mom_flux_has_p(0, 0, coord)) {
-#endif
                 amrex::ParallelFor(nbx,
                 [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
                 {
                     pradial_fab(i,j,k) = qex_arr(i,j,k,GDPRES) * dt;
                 });
             }
-
 #endif
         }
 
@@ -1359,11 +1353,7 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
 
 #if AMREX_SPACEDIM <= 2
 
-#if AMREX_SPACEDIM == 1
-            if (idir == 0 && !Geom().IsCartesian()) {
-#elif AMREX_SPACEDIM == 2
             if (idir == 0 && !mom_flux_has_p(0, 0, coord)) {
-#endif
                 Array4<Real> pradial_fab = pradial.array();
                 Array4<Real> P_radial_fab = P_radial.array(mfi);
 

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -689,17 +689,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
             Array4<Real> const qex_fab = qe[idir].array();
             const int prescomp = GDPRES;
 
-#if AMREX_SPACEDIM == 1
-            if (!Geom().IsCartesian()) {
-              amrex::ParallelFor(nbx,
-              [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
-              {
-                pradial_fab(i,j,k) = qex_fab(i,j,k,prescomp) * dt;
-              });
-            }
-#endif
-
-#if AMREX_SPACEDIM == 2
+#if AMREX_SPACEDIM <= 2
             if (!mom_flux_has_p(0, 0, coord)) {
               amrex::ParallelFor(nbx,
               [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)


### PR DESCRIPTION
this is always false in 1-d, even for Cartesian, but it does not seem that we were storing the pressure flux in that case

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
