### PR TITLE
update mom_flux_has_p to address with 2D spherical

### DIFF
--- a/Source/driver/Castro_util.H
+++ b/Source/driver/Castro_util.H
@@ -79,7 +79,7 @@ bool mom_flux_has_p (const int mom_dir, const int flux_dir, const int coord)
         if (coord == CoordSys::SPHERICAL) {
             return false;
         }
-        return true
+        return true;
 
     } else {
         return (mom_dir == flux_dir);

--- a/Source/driver/Castro_util.H
+++ b/Source/driver/Castro_util.H
@@ -75,6 +75,14 @@ bool mom_flux_has_p (const int mom_dir, const int flux_dir, const int coord)
             return true;
         }
 
+    } else if (mom_dir == 1 && flux_dir == 1) {
+
+        if (coord == CoordSys::spherical) {
+            return false;
+        } else {
+            return true
+        }
+
     } else {
         return (mom_dir == flux_dir);
     }

--- a/Source/driver/Castro_util.H
+++ b/Source/driver/Castro_util.H
@@ -71,17 +71,15 @@ bool mom_flux_has_p (const int mom_dir, const int flux_dir, const int coord)
 
         if (coord != CoordSys::cartesian) {
             return false;
-        } else {
-            return true;
         }
+        return true;
 
     } else if (mom_dir == 1 && flux_dir == 1) {
 
-        if (coord == CoordSys::spherical) {
+        if (coord == CoordSys::SPHERICAL) {
             return false;
-        } else {
-            return true
         }
+        return true
 
     } else {
         return (mom_dir == flux_dir);

--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -69,7 +69,7 @@ Castro::consup_hydro(const Box& bx,
         // Add gradp term to momentum equation -- only for axisymmetric
         // coords (and only for the radial flux).
 
-        U_new(i,j,k,UMX) += - dt * (qx(i+1,j,k,GDPRES) - qx(i,j,k,GDPRES)) / geomdata.CellSize(1);
+        U_new(i,j,k,UMX) += - dt * (qx(i+1,j,k,GDPRES) - qx(i,j,k,GDPRES)) / geomdata.CellSize(0);
 
 #if AMREX_SPACEDIM >= 2
     } else if (n == UMY && !mom_flux_has_p(1, 1, geomdata.Coord())) {

--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -71,12 +71,13 @@ Castro::consup_hydro(const Box& bx,
 
         U_new(i,j,k,UMX) += - dt * (qx(i+1,j,k,GDPRES) - qx(i,j,k,GDPRES)) / geomdata.CellSize()[0];
 
+#if AMREX_SPACEDIM >= 2
     } else if (n == UMY && !mom_flux_has_p(1, 1, geomdata.Coord())) {
         // Add gradp term to polar(theta) momentum equation for Spherical 2D geometry
 
         Real r = geom.ProbLoArray()[0] + (static_cast<Real>(i) + 0.5_rt) * geomdata.CellSize()[0];
         U_new(i,j,k,UMY) += - dt * (qy(i,j+1,k,GDPRES) - qy(i,j,k,GDPRES)) / (r * geomdata.CellSize()[1]);
-
+#endif
     }
   });
 }

--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -69,14 +69,14 @@ Castro::consup_hydro(const Box& bx,
         // Add gradp term to momentum equation -- only for axisymmetric
         // coords (and only for the radial flux).
 
-        U_new(i,j,k,UMX) += - dt * (qx(i+1,j,k,GDPRES) - qx(i,j,k,GDPRES)) / geomdata.CellSize()[0];
+        U_new(i,j,k,UMX) += - dt * (qx(i+1,j,k,GDPRES) - qx(i,j,k,GDPRES)) / geomdata.CellSize(1);
 
 #if AMREX_SPACEDIM >= 2
     } else if (n == UMY && !mom_flux_has_p(1, 1, geomdata.Coord())) {
         // Add gradp term to polar(theta) momentum equation for Spherical 2D geometry
 
-        Real r = geom.ProbLoArray()[0] + (static_cast<Real>(i) + 0.5_rt) * geomdata.CellSize()[0];
-        U_new(i,j,k,UMY) += - dt * (qy(i,j+1,k,GDPRES) - qy(i,j,k,GDPRES)) / (r * geomdata.CellSize()[1]);
+        Real r = geomdata.ProbLo(0) + (static_cast<Real>(i) + 0.5_rt) * geomdata.CellSize(0);
+        U_new(i,j,k,UMY) += - dt * (qy(i,j+1,k,GDPRES) - qy(i,j,k,GDPRES)) / (r * geomdata.CellSize(1));
 #endif
     }
   });

--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -42,7 +42,7 @@ Castro::consup_hydro(const Box& bx,
 #endif
         ) * volinv;
 
