### PR TITLE
add dirichlet boundary condition capability for thermal diffusion unit test

### DIFF
--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph
@@ -5,7 +5,7 @@ stop_time = 0.001
 # PROBLEM SIZE & GEOMETRY
 geometry.is_periodic = 0    0
 geometry.coord_sys   = 2    # 2 = SPHERICAL
-geometry.prob_lo     = 0.25   0.0
+geometry.prob_lo     = 0.1       0.0
 geometry.prob_hi     = 1.0       3.141592653589793238
 amr.n_cell           = 64        64
 

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph
@@ -5,7 +5,7 @@ stop_time = 0.001
 # PROBLEM SIZE & GEOMETRY
 geometry.is_periodic = 0    0
 geometry.coord_sys   = 2    # 2 = SPHERICAL
-geometry.prob_lo     = 0.3   0.0
+geometry.prob_lo     = 0.1   0.0
 geometry.prob_hi     = 1.0       3.141592653589793238
 amr.n_cell           = 64        64
 

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph
@@ -5,7 +5,7 @@ stop_time = 0.001
 # PROBLEM SIZE & GEOMETRY
 geometry.is_periodic = 0    0
 geometry.coord_sys   = 2    # 2 = SPHERICAL
-geometry.prob_lo     = 0.1   0.0
+geometry.prob_lo     = 0.25   0.0
 geometry.prob_hi     = 1.0       3.141592653589793238
 amr.n_cell           = 64        64
 
@@ -64,10 +64,11 @@ amr.plot_per        = 0.0001
 amr.derive_plot_vars=ALL
 
 # PROBLEM PARAMETERS
-problem.diff_coeff = 1.0
+problem.diff_coeff = 15.0
 
 # CONDUCTIVITY
 conductivity.const_conductivity = 10.0
+castro.diffuse_use_amrex_mlmg = 0
 
 # EOS
 eos.eos_assume_neutral = 1

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph
@@ -64,7 +64,7 @@ amr.plot_per        = 0.0001
 amr.derive_plot_vars=ALL
 
 # PROBLEM PARAMETERS
-problem.diff_coeff = 15.0
+problem.diff_coeff = 1.0
 
 # CONDUCTIVITY
 conductivity.const_conductivity = 10.0

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph
@@ -1,11 +1,11 @@
-# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+#------------------  INPUTS TO MAIN PROGRAM  -------------------
 max_step = 50000
 stop_time = 0.001
 
 # PROBLEM SIZE & GEOMETRY
 geometry.is_periodic = 0    0
 geometry.coord_sys   = 2    # 2 = SPHERICAL
-geometry.prob_lo     = 0.00001   0.0
+geometry.prob_lo     = 0.3   0.0
 geometry.prob_hi     = 1.0       3.141592653589793238
 amr.n_cell           = 64        64
 
@@ -16,7 +16,7 @@ castro.allow_non_unit_aspect_zones = 1
 # 1 = Inflow             4 = SlipWall
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
-castro.lo_bc       =  2   3
+castro.lo_bc       =  1   3
 castro.hi_bc       =  2   3
 
 # WHICH PHYSICS

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -30,15 +30,14 @@ void problem_bc_fill(int i, int j, int k,
 #if AMREX_SPACEDIM == 2
     const auto coord = geomdata.Coord();
     const int* domlo = geomdata.Domain().loVect();
-    const int* domhi = geomdata.Domain().hiVect();
     const Real* dx = geomdata.CellSize();
     const Real* problo = geomdata.ProbLo();
 
     Real r[3] = {0.0_rt};
-    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
+    r[0] = problo[0] + dx[0] * static_cast<Real>(i);
 
     if (coord == CoordSys::SPHERICAL) {
-        if (bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) {
+        if ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0])) {
             state(i,j,k,URHO) = problem::rho0;
             state(i,j,k,UMX) = 0.0_rt;
             state(i,j,k,UMY) = 0.0_rt;

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -28,6 +28,7 @@ void problem_bc_fill(int i, int j, int k,
 
     const auto coord = geomdata.Coord();
     const int* domlo = geomdata.Domain().loVect();
+    const int* domhi = geomdata.Domain().hiVect();
     const Real* dx = geomdata.CellSize();
     const Real* problo = geomdata.ProbLo();
 

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -21,48 +21,62 @@ void problem_bc_fill(int i, int j, int k,
                       Real time, const Array1D<BCRec, 0, NUM_STATE-1>& bcs,
                       const GeometryData& geomdata) {
 
-    // set Dirchilet boundary condition for spherical 2D diffusion problem
-    // Use the analytic solution for the lower r-boundary
+    // set Dirchilet boundary condition using analytic solution for diffusion problem.
 
     amrex::ignore_unused(j);
     amrex::ignore_unused(k);
 
-#if AMREX_SPACEDIM == 2
     const auto coord = geomdata.Coord();
     const int* domlo = geomdata.Domain().loVect();
     const Real* dx = geomdata.CellSize();
     const Real* problo = geomdata.ProbLo();
 
     Real r[3] = {0.0_rt};
-    r[0] = problo[0] + dx[0] * (static_cast<Real>(i));
+    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt) - problem::center[0];
 
-    if (coord == CoordSys::SPHERICAL) {
-        if ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0])) {
-            state(i,j,k,URHO) = problem::rho0;
-            state(i,j,k,UMX) = 0.0_rt;
-            state(i,j,k,UMY) = 0.0_rt;
-            state(i,j,k,UMZ) = 0.0_rt;
-            state(i,j,k,UTEMP) = analytic(r, time, coord);
+#if AMREX_SPACEDIM >= 2
+    r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt) - problem::center[1];
+#endif
 
