### PR TITLE
clean up the runtime parameter parser

### DIFF
--- a/Source/driver/_cpp_parameters
+++ b/Source/driver/_cpp_parameters
@@ -1,4 +1,4 @@
-# name   type   default   need in Fortran?   ifdef
+# name   type   default   ifdef
 #
 # note, name can have two values, as (a, b).  a will be the name used
 # in the inputs file, b is the variable name in the C++ class.
@@ -40,18 +40,18 @@ allow_non_unit_aspect_zones  int           0
 difmag                       Real          0.1
 
 # the small density cutoff.  Densities below this value will be reset
-small_dens                   Real         -1.e200             y
+small_dens                   Real         -1.e200
 
 # the small temperature cutoff.  Temperatures below this value will
 # be reset
-small_temp                   Real         -1.e200             y
+small_temp                   Real         -1.e200
 
 # the small pressure cutoff.  Pressures below this value will be reset
-small_pres                   Real         -1.e200             y
+small_pres                   Real         -1.e200
 
 # the small specific internal energy cutoff.  Internal energies below this
 # value will be reset
-small_ener                   Real         -1.e200             y
+small_ener                   Real         -1.e200
 
 # permits hydro to be turned on and off for running pure rad problems
 do_hydro                     int          -1
@@ -429,37 +429,37 @@ disable_shock_burning        int           0
 
 # initial guess for the temperature when inverting the EoS (e.g. when
 # calling eos_input_re)
-T_guess                     Real           1.e8               y
+T_guess                     Real           1.e8
 
 # if set to 1, we interpolate from the initial model to get the temperature
 # used to call the burner.  This prevents reactions from going nonlinear
 # and running away in place before a convective field is established.
-drive_initial_convection     int           0                  y
+drive_initial_convection     int           0
 
 # maximum time over which to do the drive_initial_convection procedure
-drive_initial_convection_tmax   Real       1.e200             y
+drive_initial_convection_tmax   Real       1.e200
 
 # frequency with which to re-initialize the thermodynamic data while preserving
 # the velocity field during drive_initial_convection
-drive_initial_convection_reinit_period   Real    1.e200      y
+drive_initial_convection_reinit_period   Real    1.e200
 
 #-----------------------------------------------------------------------------
 # category: diffusion
 #-----------------------------------------------------------------------------
 
 # enable thermal diffusion
-diffuse_temp                 int           0                  n     DIFFUSION
+diffuse_temp                 int           0                  DIFFUSION
 
 # set a cutoff density for diffusion -- we zero the term out below this density
-diffuse_cutoff_density       Real          -1.e200            n     DIFFUSION
+diffuse_cutoff_density       Real          -1.e200            DIFFUSION
 
 # secondary cutoff density -- there will be a linear dropoff in the diffusion
 # coefficient between this and the primary cutoff density. This should be the
 # larger of the two
-diffuse_cutoff_density_hi    Real          -1.e200            n     DIFFUSION
+diffuse_cutoff_density_hi    Real          -1.e200            DIFFUSION
 
 # scaling factor for conductivity
-diffuse_cond_scale_fac       Real          1.0                n     DIFFUSION
+diffuse_cond_scale_fac       Real          1.0                DIFFUSION
 
 
 #-----------------------------------------------------------------------------
@@ -480,89 +480,89 @@ grav_source_type             int           4
 do_rotation                  int          -1
 
 # the rotation period for the corotating frame
-rotational_period            Real         -1.e200             y        ROTATION
+rotational_period            Real         -1.e200             ROTATION
 
 # permits the centrifugal terms in the rotation to be turned on and off
-rotation_include_centrifugal int           1                  n        ROTATION
+rotation_include_centrifugal int           1                  ROTATION
 
 # permits the Coriolis terms in the rotation to be turned on and off
-rotation_include_coriolis    int           1                  n        ROTATION
+rotation_include_coriolis    int           1                  ROTATION
 
 # determines how the rotation source terms are added to the momentum and
 # energy equations
-rot_source_type              int           4                  n        ROTATION
+rot_source_type              int           4                  ROTATION
 
 # we can do a implicit solution of the rotation update to allow
 # for better coupling of the Coriolis terms
-implicit_rotation_update     int           1                  n        ROTATION
+implicit_rotation_update     int           1                  ROTATION
 
 # the coordinate axis (:math:`x=1`, :math:`y=2`, :math:`z=3`) for the rotation vector
