### PR TITLE
Add cross-ref to section about creating new derived variables

### DIFF
--- a/Docs/source/creating_a_problem.rst
+++ b/Docs/source/creating_a_problem.rst
@@ -200,6 +200,8 @@ each of these in the main source tree.
    problem which refines a rectangular region (fuel layer) based on
    a density parameter and the H mass fraction.
 
+   .. _problem_derives:
+
 -  ``Problem_Derives.H``, ``Problem_Derive.H``, and ``Problem_Derives.cpp``
 
    Together, these provide a mechanism to create derived quantities

--- a/Docs/source/creating_a_problem.rst
+++ b/Docs/source/creating_a_problem.rst
@@ -202,7 +202,7 @@ each of these in the main source tree.
 
    .. _problem_derives:
 
--  ``Problem_Derives.H``, ``Problem_Derive.H``, and ``Problem_Derives.cpp``
+-  ``Problem_Derives.H``, ``Problem_Derive.H``, and ``Problem_Derive.cpp``
 
    Together, these provide a mechanism to create derived quantities
    that can be stored in the plotfile. ``Problem_Derives.H``

--- a/Docs/source/io.rst
+++ b/Docs/source/io.rst
@@ -397,6 +397,8 @@ Derived variables
 problem-specific plotfile variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+See the section on :ref:`Problem_Derives.H <problem_derives>` for more details about defining your own plotfile variables.
+
 +-----------------------------------+---------------------------------------------------+--------------------------------------+
 | variable name                     | description                                       | units                                |
 +===================================+===================================================+======================================+


### PR DESCRIPTION
It took me a little while to find where this is in the docs.