### PR TITLE
fix retry timelevels when amr.subcycle_mode = None

### DIFF
--- a/Exec/gravity_tests/DustCollapse/inputs_3d_monopole_regtest
+++ b/Exec/gravity_tests/DustCollapse/inputs_3d_monopole_regtest
@@ -36,6 +36,7 @@ castro.small_dens    = 1.e-6
 castro.cfl            = 0.5     # cfl number for hyperbolic system
 castro.init_shrink    = 0.1     # scale back initial timestep
 castro.change_max     = 1.05    # scale back initial timestep
+castro.fixed_dt = 1.5e-3
 
 # SPONGE
 castro.sponge_lower_density = 1.0e-3
@@ -44,17 +45,18 @@ castro.sponge_timescale = 1.0e-3
 
 # DIAGNOSTICS & VERBOSITY
 castro.sum_interval   = 1       # timesteps between computing mass
-castro.v              = 0       # verbosity in Castro.cpp
+castro.v              = 1       # verbosity in Castro.cpp
 amr.v                 = 1       # verbosity in Amr.cpp
 #amr.grid_log        = grdlog  # name of grid logging file
 
 # REFINEMENT / REGRIDDING
-amr.max_level       = 0       # maximum level number allowed
-amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.max_level       = 1       # maximum level number allowed
+amr.ref_ratio       = 4 2 2 2 # refinement ratio
 amr.regrid_int      = 2 2 2 2 # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 32
 amr.n_error_buf     = 2 2 2 2 # number of buffer cells in error est
+amr.subcycling_mode = None
 
 amr.refinement_indicators = dengrad
 

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -346,8 +346,10 @@ Castro::subcycle_advance_ctu(const Real time, const Real dt, int amr_iteration, 
 
         // Set the relevant time levels.
 
-        for (int k = 0; k < num_state_type; k++) {
-          state[k].setTimeLevel(subcycle_time + dt_subcycle, dt_subcycle, 0.0);
+        for (int lev = level; lev <= max_level_to_advance; ++lev) {
+            for (int k = 0; k < num_state_type; k++) {
+                getLevel(lev).state[k].setTimeLevel(subcycle_time + dt_subcycle, dt_subcycle, 0.0);
+            }
         }
 
         // Do the advance and construct the relevant source terms. For CTU this


### PR DESCRIPTION
when we are not doing AMR subcycling and trigger a retry, we will advance all levels again at the new timestep.  However, we were not properly resetting the timelevels in the StateData to reflect the new subcycled timestep.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
