### PR TITLE
fix mismatch in fill_hybrid_hydro_source prototype

### DIFF
--- a/Source/hydro/Castro_hybrid.cpp
+++ b/Source/hydro/Castro_hybrid.cpp
@@ -84,7 +84,7 @@ Castro::construct_new_hybrid_source(MultiFab& source, MultiFab& state_old, Multi
 
 
 void
-Castro::fill_hybrid_hydro_source(MultiFab& sources, MultiFab& state_in, Real mult_factor)
+Castro::fill_hybrid_hydro_source(MultiFab& sources, const MultiFab& state_in, Real mult_factor)
 {
     BL_PROFILE("Castro::fill_hybrid_hydro_source()");
 
@@ -97,7 +97,7 @@ Castro::fill_hybrid_hydro_source(MultiFab& sources, MultiFab& state_in, Real mul
     {
         const Box& bx = mfi.tilebox();
 
-        auto u = state_in.array(mfi);
+        const auto u = state_in.array(mfi);
         auto src = sources.array(mfi);
 
         amrex::ParallelFor(bx,

--- a/Source/hydro/Castro_hydro.H
+++ b/Source/hydro/Castro_hydro.H
@@ -856,7 +856,7 @@
 /// @param source       MultiFab to save source to
 /// @param mult_factor
 ///
-    void fill_hybrid_hydro_source(amrex::MultiFab& state, amrex::MultiFab& source, const amrex::Real mult_factor);
+    void fill_hybrid_hydro_source(amrex::MultiFab& source, const amrex::MultiFab& state, const amrex::Real mult_factor);
 
 
 ///


### PR DESCRIPTION
we had arguments swapped
also mark the incoming state const

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
