### PR TITLE
remove aux_names vector

### DIFF
--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -525,17 +525,11 @@ Castro::variableSetUp ()
     }
 
 #if NAUX_NET > 0
-  // Get the auxiliary names from the network model.
-  std::vector<std::string> aux_names;
-  for (int i = 0; i < NumAux; i++) {
-    aux_names.push_back(short_aux_names_cxx[i]);
-  }
-
   if ( ParallelDescriptor::IOProcessor())
     {
       std::cout << NumAux << " Auxiliary Variables: " << std::endl;
       for (int i = 0; i < NumAux; i++) {
-        std::cout << aux_names[i] << ' ' << ' ';
+        std::cout << short_aux_names_cxx[i] << ' ' << ' ';
       }
       std::cout << std::endl;
     }
@@ -544,7 +538,7 @@ Castro::variableSetUp ()
     {
       set_scalar_bc(bc, phys_bc);
       bcs[UFX+i] = bc;
-      name[UFX+i] = "rho_" + aux_names[i];
+      name[UFX+i] = "rho_" + short_aux_names_cxx[i];
     }
 #endif
 
@@ -1010,9 +1004,9 @@ Castro::variableSetUp ()
 
 #if NAUX_NET > 0
   for (int i = 0; i < NumAux; i++)  {
-    derive_lst.add(aux_names[i],IndexType::TheCellType(),1,ca_derspec,the_same_box);
-    derive_lst.addComponent(aux_names[i],desc_lst,State_Type,URHO,1);
-    derive_lst.addComponent(aux_names[i],desc_lst,State_Type,UFX+i,1);
+    derive_lst.add(short_aux_names_cxx[i], IndexType::TheCellType(), 1, ca_derspec, the_same_box);
+    derive_lst.addComponent(short_aux_names_cxx[i], desc_lst, State_Type, URHO, 1);
+    derive_lst.addComponent(short_aux_names_cxx[i], desc_lst, State_Type, UFX+i, 1);
   }
 #endif
 


### PR DESCRIPTION
this seems to be a holdover from when we copied things from Fortran but we can access the names directly from network_properties.H

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
