### PR TITLE
update double_bubble, gamma_law_bubble, and hse_convergence_general

### DIFF
--- a/Exec/gravity_tests/hse_convergence_general/_prob_params
+++ b/Exec/gravity_tests/hse_convergence_general/_prob_params
@@ -2,8 +2,6 @@ X_min                   real              1.e-4_rt                  y
 
 cutoff_density          real              500.e0_rt                 y
 
-dx_model                real              10.0_rt                   y
-
 T_hi                    real              5.e8_rt                   y
 
 T_star                  real              1.e8_rt                   y

--- a/Exec/gravity_tests/hse_convergence_general/inputs_1d.128.hse_test
+++ b/Exec/gravity_tests/hse_convergence_general/inputs_1d.128.hse_test
@@ -75,8 +75,6 @@ amr.plot_per         = 1.e-5      # number of seconds between plotfiles
 amr.derive_plot_vars = ALL
 
 # PROBLEM PARAMETERS
-problem.dx_model = 20.e0
-
 problem.dens_base = 3.43e6
 
 problem.T_star = 1.e8

--- a/Exec/gravity_tests/hse_convergence_general/inputs_1d.256.hse_test
+++ b/Exec/gravity_tests/hse_convergence_general/inputs_1d.256.hse_test
@@ -75,8 +75,6 @@ amr.plot_per         = 1.e-5      # number of seconds between plotfiles
 amr.derive_plot_vars = ALL
 
 # PROBLEM PARAMETERS
-problem.dx_model = 20.e0
-
 problem.dens_base = 3.43e6
 
 problem.T_star = 1.e8

--- a/Exec/gravity_tests/hse_convergence_general/inputs_1d.512.hse_test
+++ b/Exec/gravity_tests/hse_convergence_general/inputs_1d.512.hse_test
@@ -75,8 +75,6 @@ amr.plot_per         = 1.e-5      # number of seconds between plotfiles
 amr.derive_plot_vars = ALL
 
 # PROBLEM PARAMETERS
-problem.dx_model = 20.e0
-
 problem.dens_base = 3.43e6
 
 problem.T_star = 1.e8

--- a/Exec/gravity_tests/hse_convergence_general/problem_initialize.H
+++ b/Exec/gravity_tests/hse_convergence_general/problem_initialize.H
@@ -133,9 +133,14 @@ void problem_initialize ()
         amrex::Error("ERROR: fuel mass fractions don't sum to 1");
     }
 
+    // we use the fine grid dx for the model resolution
+    auto fine_geom = global::the_amr_ptr->Geom(global::the_amr_ptr->maxLevel());
+
+    auto dx = fine_geom.CellSizeArray();
+    auto dx_model = dx[AMREX_SPACEDIM-1];
 
     int nx_model = static_cast<int>((probhi[AMREX_SPACEDIM-1] -
-                                     problo[AMREX_SPACEDIM-1]) / problem::dx_model);
+                                     problo[AMREX_SPACEDIM-1]) / dx_model);
 
     int ng = 4;
 
@@ -152,7 +157,7 @@ void problem_initialize ()
     model_params.low_density_cutoff = problem::low_density_cutoff;
 
     generate_initial_model(nx_model + ng,
-                           problo[AMREX_SPACEDIM-1] - ng*problem::dx_model,
+                           problo[AMREX_SPACEDIM-1] - ng * dx_model,
                            probhi[AMREX_SPACEDIM-1],
                            model_params);
 

--- a/Exec/hydro_tests/double_bubble/_prob_params
+++ b/Exec/hydro_tests/double_bubble/_prob_params
@@ -22,8 +22,6 @@ single                  integer       0               y
 # at the lower boundary, do we extrapolate the vertical momentum or set it to zero
 boundary_type           integer       1               y
 
-dx_model                real          0.00390625      y
-
 left_bubble_x_center    real          0.0_rt
 
 right_bubble_x_center   real          0.0_rt

