### PR TITLE
Don't install CUDA driver for GPU compilation action

### DIFF
--- a/.github/workflows/gpu_action.yml
+++ b/.github/workflows/gpu_action.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
           sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
           sudo apt-get update
-          sudo apt-get -y install cuda
+          sudo apt-get -y install cuda-toolkit
 
       - name: Get cpp linter repo
         run: |


### PR DESCRIPTION

## PR summary

If we're not actually running the code, then we only need the CUDA toolkit.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