-rot_axis                     int           3                  n        ROTATION
+rot_axis                     int           3                  ROTATION
 
 # include a central point mass
-use_point_mass               int           0                  n        GRAVITY
+use_point_mass               int           0                  GRAVITY
 
 # mass of the point mass
-point_mass                   Real          0.0                n        GRAVITY
+point_mass                   Real          0.0                GRAVITY
 
 # if we have a central point mass, we can prevent mass from building
 # up in the zones adjacent to it by keeping their density constant and
 # adding their mass to the point mass object
-point_mass_fix_solution      int           0                  n        GRAVITY
+point_mass_fix_solution      int           0                  GRAVITY
 
 # Distance (in kpc) used for calculation of the gravitational wave amplitude
 # (this will be calculated along all three coordinate axes). Only relevant if
 # castro.sum_interval > 0 and if set to a positive number. A standard value
 # in the literature is 10.0 (kpc).
-gw_dist                      Real          0.0                n        GRAVITY
+gw_dist                      Real          0.0                GRAVITY
 
 # This integer is used to activate parallel plane 1/r**2 gravity.
-point_mass_offset_is_true    int           0                  n        GRAVITY
+point_mass_offset_is_true    int           0                  GRAVITY
 
 # Distance, shifted from the origin, and used to compute the gravity on
-# plane parallel due to the action of an star with a radius given by this offset. 
+# plane parallel due to the action of an star with a radius given by this offset.
 
-point_mass_location_offset   Real          0.0                n        GRAVITY
+point_mass_location_offset   Real          0.0                GRAVITY
 
 #-----------------------------------------------------------------------------
 # category: sponge
 #-----------------------------------------------------------------------------
 
 # Minimum simulation distance from center to start applying the sponge
-sponge_lower_radius          Real         -1.0                n        SPONGE
+sponge_lower_radius          Real         -1.0                SPONGE
 
 # Simulation distance from the center at which the sponge is fully applied
-sponge_upper_radius          Real         -1.0                n        SPONGE
+sponge_upper_radius          Real         -1.0                SPONGE
 
 # Minimum density at which to start applying the sponge
-sponge_lower_density         Real         -1.0                n        SPONGE
+sponge_lower_density         Real         -1.0                SPONGE
 
 # Density at which the sponge is fully applied
-sponge_upper_density         Real         -1.0                n        SPONGE
+sponge_upper_density         Real         -1.0                SPONGE
 
 # Minimum pressure at which to start applying the sponge
-sponge_lower_pressure        Real         -1.0                n        SPONGE
+sponge_lower_pressure        Real         -1.0                SPONGE
 
 # Pressure at which the sponge is fully applied
-sponge_upper_pressure        Real         -1.0                n        SPONGE
+sponge_upper_pressure        Real         -1.0                SPONGE
 
 # Scaling factor for the sponge below the low end
-sponge_lower_factor          Real          0.0                n        SPONGE
+sponge_lower_factor          Real          0.0                SPONGE
 
 # Scaling factor for the sponge above the high end
-sponge_upper_factor          Real          1.0                n        SPONGE
+sponge_upper_factor          Real          1.0                SPONGE
 
 # Target x-velocity for the sponge to drive to
-sponge_target_x_velocity     Real          0.0                n        SPONGE
+sponge_target_x_velocity     Real          0.0                SPONGE
 
 # Target y-velocity for the sponge to drive to
-sponge_target_y_velocity     Real          0.0                n        SPONGE
+sponge_target_y_velocity     Real          0.0                SPONGE
 
 # Target z-velocity for the sponge to drive to
-sponge_target_z_velocity     Real          0.0                n        SPONGE
+sponge_target_z_velocity     Real          0.0                SPONGE
 
 # Timescale on which the sponge operates
-sponge_timescale             Real         -1.0                n        SPONGE
+sponge_timescale             Real         -1.0                SPONGE
 
 
 #-----------------------------------------------------------------------------
@@ -580,7 +580,7 @@ bndry_func_thread_safe       int           1
 #-----------------------------------------------------------------------------
 
 # the factor by which to extend the domain upon restart for embiggening
-grown_factor                 int           1                  y
+grown_factor                 int           1
 
 # used with the embiggening routines to determine how to extend the domain
 star_at_center               int          -1
