### PR TITLE
name variables to geom when its amrex::Geometry to avoid confusion in Derive.H/.cpp

### DIFF
--- a/Source/driver/Derive.H
+++ b/Source/driver/Derive.H
@@ -12,125 +12,125 @@ extern "C"
 
   void ca_derpres
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dereint1
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dereint2
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derlogden
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_deruplusc
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_deruminusc
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dersoundspeed
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dergamma1
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dermachnumber
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derentropy
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
 #ifdef DIFFUSION
   void ca_dercond
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derdiffcoeff
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derdiffterm
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 #endif
 
   void ca_derenuc
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derenuctimescale
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dervel
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dermagvel
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dermaggrav
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derradialvel
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dercircvel
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dermagmom
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derangmomx (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
-                      const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+                      const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
                       amrex::Real time, const int* bcrec, int level);
 
   void ca_derangmomy (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
-                      const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+                      const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
                       amrex::Real time, const int* bcrec, int level);
 
   void ca_derangmomz (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
-                      const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+                      const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
                       amrex::Real time, const int* bcrec, int level);
 
   void ca_derkineng (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
-                     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+                     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
                      amrex::Real time, const int* bcrec, int level);
 
   void ca_dernull
@@ -144,53 +144,53 @@ extern "C"
 
   void ca_derspec
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derabar
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derye
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dermagvort
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derdivu
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derstate
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
 #ifdef MHD
   void ca_dermagcenx
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dermagceny
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_dermagcenz
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
   void ca_derdivb
     (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int /*ncomp*/,
-     const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+     const amrex::FArrayBox& datfab, const amrex::Geometry& geom,
      amrex::Real /*time*/, const int* /*bcrec*/, int /*level*/);
 
 #endif

