### PR TITLE
fix bug introduced in #2574

### DIFF
--- a/Source/problems/Castro_bc_fill_nd.cpp
+++ b/Source/problems/Castro_bc_fill_nd.cpp
@@ -23,7 +23,7 @@ void ca_statefill(Box const& bx, FArrayBox& data,
     // valid data is always present.
 
     Vector<BCRec> bcr_noinflow{bcr};
-    for (auto bc : bcr_noinflow) {
+    for (auto & bc : bcr_noinflow) {
         for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
             if (bc.lo(dir) == EXT_DIR) {
                 bc.setLo(dir, FOEXTRAP);


### PR DESCRIPTION
we need to access bc as a reference for inflow to override the BC type

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
