### PR TITLE
Add wdmerger test coverage of subcycling_mode = None

### DIFF
--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision
@@ -74,6 +74,9 @@ amr.max_level = 0
 # Refinement ratio
 amr.ref_ratio = 4 4 4 4 4 4 4 4 4
 
+# Don't do AMR subcycling for this setup
+amr.subcycling_mode = None
+
 # How many coarse timesteps between regridding
 amr.regrid_int = 2
 

--- a/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision.test
+++ b/Exec/science/wdmerger/tests/wdmerger_collision/inputs_2d_collision.test
@@ -1,0 +1,14 @@
+FILE = inputs_2d_collision
+
+# Start the problem when the stars are already merging.
+# This is an artificially contrived setup but will ensure
+# that burning begins immediately.
+
+problem.collision_separation = 1.25
+
+amr.n_cell = 64 128
+stop_time = 1.25
+amr.max_level = 2
+amr.ref_ratio = 2
+
+castro.init_shrink = 1.0


### PR DESCRIPTION

## PR summary

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