@@ -691,7 +691,7 @@ do_radiation                 int           -1
 #-----------------------------------------------------------------------------
 
 # permits tracer particle calculation to be turned on and off
-do_tracer_particles          int           0       n      AMREX_PARTICLES
+do_tracer_particles          int           0       AMREX_PARTICLES
 
 
 @namespace: particles
@@ -725,11 +725,11 @@ timestamp_temperature        int           0
 @namespace: gravity
 
 # what type
-gravity_type                 string        "fillme"           y
+gravity_type                 string        "fillme"
 
 
 # if doing constant gravity, what is the acceleration
-const_grav                   Real          0.0                y
+const_grav                   Real          0.0
 
 # Check if the user wants to compute the boundary conditions using the
 # brute force method.  Default is false, since this method is slow.
@@ -806,7 +806,7 @@ beta                         Real          1.0
 
 @namespace: radiation
 
-prop_temp_floor              Real          0.0                y
+prop_temp_floor              Real          0.0
 
 flatten_pp_threshold         Real          -1.0
 
@@ -850,4 +850,3 @@ plot_lab_flux                int           0
 
 # do we plot the comoving frame radiation flux?
 plot_com_flux                int           0
-

--- a/Source/driver/parse_castro_params.py
+++ b/Source/driver/parse_castro_params.py
@@ -66,14 +66,14 @@ CWARNING = """
 // To update or add runtime parameters, please edit _cpp_parameters and rebuild.\n
 """
 
-def parse_params(infile, out_directory):
+def read_param_file(infile):
 
     params = []
 
     namespace = None
 
     try:
-        f = open(infile)
+        f = open(infile, encoding="UTF-8")
     except OSError:
         sys.exit("error opening the input file")
 
@@ -115,17 +115,7 @@ def parse_params(infile, out_directory):
             debug_default = None
 
         try:
-            in_fortran_string = fields[3]
-        except IndexError:
-            in_fortran = 0
-        else:
-            if in_fortran_string.lower().strip() == "y":
-                in_fortran = 1
-            else:
-                in_fortran = 0
-
-        try:
-            ifdef = fields[4]
+            ifdef = fields[3]
         except IndexError:
             ifdef = None
 
@@ -139,6 +129,9 @@ def parse_params(infile, out_directory):
                                ifdef=ifdef))
 
 
+    return params
+
+def write_headers(params, out_directory):
 
     # output
 
@@ -153,7 +146,7 @@ def parse_params(infile, out_directory):
 
         # write name_declares.H
         try:
-            cd = open(f"{out_directory}/{nm}_declares.H", "w")
+            cd = open(f"{out_directory}/{nm}_declares.H", "w", encoding="UTF-8")
         except OSError:
             sys.exit(f"unable to open {nm}_declares.H for writing")
 
@@ -179,7 +172,7 @@ def parse_params(infile, out_directory):
 
         # write name_params.H
         try:
-            cp = open(f"{out_directory}/{nm}_params.H", "w")
+            cp = open(f"{out_directory}/{nm}_params.H", "w", encoding="UTF-8")
         except OSError:
             sys.exit(f"unable to open {nm}_params.H for writing")
 
@@ -205,7 +198,7 @@ def parse_params(infile, out_directory):
 
         # write castro_queries.H
         try:
-            cq = open(f"{out_directory}/{nm}_queries.H", "w")
+            cq = open(f"{out_directory}/{nm}_queries.H", "w", encoding="UTF-8")
         except OSError:
             sys.exit(f"unable to open {nm}_queries.H for writing")
 
@@ -229,7 +222,7 @@ def parse_params(infile, out_directory):
 
         # write the job info tests
         try:
-            jo = open(f"{out_directory}/{nm}_job_info_tests.H", "w")
+            jo = open(f"{out_directory}/{nm}_job_info_tests.H", "w", encoding="UTF-8")
         except OSError:
             sys.exit(f"unable to open {nm}_job_info_tests.H")
 
@@ -256,7 +249,8 @@ def main():
 
     args = parser.parse_args()
 
-    parse_params(args.input_file[0], args.o)
+    p = read_param_file(args.input_file[0])
+    write_headers(p, args.o)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
remove the "in fortran" option as well as the field from the _cpp_parameters file and also split the parser into 2 function to make it easier to build off of.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
