### PR TITLE
Some minor rearranging of CTU advance

### DIFF
--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -295,6 +295,12 @@ Castro::finalize_do_advance (Real time, Real dt)
         }
     }
 
+    // Check for NaN's.
+
+    MultiFab& S_new = get_new_data(State_Type);
+
+    check_for_nan(S_new);
+
 #ifdef RADIATION
     if (!do_hydro && Radiation::rad_hydro_combined) {
         MultiFab& Er_old = get_old_data(Rad_Type);

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -112,10 +112,6 @@ Castro::do_advance_ctu(Real time,
     {
 #ifndef MHD
       construct_ctu_hydro_source(time, dt);
-
-//      if (print_update_diagnostics) {
-//          evaluate_and_print_source_change(hydro_source, dt, "hydro source");
-//      }
 #else
       construct_ctu_mhd_source(time, dt);
 #endif
@@ -129,29 +125,6 @@ Castro::do_advance_ctu(Real time,
           return status;
       }
     }
-
-
-    // Sync up state after old sources and hydro source.
-    clean_state(
-#ifdef MHD
-                Bx_new, By_new, Bz_new,
-#endif
-                S_new, cur_time, 0);
-
-    // Check for NaN's.
-
-    check_for_nan(S_new);
-
-    // if we are done with the update do the source correction and
-    // then the second half of the reactions
-
-#ifdef GRAVITY
-    // Must define new value of "center" before we call new gravity
-    // solve or external source routine
-    if (moving_center == 1) {
-        define_new_center(S_new, time);
-    }
-#endif
 
     // Construct and apply new-time source terms.
 

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -1481,6 +1481,22 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)
   }
 #endif
 
+  // Sync up state after hydro source.
+
+  clean_state(
+#ifdef MHD
+               Bx_new, By_new, Bz_new,
+#endif
+               S_new, cur_time, 0);
+
+#ifdef GRAVITY
+  // Must define new value of "center" after advecting on the grid
+
+  if (moving_center == 1) {
+      define_new_center(S_new, time);
+  }
+#endif
+
   if (verbose) {
       amrex::Print() << "... Leaving construct_ctu_hydro_source()" << std::endl << std::endl;
   }


### PR DESCRIPTION

## PR summary

It doesn't really matter when in the advance we do the check_for_nans, so putting it in the finalize step makes the do_advance_ctu driver cleaner (this is part of a goal to make that function as simple as possible, which will support future changes).

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
