### PR TITLE
address timestep and cfl violation for Spherical2D

### DIFF
--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -35,6 +35,7 @@ Castro::estdt_cfl (int is_new)
   // Courant-condition limited timestep
 
   const auto dx = geom.CellSizeArray();
+  const auto problo = geom.ProbLoArray();
 
   const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -85,7 +86,7 @@ Castro::estdt_cfl (int is_new)
       if (geom.IsSPHERICAL()) {
           // dx[1] in Spherical2D is just dtheta, need rdtheta for physical length
           // so just multiply by the smallest r
-          dt2 *= geom.ProbLo(0) + 0.5_rt * dx[0];
+          dt2 *= problo[0] + 0.5_rt * dx[0];
       }
 #else
       dt2 = dt1;
@@ -132,6 +133,7 @@ Castro::estdt_mhd (int is_new)
 
   // MHD timestep limiter
   const auto dx = geom.CellSizeArray();
+  const auto problo = geom.ProbLoArray();
 
   const MultiFab& U_state = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -212,7 +214,7 @@ Castro::estdt_mhd (int is_new)
 #if AMREX_SPACEDIM >= 2
       dt2 = dx[1]/(cy + std::abs(uy));
       if (geom.IsSPHERICAL()) {
-          dt2 *= geom.ProbLo(0) + 0.5_rt * dx[0];
+          dt2 *= problo[0] + 0.5_rt * dx[0];
       }
 #else
       dt2 = dt1;
@@ -246,6 +248,7 @@ Castro::estdt_temp_diffusion (int is_new)
   // where D = k/(rho c_v), and k is the conductivity
 
   const auto dx = geom.CellSizeArray();
+  const auto problo = geom.ProbLoArray();
 
   const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -296,7 +299,7 @@ Castro::estdt_temp_diffusion (int is_new)
 #if AMREX_SPACEDIM >= 2
           dt2 = 0.5_rt * dx[1]*dx[1] / D;
           if (geom.IsSPHERICAL()) {
-              Real r = geom.ProbLo(0) + 0.5_rt * dx[0];
+              Real r = problo[0] + 0.5_rt * dx[0];
               dt2 *= r * r;
           }
 #else
@@ -332,6 +335,7 @@ Castro::estdt_burning (int is_new)
     }
 
     const auto dx = geom.CellSizeArray();
+    const auto problo = geom.ProbLoArray();
 
     MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -383,7 +387,7 @@ Castro::estdt_burning (int is_new)
         Real r = 1.0_rt;
 #if AMREX_SPACEDIM >= 2
         if (geom.IsSPHERICAL()) {
-            r = geom.ProbLo(0) + 0.5_rt * dx[0];
+            r = problo[0] + 0.5_rt * dx[0];
         }
 #endif
         burn_state.dx = amrex::min(AMREX_D_DECL(dx[0], r * dx[1], dx[2]));
