### PR TITLE
Match wdmerger initial model resolution to resolution on finest level

### DIFF
--- a/Exec/science/wdmerger/_prob_params
+++ b/Exec/science/wdmerger/_prob_params
@@ -61,14 +61,6 @@ single_star                     integer               0                        n
 
 # 1D initial model parameters
 
-# For the grid spacing for our model, we'll use 
-# 6.25 km. No simulation we do is likely to have a resolution
-# higher than that inside the stars (it represents
-# three jumps by a factor of four compared to our 
-# normal coarse grid resolution).
-
-initial_model_dx                real                  6.25e5_rt                y
-
 # Composition properties of initial models.
 # We follow the prescription of Dan et al. 2012 for determining
 # the composition of the WDs. In this approach, below a certain 


### PR DESCRIPTION

## PR summary

## PR checklist

- [x] test suite needs to be run on this PR
- [x] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
