### PR TITLE
Remove the state_nghost parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # 23.07
 
+  * The parameter castro.state_nghost, which allowed State_Type to have ghost
+    zones, has been removed. (#2502)
+
   * The additional ghost zone in State_Type, used when radiation is enabled,
     has been removed. The checkpoint version number has been updated to avoid
     restarting from a checkpoint with the wrong number of ghost zones. (#2495)

--- a/Docs/source/software.rst
+++ b/Docs/source/software.rst
@@ -256,9 +256,7 @@ The current ``StateData`` names Castro carries are:
       simply be advected, but we will allow rotation (in particular,
       the Coriolis force) to affect them.
 
-   ``State_Type`` ``MultiFab`` s have no ghost cells by default.
-   There is an option to force them to have ghost cells by
-   setting the parameter ``castro.state_nghost`` at runtime.
+   ``State_Type`` ``MultiFab`` s have no ghost cells.
 
    Note that the prediction of the hydrodynamic state to the interface
    will require 4 ghost cells. This accommodated by creating a separate

--- a/Exec/reacting_tests/reacting_bubble/inputs_2d_test
+++ b/Exec/reacting_tests/reacting_bubble/inputs_2d_test
@@ -23,10 +23,6 @@ castro.yr_ext_bc_type = 1
 
 castro.hse_interp_temp = 1
 
-
-# this is here just for test suite coverage
-castro.state_nghost = 1
-
 # WHICH PHYSICS
 castro.do_hydro = 1
 castro.do_react = 1

--- a/Exec/reacting_tests/reacting_bubble/inputs_3d_test
+++ b/Exec/reacting_tests/reacting_bubble/inputs_3d_test
@@ -27,9 +27,6 @@ castro.fill_ambient_bc = 1
 castro.ambient_fill_dir = 2
 castro.ambient_outflow_vel = 1
 
-# this is here just for test suite coverage
-castro.state_nghost = 1
-
 # WHICH PHYSICS
 castro.do_hydro = 1
 castro.do_react = 1

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -122,13 +122,6 @@ Castro::do_advance_ctu (Real time, Real dt)
 #endif  
                     new_source, Sborder, S_new, cur_time, dt);
 
-    // If the state has ghost zones, sync them up now since the hydro
-    // source and new-time sources only work on the valid zones.
-
-    if (S_new.nGrow() > 0) {
-        expand_state(S_new, cur_time, S_new.nGrow());
-    }
-
     // Do the second half of the reactions for Strang, or the full burn for simplified SDC.
 
 #ifdef REACTIONS

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -348,9 +348,7 @@ Castro::variableSetUp ()
   bool state_data_extrap = false;
   bool store_in_checkpoint;
 
-  int ngrow_state = state_nghost;
-
-  BL_ASSERT(ngrow_state >= 0);
+  int ngrow_state = 0;
 
   store_in_checkpoint = true;
   desc_lst.addDescriptor(State_Type,IndexType::TheCellType(),

--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -19,11 +19,6 @@ state_interp_order           int           1
 # 2: preserve linear combinations and prevent new extrema
 lin_limit_state_interp       int           0
 
-# Number of ghost zones for state data to have. Note that
-# if you are using radiation, choosing this to be zero will
-# be overridden since radiation needs at least one ghost zone.
-state_nghost                 int           0
-
 # do we do the hyperbolic reflux at coarse-fine interfaces?
 do_reflux                    int           1
 


### PR DESCRIPTION

## PR summary

This was added years ago for performance testing, but was never used for any science.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [x] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
