### PR TITLE
some massive_star inputs fixes

### DIFF
--- a/Exec/science/massive_star/inputs_2d.nse
+++ b/Exec/science/massive_star/inputs_2d.nse
@@ -32,6 +32,7 @@ castro.do_sponge = 1
 
 castro.ppm_type = 1
 castro.ppm_temp_fix = 0
+castro.use_pslope = 1
 
 castro.use_flattening = 1
 
@@ -64,12 +65,12 @@ amr.check_int       = 50     # number of timesteps between checkpoints
 amr.plot_file       = massive_star_plt     # root name of plot file
 amr.plot_per = 5.0
 amr.derive_plot_vars = ALL
-castro.store_burn_weights = 1
+castro.store_burn_weights = 0
 
 amr.small_plot_file       = massive_star_smallplt     # root name of plot file
 amr.small_plot_per = 0.5
-amr.small_plot_vars = density Temp
-amr.derive_small_plot_vars = abar Ye enuc MachNumber magvel magvort in_nse
+amr.small_plot_vars = density Temp in_nse
+amr.derive_small_plot_vars = abar Ye enuc MachNumber magvel magvort
 
 fab.format = NATIVE_32
 


### PR DESCRIPTION
in_nse is not derived, so it wasn't being stored
turn on pslope
don't store burn weights

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
