### PR TITLE
Silence an unused variable in HSE fill

### DIFF
--- a/Source/problems/hse_fill.cpp
+++ b/Source/problems/hse_fill.cpp
@@ -112,7 +112,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                         }
                     }
 
-                    bool converged_hse = false;
+                    [[maybe_unused]] bool converged_hse = false;
 
                     Real p_want;
                     Real drho;
@@ -304,7 +304,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                         }
                     }
 
-                    bool converged_hse = false;
+                    [[maybe_unused]] bool converged_hse = false;
 
                     Real p_want;
                     Real drho;
@@ -501,7 +501,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                         }
                     }
 
-                    bool converged_hse = false;
+                    [[maybe_unused]] bool converged_hse = false;
 
                     Real p_want;
                     Real drho;
@@ -694,7 +694,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                         }
                     }
 
-                    bool converged_hse = false;
+                    [[maybe_unused]] bool converged_hse = false;
 
                     Real p_want;
                     Real drho;
@@ -890,7 +890,7 @@ hse_fill(const Box& bx, Array4<Real> const& adv,
                         }
                     }
 
-                    bool converged_hse = false;
+                    [[maybe_unused]] bool converged_hse = false;
 
                     Real p_want;
                     Real drho;


### PR DESCRIPTION

## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
