### PR TITLE
Avoid FP overflow during Detonation initialization

### DIFF
--- a/Exec/science/Detonation/problem_initialize_state_data.H
+++ b/Exec/science/Detonation/problem_initialize_state_data.H
@@ -22,7 +22,15 @@ void problem_initialize_state_data (int i, int j, int k,
 
     state(i,j,k,URHO) = problem::dens;
 
-    Real sigma = 1.0_rt / (1.0_rt + std::exp(-(c_T - xcen)/ width));
+    Real sigma_arg = -(c_T - xcen) / width;
+    Real sigma;
+    // need to avoid FP overflow for sigma_arg >= 709
+    // 1/(1 + exp(100)) ~= 3e-44, which is much smaller than machine epsilon
+    if (sigma_arg < 100) {
+        sigma = 1.0_rt / (1.0_rt + std::exp(sigma_arg));
+    } else {
+        sigma = 0.0_rt;
+    }
 
     state(i,j,k,UTEMP) = problem::T_l + (problem::T_r - problem::T_l) * (1.0_rt - sigma);
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->
I was getting errors here when running with `amrex.fpe_trap_overflow=1`.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
