### PR TITLE
Remove an unnecessary clean_state

### DIFF
--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -136,17 +136,11 @@ Castro::do_advance_ctu(Real time,
 #endif  
                     new_source, Sborder, S_new, cur_time, dt, apply_sources_to_state);
 
-    // If the state has ghost zones, sync them up now
-    // since the hydro source only works on the valid zones.
+    // If the state has ghost zones, sync them up now since the hydro
+    // source and new-time sources only work on the valid zones.
 
     if (S_new.nGrow() > 0) {
-      clean_state(
-#ifdef MHD
-                  Bx_new, By_new, Bz_new,
-#endif                
-                  S_new, cur_time, 0);
-
-      expand_state(S_new, cur_time, S_new.nGrow());
+        expand_state(S_new, cur_time, S_new.nGrow());
     }
 
     // Do the second half of the reactions for Strang, or the full burn for simplified SDC.


### PR DESCRIPTION

## PR summary

This call should be unnecessary since the hydro and new-time sources both call clean_state after being applied to the state.

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
