### PR TITLE
Move the negative density check to finalize_do_advance

### DIFF
--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -297,6 +297,14 @@ Castro::finalize_do_advance (Real time, Real dt)
 
     check_for_nan(S_new);
 
+    // Check for small/negative densities and X > 1 or X < 0.
+
+    status = check_for_negative_density();
+
+    if (status.success == false) {
+        return status;
+    }
+
 #ifdef RADIATION
     if (!do_hydro && Radiation::rad_hydro_combined) {
         MultiFab& Er_old = get_old_data(Rad_Type);

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -113,15 +113,6 @@ Castro::do_advance_ctu(Real time,
 #else
       construct_ctu_mhd_source(time, dt);
 #endif
-
-      // Check for small/negative densities and X > 1 or X < 0.
-      // If we detect this, return immediately.
-
-      status = check_for_negative_density();
-
-      if (status.success == false) {
-          return status;
-      }
     }
 
     // Construct and apply new-time source terms.


### PR DESCRIPTION

## PR summary

Continuing the general cleanup of the advance driver. This check doesn't have to be done immediately after the hydro, it just has to be done at some point before the end of the step.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
