### PR TITLE
Only print mid-timestep estTimeStep outputs if relevant

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -6,6 +6,7 @@
 // runtime parameters
 #include <castro_params.H>
 #include <prob_parameters.H>
+#include <Castro_io.H>
 #include <Castro_util.H>
 
 using namespace castro;

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -229,10 +229,21 @@ Castro::initialize_do_advance (Real time, Real dt)
 
     if (castro::check_dt_before_advance && !is_first_step_on_this_level) {
         int is_new = 0;
-        Real old_dt = estTimeStep(is_new);
+
+        // We only display the estTimeStep output if the validity check fails
+        std::string estTimeStep_output;
+
+        Real old_dt;
+
+        {
+            CoutRedirection redirection;
+            old_dt = estTimeStep(is_new);
+            estTimeStep_output = redirection.getCapturedOutput();
+        }
 
         if (castro::change_max * old_dt < dt) {
             status.success = false;
+            std::cout << estTimeStep_output;
             status.reason = "pre-advance timestep validity check failed";
         }
     }
@@ -276,10 +287,21 @@ Castro::finalize_do_advance (Real time, Real dt)
 
             if (do_validity_check) {
                 int is_new = 1;
-                Real new_dt = estTimeStep(is_new);
+
+		// We only display the estTimeStep output if the validity check fails
+		std::string estTimeStep_output;
+
+		Real new_dt;
+
+		{
+		    CoutRedirection redirection;
+		    new_dt = estTimeStep(is_new);
+		    estTimeStep_output = redirection.getCapturedOutput();
+		}
 
                 if (castro::change_max * new_dt < dt) {
                     status.success = false;
+                    std::cout << estTimeStep_output;
                     status.reason = "post-advance timestep validity check failed";
                     return status;
                 }

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -288,7 +288,7 @@ Castro::finalize_do_advance (Real time, Real dt)
             if (do_validity_check) {
                 int is_new = 1;
 
-		// We only display the estTimeStep output if the validity check fails
+                // We only display the estTimeStep output if the validity check fails
                 std::string estTimeStep_output;
 
                 Real new_dt;

--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -289,15 +289,15 @@ Castro::finalize_do_advance (Real time, Real dt)
                 int is_new = 1;
 
 		// We only display the estTimeStep output if the validity check fails
-		std::string estTimeStep_output;
+                std::string estTimeStep_output;
 
-		Real new_dt;
+                Real new_dt;
 
-		{
-		    CoutRedirection redirection;
-		    new_dt = estTimeStep(is_new);
-		    estTimeStep_output = redirection.getCapturedOutput();
-		}
+                {
+                    CoutRedirection redirection;
+                    new_dt = estTimeStep(is_new);
+                    estTimeStep_output = redirection.getCapturedOutput();
+                }
 
                 if (castro::change_max * new_dt < dt) {
                     status.success = false;

--- a/Source/driver/Castro_io.H
+++ b/Source/driver/Castro_io.H
@@ -1,6 +1,32 @@
 #ifndef CASTRO_IO_H
 #define CASTRO_IO_H
 
+#include <iostream>
+#include <sstream>
+
 extern std::string inputs_name;
+
+// Redirect std::cout to a temporary buffer.
+
+class CoutRedirection {
+
+public:
+    CoutRedirection () : original_output(std::cout.rdbuf()) {
+	std::cout.rdbuf(captured_output.rdbuf());
+    }
+
+    ~CoutRedirection () {
+	std::cout.rdbuf(original_output);
+    }
+
+    std::string getCapturedOutput () {
+	return captured_output.str();
+    }
+
+private:
+    std::ostringstream captured_output;
+    std::streambuf* original_output;
+
+};
 
 #endif

--- a/Source/driver/Castro_io.H
+++ b/Source/driver/Castro_io.H
@@ -19,6 +19,12 @@ public:
         std::cout.rdbuf(original_output);
     }
 
+    // Remove copy/move constructors/assignment operators.
+    CoutRedirection (const CoutRedirection&) = delete;
+    CoutRedirection (CoutRedirection&&) = delete;
+    CoutRedirection& operator= (const CoutRedirection&) = delete;
+    CoutRedirection& operator= (CoutRedirection&&) = delete;
+
     std::string getCapturedOutput () {
         return captured_output.str();
     }

--- a/Source/driver/Castro_io.H
+++ b/Source/driver/Castro_io.H
@@ -12,15 +12,15 @@ class CoutRedirection {
 
 public:
     CoutRedirection () : original_output(std::cout.rdbuf()) {
-	std::cout.rdbuf(captured_output.rdbuf());
+        std::cout.rdbuf(captured_output.rdbuf());
     }
 
     ~CoutRedirection () {
-	std::cout.rdbuf(original_output);
+        std::cout.rdbuf(original_output);
     }
 
     std::string getCapturedOutput () {
-	return captured_output.str();
+        return captured_output.str();
     }
 
 private:


### PR DESCRIPTION

## PR summary

Output from estTimeStep is occurring for the pre- and post-timestep validity checks, but on most timesteps this clutters the output because the validity check passes. This PR creates a class that temporarily redirects std::cout and then uses that to capture the estTimeStep output and only print it if needed.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
