### PR TITLE
optimize capture of BCs in ambient_fill

### DIFF
--- a/Source/problems/ambient_fill.cpp
+++ b/Source/problems/ambient_fill.cpp
@@ -6,9 +6,10 @@ void
 ambient_denfill(const Box& bx, Array4<Real> const& state,
                 Geometry const& geom, const Vector<BCRec>& bcr)
 {
+
     // Make a copy of the BC that can be passed by value to the ParallelFor.
 
-    BCRec bc = bcr[0];
+    BCRec bc = bcr[URHO];
 
     const auto domlo = geom.Domain().loVect3d();
     const auto domhi = geom.Domain().hiVect3d();
@@ -62,12 +63,11 @@ void
 ambient_fill(const Box& bx, Array4<Real> const& state,
              Geometry const& geom, const Vector<BCRec>& bcr)
 {
-    // Copy BCs to an Array1D so they can be passed by value to the ParallelFor.
 
-    Array1D<BCRec, 0, NUM_STATE - 1> bcs;
-    for (int n = 0; n < NUM_STATE; ++n) {
-        bcs(n) = bcr[n];
-    }
+    // Make a copy of the BC that can be passed by value to the ParallelFor.
+    // even though this fills all components, we only check the density BCs
+
+    BCRec bc = bcr[URHO];
 
     const auto domlo = geom.Domain().loVect3d();
     const auto domhi = geom.Domain().hiVect3d();
@@ -76,22 +76,22 @@ ambient_fill(const Box& bx, Array4<Real> const& state,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         bool ambient_x_lo = (castro::ambient_fill_dir == 0 || castro::ambient_fill_dir == -1) &&
-                            (bcs(URHO).lo(0) == amrex::BCType::foextrap || bcs(URHO).lo(0) == amrex::BCType::hoextrap);
+                            (bc.lo(0) == amrex::BCType::foextrap || bc.lo(0) == amrex::BCType::hoextrap);
         bool ambient_x_hi = (castro::ambient_fill_dir == 0 || castro::ambient_fill_dir == -1) &&
-                            (bcs(URHO).hi(0) == amrex::BCType::foextrap || bcs(URHO).hi(0) == amrex::BCType::hoextrap);
+                            (bc.hi(0) == amrex::BCType::foextrap || bc.hi(0) == amrex::BCType::hoextrap);
 
 #if AMREX_SPACEDIM >= 2
         bool ambient_y_lo = (castro::ambient_fill_dir == 1 || castro::ambient_fill_dir == -1) &&
-                            (bcs(URHO).lo(1) == amrex::BCType::foextrap || bcs(URHO).lo(1) == amrex::BCType::hoextrap);
+                            (bc.lo(1) == amrex::BCType::foextrap || bc.lo(1) == amrex::BCType::hoextrap);
         bool ambient_y_hi = (castro::ambient_fill_dir == 1 || castro::ambient_fill_dir == -1) &&
-                            (bcs(URHO).hi(1) == amrex::BCType::foextrap || bcs(URHO).hi(1) == amrex::BCType::hoextrap);
+                            (bc.hi(1) == amrex::BCType::foextrap || bc.hi(1) == amrex::BCType::hoextrap);
 #endif
 
 #if AMREX_SPACEDIM == 3
         bool ambient_z_lo = (castro::ambient_fill_dir == 2 || castro::ambient_fill_dir == -1) &&
-                            (bcs(URHO).lo(2) == amrex::BCType::foextrap || bcs(URHO).lo(2) == amrex::BCType::hoextrap);
+                            (bc.lo(2) == amrex::BCType::foextrap || bc.lo(2) == amrex::BCType::hoextrap);
         bool ambient_z_hi = (castro::ambient_fill_dir == 2 || castro::ambient_fill_dir == -1) &&
-                            (bcs(URHO).hi(2) == amrex::BCType::foextrap || bcs(URHO).hi(2) == amrex::BCType::hoextrap);
+                            (bc.hi(2) == amrex::BCType::foextrap || bc.hi(2) == amrex::BCType::hoextrap);
 #endif
 
         if (castro::fill_ambient_bc == 1) {


### PR DESCRIPTION
we were capturing the entire bcs array by copy even though we only ever used the density component.  This reduces the side of the copy. This was flagged by coverity

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