--- a/Source/driver/Derive.cpp
+++ b/Source/driver/Derive.cpp
@@ -21,7 +21,7 @@ extern "C"
     // need to explicitly synchronize after GPU kernels.
 
     void ca_derpres(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                    const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                    const FArrayBox& datfab, const Geometry& /*geom*/,
                     Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -54,7 +54,7 @@ extern "C"
     }
 
     void ca_dereint1(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                     const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                     const FArrayBox& datfab, const Geometry& /*geom*/,
                      Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -76,7 +76,7 @@ extern "C"
     }
 
     void ca_dereint2(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                     const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                     const FArrayBox& datfab, const Geometry& /*geom*/,
                      Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -92,7 +92,7 @@ extern "C"
     }
 
     void ca_derlogden(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                      const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                      const FArrayBox& datfab, const Geometry& /*geom*/,
                       Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -107,7 +107,7 @@ extern "C"
     }
 
     void ca_deruplusc(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                      const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                      const FArrayBox& datfab, const Geometry& /*geom*/,
                       Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -142,7 +142,7 @@ extern "C"
     }
 
     void ca_deruminusc(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                       const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                       const FArrayBox& datfab, const Geometry& /*geom*/,
                        Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -177,7 +177,7 @@ extern "C"
     }
 
     void ca_dersoundspeed(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                          const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                          const FArrayBox& datfab, const Geometry& /*geom*/,
                           Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -213,7 +213,7 @@ extern "C"
 
 
     void ca_dergamma1(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                      const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                      const FArrayBox& datfab, const Geometry& /*geom*/,
                       Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -248,7 +248,7 @@ extern "C"
     }
 
     void ca_dermachnumber(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                          const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                          const FArrayBox& datfab, const Geometry& /*geom*/,
                           Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -286,7 +286,7 @@ extern "C"
     }
 
     void ca_derentropy(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                       const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                       const FArrayBox& datfab, const Geometry& /*geom*/,
                        Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -321,7 +321,7 @@ extern "C"
 
 #ifdef DIFFUSION
     void ca_dercond(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                    const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                    const FArrayBox& datfab, const Geometry& /*geom*/,
                     Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -333,7 +333,7 @@ extern "C"
     }
 
     void ca_derdiffcoeff(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                    const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                    const FArrayBox& datfab, const Geometry& /*geom*/,
                     Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -345,7 +345,7 @@ extern "C"
     }
 
     void ca_derdiffterm(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                        const FArrayBox& datfab, const Geometry& geomdata,
+                        const FArrayBox& datfab, const Geometry& geom,
                         Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -360,9 +360,9 @@ extern "C"
 
       fill_temp_cond(obx, dat, coeff_arr);
 
-      auto dx = geomdata.CellSizeArray();
-      auto problo = geomdata.ProbLoArray();
-      const int coord_type = geomdata.Coord();
+      auto dx = geom.CellSizeArray();
+      auto problo = geom.ProbLoArray();
+      const int coord_type = geom.Coord();
 
       amrex::ParallelFor(bx,
       [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -432,14 +432,14 @@ extern "C"
 
 #ifdef REACTIONS
     void ca_derenuctimescale(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                             const FArrayBox& datfab, const Geometry& geomdata,
+                             const FArrayBox& datfab, const Geometry& geom,
                              Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
       auto const dat = datfab.array();
       auto const der = derfab.array();
 
-      auto dx = geomdata.CellSizeArray();
+      auto dx = geom.CellSizeArray();
 
       Real dd = 0.0_rt;
 #if AMREX_SPACEDIM == 1
@@ -494,7 +494,7 @@ extern "C"
     }
 
     void ca_derenuc(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                    const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                    const FArrayBox& datfab, const Geometry& /*geom*/,
                     Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
       auto const dat = datfab.array();
@@ -512,7 +512,7 @@ extern "C"
 #endif
 
     void ca_dervel(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                   const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                   const FArrayBox& datfab, const Geometry& /*geom*/,
                    Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -528,7 +528,7 @@ extern "C"
 
 
     void ca_dermagvel(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                      const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                      const FArrayBox& datfab, const Geometry& /*geom*/,
                       Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -549,7 +549,7 @@ extern "C"
 
 
     void ca_dermaggrav(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                       const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                       const FArrayBox& datfab, const Geometry& /*geom*/,
                        Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -568,7 +568,7 @@ extern "C"
     }
 
     void ca_derradialvel(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                         const FArrayBox& datfab, const Geometry& geomdata,
+                         const FArrayBox& datfab, const Geometry& geom,
                          Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -577,8 +577,8 @@ extern "C"
       auto const dat = datfab.array();
       auto const der = derfab.array();
 
-      auto dx = geomdata.CellSizeArray();
-      auto problo = geomdata.ProbLoArray();
+      auto dx = geom.CellSizeArray();
+      auto problo = geom.ProbLoArray();
 
       amrex::ParallelFor(bx,
       [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -623,7 +623,7 @@ extern "C"
 
 
     void ca_dercircvel(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                       const FArrayBox& datfab, const Geometry& geomdata,
+                       const FArrayBox& datfab, const Geometry& geom,
                        Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -632,8 +632,8 @@ extern "C"
       auto const dat = datfab.array();
       auto const der = derfab.array();
 
-      auto dx = geomdata.CellSizeArray();
-      auto problo = geomdata.ProbLoArray();
+      auto dx = geom.CellSizeArray();
+      auto problo = geom.ProbLoArray();
 
       amrex::ParallelFor(bx,
       [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -688,7 +688,7 @@ extern "C"
 
 
   void ca_dermagmom(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                    const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                    const FArrayBox& datfab, const Geometry& /*geom*/,
                     Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
@@ -707,13 +707,13 @@ extern "C"
   }
 
   void ca_derangmomx (const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                      const FArrayBox& datfab, const Geometry& geomdata,
+                      const FArrayBox& datfab, const Geometry& geom,
                       Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
     int idir = 0;
-    auto dx     = geomdata.CellSizeArray();
-    auto problo = geomdata.ProbLoArray();
+    auto dx     = geom.CellSizeArray();
+    auto problo = geom.ProbLoArray();
 
     auto const dat = datfab.array();
     auto const L = derfab.array();
@@ -724,7 +724,7 @@ extern "C"
                          Real loc[3];
 
                          //loc calculated like sum_utils.cpp
-                         //This might be equivalent and more modular: position(i, j, k, geomdata, loc);
+                         //This might be equivalent and more modular: position(i, j, k, geom, loc);
                          loc[0] = problo[0] + (0.5_rt + i) * dx[0];
 
 #if AMREX_SPACEDIM >= 2
@@ -759,13 +759,13 @@ extern "C"
   }
 
   void ca_derangmomy (const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                      const FArrayBox& datfab, const Geometry& geomdata,
+                      const FArrayBox& datfab, const Geometry& geom,
                       Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
     int idir = 1;
-    auto dx     = geomdata.CellSizeArray();
-    auto problo = geomdata.ProbLoArray();
+    auto dx     = geom.CellSizeArray();
+    auto problo = geom.ProbLoArray();
 
     auto const dat = datfab.array();
     auto const L = derfab.array();
@@ -807,13 +807,13 @@ extern "C"
   }
 
   void ca_derangmomz (const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                      const FArrayBox& datfab, const Geometry& geomdata,
+                      const FArrayBox& datfab, const Geometry& geom,
                       Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
     int idir = 2;
-    auto dx     = geomdata.CellSizeArray();
-    auto problo = geomdata.ProbLoArray();
+    auto dx     = geom.CellSizeArray();
+    auto problo = geom.ProbLoArray();
 
     auto const dat = datfab.array();
     auto const L = derfab.array();
@@ -856,7 +856,7 @@ extern "C"
   }
 
   void ca_derkineng (const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                     const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                     const FArrayBox& datfab, const Geometry& /*geom*/,
                      Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
@@ -887,7 +887,7 @@ extern "C"
   }
 
   void ca_derspec(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                  const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                  const FArrayBox& datfab, const Geometry& /*geom*/,
                   Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -903,7 +903,7 @@ extern "C"
 
 
   void ca_derye(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                const FArrayBox& datfab, const Geometry& /*geom*/,
                 Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -925,7 +925,7 @@ extern "C"
     }
 
   void ca_derabar(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                  const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                  const FArrayBox& datfab, const Geometry& /*geom*/,
                   Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
@@ -947,19 +947,19 @@ extern "C"
     }
 
   void ca_dermagvort(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                     const FArrayBox& datfab, const Geometry& geomdata,
+                     const FArrayBox& datfab, const Geometry& geom,
                      Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
       auto const dat = datfab.array();
       auto const der = derfab.array();
 
-      auto dx = geomdata.CellSizeArray();
+      auto dx = geom.CellSizeArray();
 
-      const int coord_type = geomdata.Coord();
+      const int coord_type = geom.Coord();
 
 #if AMREX_SPACEDIM == 2
-      auto problo = geomdata.ProbLoArray();
+      auto problo = geom.ProbLoArray();
 #endif
 
       amrex::ParallelFor(bx,
@@ -1046,18 +1046,18 @@ extern "C"
     }
 
   void ca_derdivu(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                         const FArrayBox& datfab, const Geometry& geomdata,
+                         const FArrayBox& datfab, const Geometry& geom,
                          Real /*time*/, const int* /*bcrec*/, int /*level*/)
     {
 
       auto const dat = datfab.array();
       auto const der = derfab.array();
 
-      auto dx = geomdata.CellSizeArray();
+      auto dx = geom.CellSizeArray();
 
-      auto problo = geomdata.ProbLoArray();
+      auto problo = geom.ProbLoArray();
 
-      const int coord_type = geomdata.Coord();
+      const int coord_type = geom.Coord();
 
       amrex::ParallelFor(bx,
       [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -1112,7 +1112,7 @@ extern "C"
   }
 
   void ca_derstate(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                   const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                   const FArrayBox& datfab, const Geometry& /*geom*/,
                    Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
@@ -1138,7 +1138,7 @@ extern "C"
 
 #ifdef MHD
   void ca_dermagcenx(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                     const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                     const FArrayBox& datfab, const Geometry& /*geom*/,
                      Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
@@ -1154,7 +1154,7 @@ extern "C"
   }
 
   void ca_dermagceny(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                     const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                     const FArrayBox& datfab, const Geometry& /*geom*/,
                      Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
@@ -1170,7 +1170,7 @@ extern "C"
   }
 
   void ca_dermagcenz(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                     const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                     const FArrayBox& datfab, const Geometry& /*geom*/,
                      Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
@@ -1186,14 +1186,14 @@ extern "C"
   }
 
   void ca_derdivb(const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
-                  const FArrayBox& datfab, const Geometry& geomdata,
+                  const FArrayBox& datfab, const Geometry& geom,
                   Real /*time*/, const int* /*bcrec*/, int /*level*/)
   {
 
     auto const dat = datfab.array();
     auto const der = derfab.array();
 
-    auto dx = geomdata.CellSizeArray();
+    auto dx = geom.CellSizeArray();
 
     amrex::ParallelFor(bx,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->
correct variable names from geomdata -> geom when its actually amrex::Geometry
## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