-   // Add the p div(u) source term to (rho e).
+    // Add the p div(u) source term to (rho e).
     if (n == UEINT) {
 
       Real pdu = (qx(i+1,j,k,GDPRES) + qx(i,j,k,GDPRES)) *
@@ -65,13 +65,18 @@ Castro::consup_hydro(const Box& bx,
 
       U_new(i,j,k,n) = U_new(i,j,k,n) - dt * pdu;
 
-    } else if (n == UMX) {
-      // Add gradp term to momentum equation -- only for axisymmetric
-      // coords (and only for the radial flux).
+    } else if (n == UMX && !mom_flux_has_p(0, 0, geomdata.Coord())) {
+        // Add gradp term to momentum equation -- only for axisymmetric
+        // coords (and only for the radial flux).
 
-      if (!mom_flux_has_p(0, 0, geomdata.Coord())) {
         U_new(i,j,k,UMX) += - dt * (qx(i+1,j,k,GDPRES) - qx(i,j,k,GDPRES)) / geomdata.CellSize()[0];
-      }
+
+    } else if (n == UMY && !mom_flux_has_p(1, 1, geomdata.Coord())) {
+        // Add gradp term to polar(theta) momentum equation for Spherical 2D geometry
+
+        Real r = geomdata.ProbLoArray()[0] + (static_cast<Real>(i) + 0.5_rt) * geomdata.Coord()[0];
+        U_new(i,j,k,UMY) += - dt * (qy(i,j+1,k,GDPRES) - qy(i,j,k,GDPRES)) / (r * geomdata.CellSize()[0]);
+
     }
   });
 }

--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -74,7 +74,7 @@ Castro::consup_hydro(const Box& bx,
     } else if (n == UMY && !mom_flux_has_p(1, 1, geomdata.Coord())) {
         // Add gradp term to polar(theta) momentum equation for Spherical 2D geometry
 
-        Real r = geomdata.ProbLoArray()[0] + (static_cast<Real>(i) + 0.5_rt) * geomdata.Cellsize()[0];
+        Real r = geom.ProbLoArray()[0] + (static_cast<Real>(i) + 0.5_rt) * geomdata.CellSize()[0];
         U_new(i,j,k,UMY) += - dt * (qy(i,j+1,k,GDPRES) - qy(i,j,k,GDPRES)) / (r * geomdata.CellSize()[1]);
 
     }

--- a/Source/hydro/Castro_ctu.cpp
+++ b/Source/hydro/Castro_ctu.cpp
@@ -74,8 +74,8 @@ Castro::consup_hydro(const Box& bx,
     } else if (n == UMY && !mom_flux_has_p(1, 1, geomdata.Coord())) {
         // Add gradp term to polar(theta) momentum equation for Spherical 2D geometry
 
-        Real r = geomdata.ProbLoArray()[0] + (static_cast<Real>(i) + 0.5_rt) * geomdata.Coord()[0];
-        U_new(i,j,k,UMY) += - dt * (qy(i,j+1,k,GDPRES) - qy(i,j,k,GDPRES)) / (r * geomdata.CellSize()[0]);
+        Real r = geomdata.ProbLoArray()[0] + (static_cast<Real>(i) + 0.5_rt) * geomdata.Cellsize()[0];
+        U_new(i,j,k,UMY) += - dt * (qy(i,j+1,k,GDPRES) - qy(i,j,k,GDPRES)) / (r * geomdata.CellSize()[1]);
 
     }
   });

--- a/Source/hydro/Castro_hydro.H
+++ b/Source/hydro/Castro_hydro.H
@@ -387,6 +387,7 @@
 /// @param area1   area of y faces
 /// @param area2   area of z faces
 /// @param q0      Godunuv state on x faces
+/// @param q1      Godunuv state on y faces
 /// @param vol     cell volume
 ///
     void mol_consup(const amrex::Box& bx,
@@ -412,6 +413,7 @@
 #endif
 #if AMREX_SPACEDIM <= 2
                     amrex::Array4<amrex::Real const> const& q0,
+                    amrex::Array4<amrex::Real const> const& q1,
 #endif
                     amrex::Array4<amrex::Real const> const& vol);
 

--- a/Source/hydro/Castro_mol.cpp
+++ b/Source/hydro/Castro_mol.cpp
@@ -270,7 +270,7 @@ Castro::mol_consup(const Box& bx,  // NOLINT(readability-convert-member-function
         } else if (n == UMY && !mom_flux_has_p(1, 1, coord)) {
             // Add gradp term to polar(theta) momentum equation for Spherical 2D geometry
 
-            Real r = prob_lo[0] + (static_cast<Real>(i) + 0.5_rt)*dx[0];
+            Real r = prob_lo[0] + (static_cast<Real>(i) + 0.5_rt) * dx[0];
             update(i,j,k,UMY) -= (q1(i,j+1,k,GDPRES) - q1(i,j,k,GDPRES)) / (r * dx[1]);
         }
     }

--- a/Source/hydro/Castro_mol_hydro.cpp
+++ b/Source/hydro/Castro_mol_hydro.cpp
@@ -620,6 +620,7 @@ Castro::construct_mol_hydro_source(Real time, Real dt, MultiFab& A_update)
 #endif
 #if AMREX_SPACEDIM <= 2
                    qe[0].array(),
+                   qe[1].array(),
 #endif
                    volume.array(mfi));
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary
This is to address issue #2927 . I updated mom_flux_has_p to work with theta direction in 2d spherical. Also update places where it is used. I think it should just work in riemann_solver and HLL_solver, so nothing is changed there. For `Castro_ctu_hydro.cpp` and `Castro_mol_hydro.cpp` I will need to include ptheta just like pradial, so I'll do that in a separate pr to address that separately. I'll also address `trans.cpp` separately when I do the transverse flux pr

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
