### PR TITLE
allow for optional passive sources to the conserved state

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -270,6 +270,10 @@ ifeq ($(USE_ROTATION), TRUE)
   DEFINES += -DROTATION
 endif
 
+ifeq ($(USE_SPECIES_SOURCES), TRUE)
+  DEFINES += -DCONS_SPECIES_HAVE_SOURCES
+endif
+
 ifeq ($(USE_PARTICLES), TRUE)
   Bdirs += Source/particles
 endif

--- a/Source/driver/_variables
+++ b/Source/driver/_variables
@@ -16,9 +16,9 @@
    energy-density         UEDEN     NSRC                                  1                 None
    internal-energy        UEINT     NSRC                                  1                 None
    temperature            UTEMP     NSRC                                  1                 None
-   advected               UFA       None                                  NumAdv            None
-   species                UFS       None                                  NumSpec           None
-   auxiliary              UFX       None                                  NumAux            None
+   advected               UFA       [(NSRC, CONS_SPECIES_HAVE_SOURCES)]   NumAdv            None
+   species                UFS       [(NSRC, CONS_SPECIES_HAVE_SOURCES)]   NumSpec           None
+   auxiliary              UFX       [(NSRC, CONS_SPECIES_HAVE_SOURCES)]   NumAux            None
    shock                  USHK      None                                  1                 SHOCK_VAR
    mu_p                   UMUP      None                                  1                 NSE_NET
    mu_n                   UMUN      None                                  1                 NSE_NET

--- a/Source/driver/set_variables.py
+++ b/Source/driver/set_variables.py
@@ -132,6 +132,7 @@ def doit(variables_file, odir, defines, nadv):
                 count = fields[3]
                 ifdef = fields[4]
 
+                print("here: ", name, var, adds_to_temp, count, ifdef)
                 # we may be fed a pair of the form (SET, DEFINE),
                 # in which case we only add to SET if we define
                 # DEFINE
@@ -153,6 +154,8 @@ def doit(variables_file, odir, defines, nadv):
                     if adds_to_temp == "None":
                         adds_to = None
                     else:
+                        if adds_to_temp.startswith("("):
+                            print("here")
                         adds_to = [adds_to_temp]
 
                 # only recognize the index if we defined any required preprocessor variable

--- a/Source/driver/set_variables.py
+++ b/Source/driver/set_variables.py
@@ -132,7 +132,6 @@ def doit(variables_file, odir, defines, nadv):
                 count = fields[3]
                 ifdef = fields[4]
 
-                print("here: ", name, var, adds_to_temp, count, ifdef)
                 # we may be fed a pair of the form (SET, DEFINE),
                 # in which case we only add to SET if we define
                 # DEFINE
@@ -154,8 +153,6 @@ def doit(variables_file, odir, defines, nadv):
                     if adds_to_temp == "None":
                         adds_to = None
                     else:
-                        if adds_to_temp.startswith("("):
-                            print("here")
                         adds_to = [adds_to_temp]
 
                 # only recognize the index if we defined any required preprocessor variable


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

Space will be allocated for the passive scalars in the conserved state if we set USE_SPECIES_SOURCES=TRUE
in the makefile.  This is off by default, as most applications don't need it.

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
