### PR TITLE
Remove the gravity no_composite parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # 23.07
 
+  * The parameter gravity.no_composite was removed (#2483)
+
   * The parameter spherical_star was removed (#2482)
 
 # 23.06

--- a/Docs/source/gravity.rst
+++ b/Docs/source/gravity.rst
@@ -63,7 +63,7 @@ The overall integration strategy is as follows, and is similar to
 the discussion in :cite:`castro_I`. Briefly:
 
 -  At the beginning of a simulation, we do a multilevel composite
-   solve (if ``gravity.no_composite`` = 0).
+   solve.
 
    We also do a multilevel composite solve after each regrid.
 
@@ -95,19 +95,13 @@ the discussion in :cite:`castro_I`. Briefly:
    result as if you had done a full composite solve at the end of the
    timestep (assuming ``gravity.no_sync`` = 0).
 
-If you do ``gravity.no_composite`` = 1, then you never do a full
-multilevel solve, and the gravity on any level is defined only by the
-solve on that level. The only time this would be appropriate is if
-the fine level(s) cover essentially all of the mass on the grid for
-all time.
-
 Controls
 --------
 
 -  For the full Poisson solver
    (``gravity.gravity_type`` = ``PoissonGrav``), the behavior
    of the full Poisson solve / multigrid solver is controlled by
-   ``gravity.no_sync`` and ``gravity.no_composite``.
+   ``gravity.no_sync``.
 
 -  For isolated boundary conditions, and when
    ``gravity.gravity_type`` = ``PoissonGrav``, the parameters
@@ -130,10 +124,6 @@ solves:
 
 -  ``gravity.no_sync`` : ``gravity.gravity_type`` =
    ``PoissonGrav``, do we perform the “sync solve"? (0 or 1; default: 0)
-
--  ``gravity.no_composite`` : if gravity.gravity_type
-   = ``PoissonGrav``, whether to perform a composite solve (0 or 1;
-   default: 0)
 
 -  ``gravity.max_solve_level`` : maximum level to solve
    for :math:`\phi` and :math:`\mathbf{g}`; above this level, interpolate from

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -705,12 +705,6 @@ Castro::Castro (Amr&            papa,
       if (verbose && level == 0 &&  ParallelDescriptor::IOProcessor()) {
         std::cout << "Setting the gravity type to " << gravity->get_gravity_type() << std::endl;
       }
-
-      if (gravity->get_gravity_type() == "PoissonGrav" && gravity->NoComposite() != 0 && gravity->NoSync() == 0)
-      {
-          std::cerr << "Error: not meaningful to have gravity.no_sync == 0 without having gravity.no_composite == 0.";
-          amrex::Error();
-      }
    }
 
 #endif
@@ -2152,16 +2146,13 @@ Castro::post_restart ()
 
             if ( gravity->get_gravity_type() == "PoissonGrav")
             {
-                if (gravity->NoComposite() != 1)
-                {
-                   // Update the maximum density, used in setting the solver tolerance.
+                // Update the maximum density, used in setting the solver tolerance.
 
-                   gravity->update_max_rhs();
+                gravity->update_max_rhs();
 
-                   gravity->multilevel_solve_for_new_phi(0, parent->finestLevel());
-                   if (gravity->test_results_of_solves() == 1) {
-                       gravity->test_composite_phi(level);
-                   }
+                gravity->multilevel_solve_for_new_phi(0, parent->finestLevel());
+                if (gravity->test_results_of_solves() == 1) {
+                    gravity->test_composite_phi(level);
                 }
             }
 
@@ -2273,7 +2264,7 @@ Castro::post_regrid (int lbase,
             const Real cur_time = state[State_Type].curTime();
             if ( (level == lbase) && cur_time > 0.)
             {
-                if ( gravity->get_gravity_type() == "PoissonGrav" && (gravity->NoComposite() != 1) ) {
+                if (gravity->get_gravity_type() == "PoissonGrav") {
                     // Update the maximum density, used in setting the solver tolerance.
 
                     if (level == 0) {
@@ -2358,11 +2349,9 @@ Castro::post_init (Real /*stop_time*/)
           // Calculate offset before first multilevel solve.
           gravity->set_mass_offset(cur_time);
 
-          if (gravity->NoComposite() != 1)  {
-             gravity->multilevel_solve_for_new_phi(level,finest_level);
-             if (gravity->test_results_of_solves() == 1) {
-               gravity->test_composite_phi(level);
-             }
+          gravity->multilevel_solve_for_new_phi(level,finest_level);
+          if (gravity->test_results_of_solves() == 1) {
+              gravity->test_composite_phi(level);
           }
        }
 
@@ -2479,11 +2468,9 @@ Castro::post_grown_restart ()
           // Calculate offset before first multilevel solve.
           gravity->set_mass_offset(cur_time);
 
-          if (gravity->NoComposite() != 1)  {
-             gravity->multilevel_solve_for_new_phi(level,finest_level);
-             if (gravity->test_results_of_solves() == 1) {
-                gravity->test_composite_phi(level);
-             }
+          gravity->multilevel_solve_for_new_phi(level,finest_level);
+          if (gravity->test_results_of_solves() == 1) {
+              gravity->test_composite_phi(level);
           }
        }
 

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -763,9 +763,6 @@ drdxfac                     int            1
 # do we perform the synchronization at coarse-fine interfaces?
 no_sync                     int            0
 
-# do we do a composite solve?
-no_composite                int            0
-
 # should we apply a lagged correction to the potential that
 # gets us closer to the composite solution? This makes the
 # resulting fine grid calculation slightly more accurate,

--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -44,13 +44,12 @@ Castro::construct_old_gravity(int amr_iteration, int amr_ncycle, Real time)
 
     if (gravity->get_gravity_type() == "PoissonGrav" && parent->finestLevel() > 0)
     {
-
         // Create a copy of the current (composite) data on this level.
 
         MultiFab comp_phi;
         Vector<std::unique_ptr<MultiFab> > comp_gphi(AMREX_SPACEDIM);
 
-        if (gravity->NoComposite() != 1 && gravity->DoCompositeCorrection() && level < parent->finestLevel() && level <= gravity->get_max_solve_level()) {
+        if (gravity->DoCompositeCorrection() && level < parent->finestLevel() && level <= gravity->get_max_solve_level()) {
 
             comp_phi.define(phi_old.boxArray(), phi_old.DistributionMap(), phi_old.nComp(), phi_old.nGrow());
             MultiFab::Copy(comp_phi, phi_old, 0, 0, phi_old.nComp(), phi_old.nGrow());
@@ -77,7 +76,7 @@ Castro::construct_old_gravity(int amr_iteration, int amr_ncycle, Real time)
                                amrex::GetVecOfPtrs(gravity->get_grad_phi_prev(level)),
                                is_new);
 
-        if (gravity->NoComposite() != 1 && gravity->DoCompositeCorrection() && level < parent->finestLevel() && level <= gravity->get_max_solve_level()) {
+        if (gravity->DoCompositeCorrection() && level < parent->finestLevel() && level <= gravity->get_max_solve_level()) {
 
             // Subtract the level solve from the composite solution.
 
@@ -158,7 +157,7 @@ Castro::construct_new_gravity(int amr_iteration, int amr_ncycle, Real time)
         // Subtract off the (composite - level) contribution for the purposes
         // of the level solve. We'll add it back later.
 
-        if (gravity->NoComposite() != 1 && gravity->DoCompositeCorrection() && level < parent->finestLevel() && level <= gravity->get_max_solve_level()) {
+        if (gravity->DoCompositeCorrection() && level < parent->finestLevel() && level <= gravity->get_max_solve_level()) {
             phi_new.minus(comp_minus_level_phi, 0, 1, 0);
         }
 
@@ -173,7 +172,7 @@ Castro::construct_new_gravity(int amr_iteration, int amr_ncycle, Real time)
                                amrex::GetVecOfPtrs(gravity->get_grad_phi_curr(level)),
                                is_new);
 
-        if (gravity->NoComposite() != 1 && gravity->DoCompositeCorrection() == 1 && level < parent->finestLevel() && level <= gravity->get_max_solve_level()) {
+        if (gravity->DoCompositeCorrection() == 1 && level < parent->finestLevel() && level <= gravity->get_max_solve_level()) {
 
             if (gravity->test_results_of_solves() == 1) {
 
@@ -217,7 +216,7 @@ Castro::construct_new_gravity(int amr_iteration, int amr_ncycle, Real time)
 
     if (gravity->get_gravity_type() == "PoissonGrav" && level <= gravity->get_max_solve_level()) {
 
-        if (gravity->NoComposite() != 1 && gravity->DoCompositeCorrection() == 1 && level < parent->finestLevel()) {
+        if (gravity->DoCompositeCorrection() == 1 && level < parent->finestLevel()) {
 
             // Now that we have calculated the force, if we are going to do a sync
             // solve then subtract off the (composite - level) contribution, as it

--- a/Source/gravity/Gravity.H
+++ b/Source/gravity/Gravity.H
@@ -111,11 +111,6 @@ public:
   static int NoSync();
 
 ///
-/// Returns ``no_composite``
-///
-  static int NoComposite();
-
-///
 /// Returns ``do_composite_phi_correction``
 ///
   static int DoCompositeCorrection();

--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -356,11 +356,6 @@ int Gravity::NoSync()
   return gravity::no_sync;
 }
 
-int Gravity::NoComposite()
-{
-  return gravity::no_composite;
-}
-
 int Gravity::DoCompositeCorrection()
 {
   return gravity::do_composite_phi_correction;


### PR DESCRIPTION

## PR summary

This parameter is never changed in practice, and there isn't really a good reason to change it.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
