### PR TITLE
Protect against use_post_step_regrid when not subcycling

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -216,6 +216,7 @@ Castro::read_params ()
     initialize_cpp_runparams();
 
     ParmParse pp("castro");
+    ParmParse ppa("amr");
 
     using namespace castro;
 
@@ -441,6 +442,13 @@ Castro::read_params ()
         }
     }
 
+    // Post-timestep regrids only make sense if we're subcycling.
+    std::string subcycling_mode;
+    ppa.query("subcycling_mode", subcycling_mode);
+    if (use_post_step_regrid == 1 && subcycling_mode == "None") {
+        amrex::Error("castro.use_post_step_regrid == 1 is not consistent with amr.subcycling_mode = None.");
+    }
+
 #ifdef AMREX_PARTICLES
     read_particle_params();
 #endif
@@ -545,7 +553,6 @@ Castro::read_params ()
 
    }
 
-   ParmParse ppa("amr");
    ppa.query("probin_file",probin_file);
 
     Vector<int> tilesize(AMREX_SPACEDIM);


### PR DESCRIPTION

## PR summary

The castro.use_post_step_regrid parameter doesn't make sense when we're not subcycling. By the time we finish the coarse step we will already have finished all of the fine timesteps (thanks to the recent change in #2505), so there's nothing left to do.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
