### PR TITLE
fix NaN issue when using transverse_use_eos

### DIFF
--- a/Source/hydro/trans.cpp
+++ b/Source/hydro/trans.cpp
@@ -446,6 +446,8 @@ Castro::actual_trans_single(const Box& bx,  // NOLINT(readability-convert-member
                 eos_rep_t eos_state;
                 eos_state.rho = rrnewn;
                 eos_state.e = qo_arr(i,j,k,QREINT) / rrnewn;
+                eos_state.T = small_temp;
+
                 for (int n = 0; n < NumSpec; n++) {
                     eos_state.xn[n] = qo_arr(i,j,k,QFS+n);
                 }

--- a/Source/hydro/trans.cpp
+++ b/Source/hydro/trans.cpp
@@ -919,6 +919,8 @@ Castro::actual_trans_final(const Box& bx,  // NOLINT(readability-convert-member-
                 eos_rep_t eos_state;
                 eos_state.rho = rrnewn;
                 eos_state.e = qo_arr(i,j,k,QREINT) / rrnewn;
+                eos_state.T = small_temp;
+
                 for (int n = 0; n < NumSpec; n++) {
                     eos_state.xn[n] = qo_arr(i,j,k,QFS+n);
                 }


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary
This fixes issue #3042 . Temperature was 0, causing tempi to be infinity during the eos call.
I'm able to run wdmerger to the step # 3.

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
