### PR TITLE
if we have USE_GPU_PRINTF = TRUE, then fflush the output after burn

### DIFF
--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -415,8 +415,13 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
         });
 
 #if defined(AMREX_USE_HIP)
-        Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
+       Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
 #endif
+
+#ifdef ALLOW_GPU_PRINTF
+       std::fflush(nullptr);
+#endif
+
     }
 
 #if defined(AMREX_USE_GPU)
@@ -812,6 +817,11 @@ Castro::react_state(Real time, Real dt)
 #if defined(AMREX_USE_HIP)
         Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
 #endif
+
+#ifdef ALLOW_GPU_PRINTF
+       std::fflush(nullptr);
+#endif
+
     }
 
 #if defined(AMREX_USE_GPU)

--- a/Source/reactions/Castro_react.cpp
+++ b/Source/reactions/Castro_react.cpp
@@ -415,11 +415,11 @@ Castro::react_state(MultiFab& s, MultiFab& r, Real time, Real dt, const int stra
         });
 
 #if defined(AMREX_USE_HIP)
-       Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
+        Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
 #endif
 
 #ifdef ALLOW_GPU_PRINTF
-       std::fflush(nullptr);
+        std::fflush(nullptr);
 #endif
 
     }


### PR DESCRIPTION
this will catch the prints from the burner that were added to Microphysics

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
