### PR TITLE
fix divu when theta=0 or pi

### DIFF
--- a/Source/hydro/advection_util.cpp
+++ b/Source/hydro/advection_util.cpp
@@ -310,12 +310,18 @@ Castro::divu(const Box& bx,
         // Finite difference to get divergence. ux = 1/r^2 d/dr(r^2 * u)
         ux = (ur * rr * rr - ul * rl * rl) * dxinv / (rc * rc);
 
-        // These are transverse averages in the x-direction
-        Real vb = 0.5_rt * (q_arr(i,j-1,k,QV) + q_arr(i-1,j-1,k,QV));
-        Real vt = 0.5_rt * (q_arr(i,j,k,QV) + q_arr(i-1,j,k,QV));
+        // If sinc == 0, then vy goes inf.
+        // But due to Phi-symmetry, vt*sint = vb*sinb, so set to 0.
+        if (sinc == 0.0_rt) {
+            vy = 0.0_rt;
+        } else {
+            // These are transverse averages in the x-direction
+            Real vb = 0.5_rt * (q_arr(i,j-1,k,QV) + q_arr(i-1,j-1,k,QV));
+            Real vt = 0.5_rt * (q_arr(i,j,k,QV) + q_arr(i-1,j,k,QV));
 
-        // Finite difference to get divergence. vy = 1/(r sin) * d/dtheta(v sin)
-        vy = (vt * sint - vb * sinb) * dyinv / (rc * sinc);
+            // Finite difference to get divergence. vy = 1/(r sin) * d/dtheta(v sin)
+            vy = (vt * sint - vb * sinb) * dyinv / (rc * sinc);
+        }
     }
 
     div(i,j,k) = ux + vy;


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:
    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary
When calculating `vy`,  when $`\theta = 0`$ or $`\theta = \pi`$, `sinc=0` which causes division by 0. But the numerator should cancel due to azimuthal symmetry. So numerator is 0. So set `vy=0` when that happens.

Do it more precisely, expand out divergence in theta to be: $`\frac{1}{r sin\theta} \frac{\partial (v sin\theta)}{\partial \theta}`$ =  $`\frac{1}{r} \left(\frac{\Delta v}{\Delta \theta} + v cot\theta   \right)`$. Both $`\Delta v = 0`$ and $`v = 0`$ at $`\theta = 0`$, so we have $`\frac{1}{r} \frac{cos \theta v}{sin \theta} = 0/0`$. With l'hopital, we have $`lim_{\theta \rightarrow 0} \frac{\partial(v cos \theta) / \partial \theta}{cos \theta } = 0`$

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