-            // compute internal energy
-            eos_t eos_state;
-            eos_state.T = state(i,j,k,UTEMP);
-            eos_state.rho = state(i,j,k,URHO);
-            Real X[NumSpec] = {0.0_rt};
-            X[0] = 1.0_rt;
-            for (int n = 0; n < NumSpec; n++) {
-                eos_state.xn[n] = X[n];
-            }
-            eos(eos_input_rt, eos_state);
+#if AMREX_SPACEDIM == 3
+    r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt) - problem::center[2];
+#endif
 
-            state(i,j,k,UEDEN) = problem::rho0 * eos_state.e;
-            state(i,j,k,UEINT) = problem::rho0 * eos_state.e;
-            for (int n = 0; n < NumSpec; n++) {
-                state(i,j,k,UFS+n) = problem::rho0 * X[n];
-            }
+    if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
+        || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))
+#if AMREX_SPACEDIM >= 2
+        || ((bcs(UTEMP).lo(1) == amrex::BCType::ext_dir) && (j < domlo[1]))
+        || ((bcs(UTEMP).hi(1) == amrex::BCType::ext_dir) && (j > domhi[1]))
+#endif
+#if AMREX_SPACEDIM == 3
+        || ((bcs(UTEMP).lo(2) == amrex::BCType::ext_dir) && (k < domlo[2]))
+        || ((bcs(UTEMP).hi(2) == amrex::BCType::ext_dir) && (k > domhi[2]))
+#endif
+        ) {
+
+        state(i,j,k,URHO) = problem::rho0;
+        state(i,j,k,UMX) = 0.0_rt;
+        state(i,j,k,UMY) = 0.0_rt;
+        state(i,j,k,UMZ) = 0.0_rt;
+        state(i,j,k,UTEMP) = analytic(r, time, coord);
+
+        // compute internal energy
+        eos_t eos_state;
+        eos_state.T = state(i,j,k,UTEMP);
+        eos_state.rho = state(i,j,k,URHO);
+        Real X[NumSpec] = {0.0_rt};
+        X[0] = 1.0_rt;
+        for (int n = 0; n < NumSpec; n++) {
+            eos_state.xn[n] = X[n];
+        }
+        eos(eos_input_rt, eos_state);
+
+        state(i,j,k,UEDEN) = problem::rho0 * eos_state.e;
+        state(i,j,k,UEINT) = problem::rho0 * eos_state.e;
+        for (int n = 0; n < NumSpec; n++) {
+            state(i,j,k,UFS+n) = problem::rho0 * X[n];
         }
     }
-#endif
 }
 
 #endif

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -34,7 +34,7 @@ void problem_bc_fill(int i, int j, int k,
     const Real* problo = geomdata.ProbLo();
 
     Real r[3] = {0.0_rt};
-    r[0] = problo[0] + dx[0] * static_cast<Real>(i);
+    r[0] = problo[0] + dx[0] * (static_cast<Real>(i));
 
     if (coord == CoordSys::SPHERICAL) {
         if ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0])) {

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -1,0 +1,69 @@
+#ifndef problem_bc_fill_H
+#define problem_bc_fill_H
+
+#include <prob_util.H>
+#include <eos.H>
+
+///
+/// Problem-specific boundary condition fill
+///
+/// @param i         x-index
+/// @param j         y-index
+/// @param k         z-index
+/// @param state     simulation state (Fab)
+/// @param time      simulation time
+/// @param bcs       boundary conditions
+/// @param geomdata  geometry data
+///
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void problem_bc_fill(int i, int j, int k,
+                      Array4<Real> const& state,
+                      Real time, const Array1D<BCRec, 0, NUM_STATE-1>& bcs,
+                      const GeometryData& geomdata) {
+
+    // set Dirchilet boundary condition for spherical 2D diffusion problem
+    // Use the analytic solution for the lower r-boundary
+
+    amrex::ignore_unused(j);
+    amrex::ignore_unused(k);
+
+#if AMREX_SPACEDIM == 2
+    const auto coord = geomdata.Coord();
+    const int* domlo = geomdata.Domain().loVect();
+    const int* domhi = geomdata.Domain().hiVect();
+    const Real* dx = geomdata.CellSize();
+    const Real* problo = geomdata.ProbLo();
+
+    Real r[3] = {0.0_rt};
+    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
+
+    if (coord == CoordSys::SPHERICAL) {
+        if (bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) {
+            state(i,j,k,URHO) = problem::rho0;
+            state(i,j,k,UMX) = 0.0_rt;
+            state(i,j,k,UMY) = 0.0_rt;
+            state(i,j,k,UMZ) = 0.0_rt;
+            state(i,j,k,UTEMP) = analytic(r, time, coord);
+
+            // compute internal energy
+            eos_t eos_state;
+            eos_state.T = state(i,j,k,UTEMP);
+            eos_state.rho = state(i,j,k,URHO);
+            Real X[NumSpec] = {0.0_rt};
+            X[0] = 1.0_rt;
+            for (int n = 0; n < NumSpec; n++) {
+                eos_state.xn[n] = X[n];
+            }
+            eos(eos_input_rt, eos_state);
+
+            state(i,j,k,UEDEN) = problem::rho0 * eos_state.e;
+            state(i,j,k,UEINT) = problem::rho0 * eos_state.e;
+            for (int n = 0; n < NumSpec; n++) {
+                state(i,j,k,UFS+n) = problem::rho0 * X[n];
+            }
+        }
+    }
+#endif
+}
+
+#endif


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary
this pr adds `problem_bc_fill.H`, which allows to use `inflow`, i.e. Dirichlet, boundary condition by using the analytic solution for different problems.
Even though this is intended to use for spherical 2d input file, but any input file theoretically can use this as long as its constant conductivity.

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