@@ -482,6 +486,7 @@ Real
 Castro::estdt_rad (int is_new)
 {
     auto dx = geom.CellSizeArray();
+    const auto problo = geom.ProbLoArray();
 
     const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
     const MultiFab& radMF = is_new ? get_new_data(Rad_Type) : get_old_data(Rad_Type);
@@ -542,7 +547,7 @@ Castro::estdt_rad (int is_new)
 #if AMREX_SPACEDIM >= 2
             Real dt2 = dx[1] / (c + std::abs(uy));
             if (geom.IsSPHERICAL()) {
-                dt2 *= geom.ProbLo(0) + 0.5_rt * dx[0];
+                dt2 *= problo[0] + 0.5_rt * dx[0];
             }
 #else
             Real dt2 = std::numeric_limits<Real>::max();

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -35,6 +35,8 @@ Castro::estdt_cfl (int is_new)
   // Courant-condition limited timestep
 
   const auto dx = geom.CellSizeArray();
+  const auto problo = geom.ProbLoArray();
+  amrex::ignore_unused(problo);
 
   const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -85,7 +87,7 @@ Castro::estdt_cfl (int is_new)
       if (geom.IsSPHERICAL()) {
           // dx[1] in Spherical2D is just dtheta, need rdtheta for physical length
           // so just multiply by the smallest r
-          dt2 *= geom.ProbLoArray()[0] + 0.5_rt * dx[0];
+          dt2 *= problo[0] + 0.5_rt * dx[0];
       }
 #else
       dt2 = dt1;
@@ -132,6 +134,8 @@ Castro::estdt_mhd (int is_new)
 
   // MHD timestep limiter
   const auto dx = geom.CellSizeArray();
+  const auto problo = geom.ProbLoArray();
+  amrex::ignore_unused(problo);
 
   const MultiFab& U_state = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -212,7 +216,7 @@ Castro::estdt_mhd (int is_new)
 #if AMREX_SPACEDIM >= 2
       dt2 = dx[1]/(cy + std::abs(uy));
       if (geom.IsSPHERICAL()) {
-          dt2 *= geom.ProbLoArray()[0] + 0.5_rt * dx[0];
+          dt2 *= problo[0] + 0.5_rt * dx[0];
       }
 #else
       dt2 = dt1;
@@ -246,6 +250,8 @@ Castro::estdt_temp_diffusion (int is_new)
   // where D = k/(rho c_v), and k is the conductivity
 
   const auto dx = geom.CellSizeArray();
+  const auto problo = geom.ProbLoArray();
+  amrex::ignore_unused(problo);
 
   const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -296,7 +302,7 @@ Castro::estdt_temp_diffusion (int is_new)
 #if AMREX_SPACEDIM >= 2
           dt2 = 0.5_rt * dx[1]*dx[1] / D;
           if (geom.IsSPHERICAL()) {
-              Real r = geom.ProbLoArray()[0] + 0.5_rt * dx[0];
+              Real r = problo[0] + 0.5_rt * dx[0];
               dt2 *= r * r;
           }
 #else
@@ -332,6 +338,8 @@ Castro::estdt_burning (int is_new)
     }
 
     const auto dx = geom.CellSizeArray();
+    const auto problo = geom.ProbLoArray();
+    amrex::ignore_unused(problo);
 
     MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -383,7 +391,7 @@ Castro::estdt_burning (int is_new)
         Real r = 1.0_rt;
 #if AMREX_SPACEDIM >= 2
         if (geom.IsSPHERICAL()) {
-            r = geom.ProbLoArray()[0] + 0.5_rt * dx[0];
+            r = problo[0] + 0.5_rt * dx[0];
         }
 #endif
         burn_state.dx = amrex::min(AMREX_D_DECL(dx[0], r * dx[1], dx[2]));
@@ -482,6 +490,8 @@ Real
 Castro::estdt_rad (int is_new)
 {
     auto dx = geom.CellSizeArray();
+    const auto problo = geom.ProbLoArray();
+    amrex::ignore_unused(problo);
 
     const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
     const MultiFab& radMF = is_new ? get_new_data(Rad_Type) : get_old_data(Rad_Type);
@@ -542,7 +552,7 @@ Castro::estdt_rad (int is_new)
 #if AMREX_SPACEDIM >= 2
             Real dt2 = dx[1] / (c + std::abs(uy));
             if (geom.IsSPHERICAL()) {
-                dt2 *= geom.ProbLoArray()[0] + 0.5_rt * dx[0];
+                dt2 *= problo[0] + 0.5_rt * dx[0];
             }
 #else
             Real dt2 = std::numeric_limits<Real>::max();

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -35,7 +35,6 @@ Castro::estdt_cfl (int is_new)
   // Courant-condition limited timestep
 
   const auto dx = geom.CellSizeArray();
-  const auto problo = geom.ProbLoArray();
 
   const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -86,7 +85,7 @@ Castro::estdt_cfl (int is_new)
       if (geom.IsSPHERICAL()) {
           // dx[1] in Spherical2D is just dtheta, need rdtheta for physical length
           // so just multiply by the smallest r
-          dt2 *= problo[0] + 0.5_rt * dx[0];
+          dt2 *= geom.ProbLoArray()[0] + 0.5_rt * dx[0];
       }
 #else
       dt2 = dt1;
@@ -133,7 +132,6 @@ Castro::estdt_mhd (int is_new)
 
   // MHD timestep limiter
   const auto dx = geom.CellSizeArray();
-  const auto problo = geom.ProbLoArray();
 
   const MultiFab& U_state = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -214,7 +212,7 @@ Castro::estdt_mhd (int is_new)
 #if AMREX_SPACEDIM >= 2
       dt2 = dx[1]/(cy + std::abs(uy));
       if (geom.IsSPHERICAL()) {
-          dt2 *= problo[0] + 0.5_rt * dx[0];
+          dt2 *= geom.ProbLoArray()[0] + 0.5_rt * dx[0];
       }
 #else
       dt2 = dt1;
@@ -248,7 +246,6 @@ Castro::estdt_temp_diffusion (int is_new)
   // where D = k/(rho c_v), and k is the conductivity
 
   const auto dx = geom.CellSizeArray();
-  const auto problo = geom.ProbLoArray();
 
   const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -299,7 +296,7 @@ Castro::estdt_temp_diffusion (int is_new)
 #if AMREX_SPACEDIM >= 2
           dt2 = 0.5_rt * dx[1]*dx[1] / D;
           if (geom.IsSPHERICAL()) {
-              Real r = problo[0] + 0.5_rt * dx[0];
+              Real r = geom.ProbLoArray()[0] + 0.5_rt * dx[0];
               dt2 *= r * r;
           }
 #else
@@ -335,7 +332,6 @@ Castro::estdt_burning (int is_new)
     }
 
     const auto dx = geom.CellSizeArray();
