### PR TITLE
Remove the cfl_violation parameter

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -1336,11 +1336,6 @@ protected:
 #endif
 
 
-///
-/// Did we trigger a CFL violation?
-///
-    int cfl_violation;
-
 
 ///
 /// State data to hold if we want to do a retry.

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -71,16 +71,6 @@ Castro::advance (Real time,
 #endif //MHD    
     }
 
-    // Optionally kill the job at this point, if we've detected a violation.
-
-    if (cfl_violation == 1 && use_retry != 0) {
-        amrex::Abort("CFL is too high at this level; go back to a checkpoint and restart with lower CFL number, or set castro.use_retry = 1");
-    }
-
-    // If we didn't kill the job, reset the violation counter.
-
-    cfl_violation = 0;
-
     // If the user requests, indicate that we want a regrid at the end of the step.
 
     if (use_post_step_regrid == 1) {
@@ -121,10 +111,6 @@ Castro::initialize_do_advance (Real time, Real dt)
     BL_PROFILE("Castro::initialize_do_advance()");
 
     advance_status status {};
-
-    // Reset the CFL violation flag.
-
-    cfl_violation = 0;
 
 #ifdef RADIATION
     // make sure these are filled to avoid check/plot file errors:

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -386,12 +386,6 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
 
         sdc_iters = sdc_iters_old;
 
-        // If we have hit a CFL violation during this subcycle, we must abort.
-
-        if (cfl_violation && !use_retry) {
-          amrex::Abort("CFL is too high at this level; go back to a checkpoint and restart with lower CFL number, or set castro.use_retry = 1");
-        }
-
         // If we're allowing for retries, check for that here.
 
         if (use_retry) {

--- a/Source/driver/Castro_advance_sdc.cpp
+++ b/Source/driver/Castro_advance_sdc.cpp
@@ -163,10 +163,6 @@ Castro::do_advance_sdc (Real time,
       if (do_hydro) {
         // Check for CFL violations.
         check_for_cfl_violation(S_old, dt);
-
-        // If we detect one, return immediately.
-        if (cfl_violation)
-          return dt;
       }
 
       // construct the update for the current stage -- this fills

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -391,7 +391,7 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
         cfl_violation = 1;
     }
 
-    // If we detect one, abort.
+    // If we detect a CFL violation, abort.
     if (cfl_violation) {
         amrex::Abort("CFL is too high at this level; go back to a checkpoint and restart with lower CFL number");
     }

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -233,8 +233,9 @@ Castro::cons_to_prim_fourth(const Real time)
 void
 Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
 {
-
     BL_PROFILE("Castro::check_for_cfl_violation()");
+
+    int cfl_violation = 0;
 
     auto dx = geom.CellSizeArray();
 
@@ -390,4 +391,8 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
         cfl_violation = 1;
     }
 
+    // If we detect one, abort.
+    if (cfl_violation) {
+        amrex::Abort("CFL is too high at this level; go back to a checkpoint and restart with lower CFL number");
+    }
 }


### PR DESCRIPTION

## PR summary

For the CTU advance, this case is already handled by the retry functionality. For the true SDC advance, which does not yet take advantage of retries, we directly abort if a CFL violation is found.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
