### PR TITLE
ROCm workaround: Use ParallelFor instead of Reduce

### DIFF
--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -193,7 +193,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
     int num_failed = 0;
 
 #ifdef _OPENMP
-#pragma omp parallel reduce(+:num_failed);
+#pragma omp parallel reduction(+:num_failed);
 #endif
     for (MFIter mfi(s, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {

--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -193,7 +193,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
     int num_failed = 0;
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(+:num_failed);
+#pragma omp parallel reduction(+:num_failed)
 #endif
     for (MFIter mfi(s, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -210,7 +210,11 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
         const auto problo = geom.ProbLoArray();
 #endif
 
+#if defined(AMREX_USE_GPU)
         ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+#else
+        LoopOnCpu(bx, [&] (int i, int j, int k) mutable
+#endif
         {
 
             burn_t burn_state;
@@ -549,7 +553,11 @@ Castro::react_state(Real time, Real dt)
         const auto dx = geom.CellSizeArray();
         const auto problo = geom.ProbLoArray();
 
+#if defined(AMREX_USE_GPU)
         ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+#else
+        LoopOnCpu(bx, [&] (int i, int j, int k) mutable
+#endif
         {
             burn_t burn_state;
 

--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -409,6 +409,7 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
 #endif
         });
 
+        Gpu::streamSynchronize(); // otherwise HIP may faile to allocate the necessary resources.
     }
 
 #if defined(AMREX_USE_GPU)
@@ -793,6 +794,8 @@ Castro::react_state(Real time, Real dt)
             num_failed += burn_failed;
 #endif
         });
+
+        Gpu::streamSynchronize(); // otherwise HIP may faile to allocate the necessary resources.
     }
 
 #if defined(AMREX_USE_GPU)

--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -413,7 +413,9 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
 #endif
         });
 
+#if defined(AMREX_USE_HIP)
         Gpu::streamSynchronize(); // otherwise HIP may faile to allocate the necessary resources.
+#endif
     }
 
 #if defined(AMREX_USE_GPU)
@@ -803,7 +805,9 @@ Castro::react_state(Real time, Real dt)
 #endif
         });
 
+#if defined(AMREX_USE_HIP)
         Gpu::streamSynchronize(); // otherwise HIP may faile to allocate the necessary resources.
+#endif
     }
 
 #if defined(AMREX_USE_GPU)


### PR DESCRIPTION
Assuming the failure is not often, we can use ParallelFor with atomicAdd to
obtain the number of failures. With this change, the ROCm memory issue seems
to be gone.