--- a/Exec/hydro_tests/double_bubble/inputs_2d
+++ b/Exec/hydro_tests/double_bubble/inputs_2d
@@ -86,8 +86,6 @@ problem.pert_width = 0.025e0
 
 problem.do_isentropic = 1
 
-problem.dx_model = 0.00390625
-
 # EOS
 eos.species_a_name = "A"
 eos.species_a_gamma = 1.666e0

--- a/Exec/hydro_tests/double_bubble/inputs_2d.single
+++ b/Exec/hydro_tests/double_bubble/inputs_2d.single
@@ -88,8 +88,6 @@ problem.do_isentropic = 1
 
 problem.single = 1
 
-problem.dx_model = 0.005859375
-
 # EOS
 eos.species_a_name = "A"
 eos.species_a_gamma = 1.666e0

--- a/Exec/hydro_tests/double_bubble/inputs_2d.single.equal
+++ b/Exec/hydro_tests/double_bubble/inputs_2d.single.equal
@@ -88,8 +88,6 @@ problem.do_isentropic = 1
 
 problem.single = 1
 
-problem.dx_model = 0.005859375
-
 # EOS
 eos.species_a_name = "A"
 eos.species_a_gamma = 1.666e0

--- a/Exec/hydro_tests/double_bubble/inputs_2d.test
+++ b/Exec/hydro_tests/double_bubble/inputs_2d.test
@@ -86,8 +86,6 @@ problem.pert_width = 0.025e0
 
 problem.do_isentropic = 1
 
-problem.dx_model = 0.00390625
-
 # EOS
 eos.species_a_name = "A"
 eos.species_a_gamma = 1.666e0

--- a/Exec/hydro_tests/double_bubble/problem_initialize.H
+++ b/Exec/hydro_tests/double_bubble/problem_initialize.H
@@ -37,8 +37,14 @@ void problem_initialize ()
 
     // we'll generate the initial model at the needed resolution
 
+    // we use the fine grid dx for the model resolution
+    auto fine_geom = global::the_amr_ptr->Geom(global::the_amr_ptr->maxLevel());
+
+    auto dx = fine_geom.CellSizeArray();
+    auto dx_model = dx[AMREX_SPACEDIM-1];
+
     int nx = (2.0_rt * problem::center[AMREX_SPACEDIM-1] + 1.e-8_rt) /
-        problem::dx_model;
+        dx_model;
 
     model_t model_params;
     model_params.dens_base = problem::dens_base;

--- a/Exec/hydro_tests/gamma_law_bubble/_prob_params
+++ b/Exec/hydro_tests/gamma_law_bubble/_prob_params
@@ -9,5 +9,3 @@ y_pert_center     real           0.7_rt      y
 pert_width        real           0.025_rt    y
 
 do_isentropic     integer        0           y
-
-dx_model          real           0.00390625  y

--- a/Exec/hydro_tests/gamma_law_bubble/problem_initialize.H
+++ b/Exec/hydro_tests/gamma_law_bubble/problem_initialize.H
@@ -28,8 +28,14 @@ void problem_initialize ()
     // first make a 1D initial model for the entire domain
     // we'll create it ourselves, but hook it into the model_parser
 
+    // we use the fine grid dx for the model resolution
+    auto fine_geom = global::the_amr_ptr->Geom(global::the_amr_ptr->maxLevel());
+
+    auto dx = fine_geom.CellSizeArray();
+    auto dx_model = dx[AMREX_SPACEDIM-1];
+
     int nx = (2.0_rt * problem::center[AMREX_SPACEDIM-1] + 1.e-8_rt) /
-        problem::dx_model;
+        dx_model;
 
     model_t model_params;
     model_params.p_base = problem::pres_base;


### PR DESCRIPTION
now they infer dx_model from the_amr_ptr instead of needing it to be set manually as a runtime parameter

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
