### PR TITLE
add braces around initialization to address clang-tidy

### DIFF
--- a/Source/driver/sum_utils.cpp
+++ b/Source/driver/sum_utils.cpp
@@ -517,7 +517,7 @@ Castro::gwstrain (Real time,
 
     // Standard Kronecker delta.
 
-    Real delta[3][3] = {0.0};
+    Real delta[3][3] = {{0.0}};
 
     for (int i = 0; i < 3; ++i) {
         delta[i][i] = 1.0;
@@ -539,7 +539,7 @@ Castro::gwstrain (Real time,
 
         // Projection operator onto the unit vector n.
 
-        Real proj[3][3][3][3] = {0.0};
+        Real proj[3][3][3][3] = {{0.0}};
 
         for (int l = 0; l < 3; ++l) {
             for (int k = 0; k < 3; ++k) {
@@ -554,7 +554,7 @@ Castro::gwstrain (Real time,
 
         // Now we can calculate the strain tensor.
 
-        Real h[3][3] = {0.0};
+        Real h[3][3] = {{0.0}};
 
         for (int l = 0; l < 3; ++l) {
             for (int k = 0; k < 3; ++k) {


### PR DESCRIPTION
it has: warning: suggest braces around initialization of subobject

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
