### PR TITLE
get rid of asctime -- it is unsafe

### DIFF
--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -575,10 +575,8 @@ Castro::writeJobInfo (const std::string& dir, const Real io_time)
   jobInfoFile << PrettyLine;
 
   const std::time_t now = time(nullptr);
-  char buf[64];
-  if (strftime(buf, sizeof buf, "%c\n", std::localtime(&now))) {
-      jobInfoFile << "output date / time: " << buf << "\n";
-  }
+  jobInfoFile << "output date / time: "
+              << std::put_time(std::localtime(&now), "%c\n") << "\n";
 
   char currentDir[FILENAME_MAX];
   if (getcwd(currentDir, FILENAME_MAX) != nullptr) {

--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -574,11 +574,11 @@ Castro::writeJobInfo (const std::string& dir, const Real io_time)
   jobInfoFile << " Plotfile Information\n";
   jobInfoFile << PrettyLine;
 
-  time_t now = time(nullptr);
-
-  // Convert now to tm struct for local timezone
-  tm* localtm = localtime(&now);
-  jobInfoFile   << "output date / time: " << asctime(localtm);
+  const std::time_t now = time(nullptr);
+  char buf[64];
+  if (strftime(buf, sizeof buf, "%c\n", std::localtime(&now))) {
+      jobInfoFile << "output date / time: " << buf << "\n";
+  }
 
   char currentDir[FILENAME_MAX];
   if (getcwd(currentDir, FILENAME_MAX) != nullptr) {


### PR DESCRIPTION
flagged by clang-tidy bugprone-unsafe-functions
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
