### PR TITLE
change NSE_NET y_e initialization

### DIFF
--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -205,7 +205,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
 	    burn_state.mu_p = U(i,j,k,UMUP);
 	    burn_state.mu_n = U(i,j,k,UMUN);
 
-	    burn_state.y_e = 0.0_rt;
+	    burn_state.y_e = -1.0_rt;
 #endif
 
 #if AMREX_SPACEDIM == 1
@@ -528,7 +528,7 @@ Castro::react_state(Real time, Real dt)
 	    burn_state.mu_p = U_old(i,j,k,UMUP);
 	    burn_state.mu_n = U_old(i,j,k,UMUN);
 
-	    burn_state.y_e = 0.0_rt;
+	    burn_state.y_e = -1.0_rt;
 #endif
             // Initialize some data for later.
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

Change y_e initialization to -1.0. 

Pr1269 in Microphysics gives a warning when we recompute ye when ye was not 1.0 and when it goes out of range. It is better for debugging in the future.

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
