### PR TITLE
don't compute hybrid momentum sources unless needed

### DIFF
--- a/Source/hydro/Castro_hybrid.cpp
+++ b/Source/hydro/Castro_hybrid.cpp
@@ -14,6 +14,10 @@ Castro::construct_old_hybrid_source(MultiFab& source, MultiFab& state_old, Real 
 
     BL_PROFILE("Castro::construct_old_hybrid_source()");
 
+    if (! castro::hybrid_hydro) {
+        return;
+    }
+
     const Real strt_time = ParallelDescriptor::second();
 
     Real mult_factor = 1.0;
@@ -48,6 +52,10 @@ Castro::construct_new_hybrid_source(MultiFab& source, MultiFab& state_old, Multi
     amrex::ignore_unused(dt);
 
     BL_PROFILE("Castro::construct_new_hybrid_source()");
+
+    if (! castro::hybrid_hydro) {
+        return;
+    }
 
     const Real strt_time = ParallelDescriptor::second();
 

--- a/Source/sources/Castro_sources.cpp
+++ b/Source/sources/Castro_sources.cpp
@@ -80,7 +80,7 @@ Castro::source_flag(int src)
 
 #ifdef HYBRID_MOMENTUM
     case hybrid_src:
-        if (castro::hybid_hydro) {
+        if (castro::hybrid_hydro) {
             return true;
         } else {
             return false;

--- a/Source/sources/Castro_sources.cpp
+++ b/Source/sources/Castro_sources.cpp
@@ -80,7 +80,11 @@ Castro::source_flag(int src)
 
 #ifdef HYBRID_MOMENTUM
     case hybrid_src:
-        return true;
+        if (castro::hybid_hydro) {
+            return true;
+        } else {
+            return false;
+        }
 #endif
 
 #ifdef GRAVITY


### PR DESCRIPTION
if we compile with USE_HYBRID_MOMENTUM=TRUE but run with castro.hybrid_hydro=0, we were still computing the hybrid_sources. These are not needed.

This logic now mirrors the rotation logic.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