-    const auto problo = geom.ProbLoArray();
 
     MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -387,7 +383,7 @@ Castro::estdt_burning (int is_new)
         Real r = 1.0_rt;
 #if AMREX_SPACEDIM >= 2
         if (geom.IsSPHERICAL()) {
-            r = problo[0] + 0.5_rt * dx[0];
+            r = geom.ProbLoArray()[0] + 0.5_rt * dx[0];
         }
 #endif
         burn_state.dx = amrex::min(AMREX_D_DECL(dx[0], r * dx[1], dx[2]));
@@ -486,7 +482,6 @@ Real
 Castro::estdt_rad (int is_new)
 {
     auto dx = geom.CellSizeArray();
-    const auto problo = geom.ProbLoArray();
 
     const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
     const MultiFab& radMF = is_new ? get_new_data(Rad_Type) : get_old_data(Rad_Type);
@@ -547,7 +542,7 @@ Castro::estdt_rad (int is_new)
 #if AMREX_SPACEDIM >= 2
             Real dt2 = dx[1] / (c + std::abs(uy));
             if (geom.IsSPHERICAL()) {
-                dt2 *= problo[0] + 0.5_rt * dx[0];
+                dt2 *= geom.ProbLoArray()[0] + 0.5_rt * dx[0];
             }
 #else
             Real dt2 = std::numeric_limits<Real>::max();

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -82,7 +82,7 @@ Castro::estdt_cfl (int is_new)
       Real dt2;
 #if AMREX_SPACEDIM >= 2
       dt2 = dx[1]/(c + std::abs(uy));
-      if (geom.IsSPHERICAL) {
+      if (geom.IsSPHERICAL()) {
           // dx[1] in Spherical2D is just dtheta, need rdtheta for physical length
           // so just multiply by the smallest r
           dt2 *= geom.ProbLo(0) + 0.5_rt * dx[0];
@@ -211,7 +211,7 @@ Castro::estdt_mhd (int is_new)
       Real dt2;
 #if AMREX_SPACEDIM >= 2
       dt2 = dx[1]/(cy + std::abs(uy));
-      if (geom.IsSPHERICAL) {
+      if (geom.IsSPHERICAL()) {
           dt2 *= geom.ProbLo(0) + 0.5_rt * dx[0];
       }
 #else
@@ -295,7 +295,7 @@ Castro::estdt_temp_diffusion (int is_new)
           Real dt2;
 #if AMREX_SPACEDIM >= 2
           dt2 = 0.5_rt * dx[1]*dx[1] / D;
-          if (geom.IsSPHERICAL) {
+          if (geom.IsSPHERICAL()) {
               Real r = geom.ProbLo(0) + 0.5_rt * dx[0];
               dt2 *= r * r;
           }
@@ -382,7 +382,7 @@ Castro::estdt_burning (int is_new)
 #else
         Real r = 1.0_rt;
 #if AMREX_SPACEDIM >= 2
-        if (geom.IsSPHERICAL) {
+        if (geom.IsSPHERICAL()) {
             r = geom.ProbLo(0) + 0.5_rt * dx[0];
         }
 #endif
@@ -541,7 +541,7 @@ Castro::estdt_rad (int is_new)
             Real dt1 = dx[0] / (c + std::abs(ux));
 #if AMREX_SPACEDIM >= 2
             Real dt2 = dx[1] / (c + std::abs(uy));
-            if (geom.IsSPHERICAL) {
+            if (geom.IsSPHERICAL()) {
                 dt2 *= geom.ProbLo(0) + 0.5_rt * dx[0];
             }
 #else

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -36,7 +36,8 @@ Castro::estdt_cfl (int is_new)
 
   const auto dx = geom.CellSizeArray();
   const auto problo = geom.ProbLoArray();
-  amrex::ignore_unused(problo);
+  const auto coord = geom.Coord();
+  amrex::ignore_unused(problo, coord);
 
   const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -84,7 +85,7 @@ Castro::estdt_cfl (int is_new)
       Real dt2;
 #if AMREX_SPACEDIM >= 2
       dt2 = dx[1]/(c + std::abs(uy));
-      if (geom.IsSPHERICAL()) {
+      if (coord == 2) {
           // dx[1] in Spherical2D is just dtheta, need rdtheta for physical length
           // so just multiply by the smallest r
           dt2 *= problo[0] + 0.5_rt * dx[0];
@@ -135,7 +136,8 @@ Castro::estdt_mhd (int is_new)
   // MHD timestep limiter
   const auto dx = geom.CellSizeArray();
   const auto problo = geom.ProbLoArray();
-  amrex::ignore_unused(problo);
+  const auto coord = geom.Coord();
+  amrex::ignore_unused(problo, coord);
 
   const MultiFab& U_state = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -215,7 +217,7 @@ Castro::estdt_mhd (int is_new)
       Real dt2;
 #if AMREX_SPACEDIM >= 2
       dt2 = dx[1]/(cy + std::abs(uy));
-      if (geom.IsSPHERICAL()) {
+      if (coord == 2) {
           dt2 *= problo[0] + 0.5_rt * dx[0];
       }
 #else
@@ -251,7 +253,8 @@ Castro::estdt_temp_diffusion (int is_new)
 
   const auto dx = geom.CellSizeArray();
   const auto problo = geom.ProbLoArray();
-  amrex::ignore_unused(problo);
+  const auto coord = geom.Coord();
+  amrex::ignore_unused(problo, coord);
 
   const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -301,7 +304,7 @@ Castro::estdt_temp_diffusion (int is_new)
           Real dt2;
 #if AMREX_SPACEDIM >= 2
           dt2 = 0.5_rt * dx[1]*dx[1] / D;
-          if (geom.IsSPHERICAL()) {
+          if (coord == 2) {
               Real r = problo[0] + 0.5_rt * dx[0];
               dt2 *= r * r;
           }
@@ -339,7 +342,8 @@ Castro::estdt_burning (int is_new)
 
     const auto dx = geom.CellSizeArray();
     const auto problo = geom.ProbLoArray();
-    amrex::ignore_unused(problo);
+    const auto coord = geom.Coord();
+    amrex::ignore_unused(problo, coord);
 
     MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
@@ -388,13 +392,13 @@ Castro::estdt_burning (int is_new)
 #if AMREX_SPACEDIM == 1
         burn_state.dx = dx[0];
 #else
-        Real r = 1.0_rt;
+        Real dx1 = dx[1];
 #if AMREX_SPACEDIM >= 2
-        if (geom.IsSPHERICAL()) {
-            r = problo[0] + 0.5_rt * dx[0];
+        if (coord == 2) {
+            dx1 *= problo[0] + 0.5_rt * dx[0];
         }
 #endif
-        burn_state.dx = amrex::min(AMREX_D_DECL(dx[0], r * dx[1], dx[2]));
+        burn_state.dx = amrex::min(AMREX_D_DECL(dx[0], dx1, dx[2]));
 #endif
 
         burn_state.rho = S(i,j,k,URHO);
@@ -491,7 +495,8 @@ Castro::estdt_rad (int is_new)
 {
     auto dx = geom.CellSizeArray();
     const auto problo = geom.ProbLoArray();
-    amrex::ignore_unused(problo);
+    const auto coord = geom.Coord();
+    amrex::ignore_unused(problo, coord);
 
     const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
     const MultiFab& radMF = is_new ? get_new_data(Rad_Type) : get_old_data(Rad_Type);
@@ -551,7 +556,7 @@ Castro::estdt_rad (int is_new)
             Real dt1 = dx[0] / (c + std::abs(ux));
 #if AMREX_SPACEDIM >= 2
             Real dt2 = dx[1] / (c + std::abs(uy));
-            if (geom.IsSPHERICAL()) {
+            if (coord == 2) {
                 dt2 *= problo[0] + 0.5_rt * dx[0];
             }
 #else

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -237,6 +237,8 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
     int cfl_violation = 0;
 
     auto dx = geom.CellSizeArray();
+    const auto problo = geom.ProbLoArray();
+    amrex::ignore_unused(problo);
 
     Real dtdx = dt / dx[0];
 
@@ -246,7 +248,7 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
       if (geom.IsSPHERICAL()) {
           // dx[1] in Spherical2D is just rdtheta, need rdtheta for physical length
           // Just choose to divide by the smallest r
-          dtdy /= geom.ProbLoArray()[0] + 0.5_rt * dx[0];
+          dtdy /= problo[0] + 0.5_rt * dx[0];
       }
     }
 

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -243,6 +243,11 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
     Real dtdy = 0.0_rt;
     if (AMREX_SPACEDIM >= 2) {
       dtdy = dt / dx[1];
+      if (geom.IsSPHERICAL) {
+          // dx[1] in Spherical2D is just rdtheta, need rdtheta for physical length
+          // Just choose to divide by the smallest r
+          dtdy /= geom.ProbLo(0) + 0.5_rt * dx[0];
+      }
     }
 
     Real dtdz = 0.0_rt;

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -237,7 +237,6 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
     int cfl_violation = 0;
 
     auto dx = geom.CellSizeArray();
-    const auto problo = geom.ProbLoArray();
 
     Real dtdx = dt / dx[0];
 
@@ -247,7 +246,7 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
       if (geom.IsSPHERICAL()) {
           // dx[1] in Spherical2D is just rdtheta, need rdtheta for physical length
           // Just choose to divide by the smallest r
-          dtdy /= problo[0] + 0.5_rt * dx[0];
+          dtdy /= geom.ProbLoArray()[0] + 0.5_rt * dx[0];
       }
     }
 

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -238,14 +238,15 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
 
     auto dx = geom.CellSizeArray();
     const auto problo = geom.ProbLoArray();
-    amrex::ignore_unused(problo);
+    const auto coord = geom.Coord();
+    amrex::ignore_unused(problo, coord);
 
     Real dtdx = dt / dx[0];
 
     Real dtdy = 0.0_rt;
     if (AMREX_SPACEDIM >= 2) {
       dtdy = dt / dx[1];
-      if (geom.IsSPHERICAL()) {
+      if (coord == 2) {
           // dx[1] in Spherical2D is just rdtheta, need rdtheta for physical length
           // Just choose to divide by the smallest r
           dtdy /= problo[0] + 0.5_rt * dx[0];

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -237,6 +237,7 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
     int cfl_violation = 0;
 
     auto dx = geom.CellSizeArray();
+    const auto problo = geom.ProbLoArray();
 
     Real dtdx = dt / dx[0];
 
@@ -246,7 +247,7 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
       if (geom.IsSPHERICAL()) {
           // dx[1] in Spherical2D is just rdtheta, need rdtheta for physical length
           // Just choose to divide by the smallest r
-          dtdy /= geom.ProbLo(0) + 0.5_rt * dx[0];
+          dtdy /= problo[0] + 0.5_rt * dx[0];
       }
     }
 

--- a/Source/hydro/Castro_hydro.cpp
+++ b/Source/hydro/Castro_hydro.cpp
@@ -243,7 +243,7 @@ Castro::check_for_cfl_violation(const MultiFab& State, const Real dt)
     Real dtdy = 0.0_rt;
     if (AMREX_SPACEDIM >= 2) {
       dtdy = dt / dx[1];
-      if (geom.IsSPHERICAL) {
+      if (geom.IsSPHERICAL()) {
           // dx[1] in Spherical2D is just rdtheta, need rdtheta for physical length
           // Just choose to divide by the smallest r
           dtdy /= geom.ProbLo(0) + 0.5_rt * dx[0];


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary
address #2927 .  Change timestep and cfl_violation so we use rdtheta, rdx[1], which is the physical cell length instead of just dx[1] for cell length in theta direction for spherical 2d.
<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
