### PR TITLE
add bessel-legendre initial condition for spherical 2D geometry in diffusion test

### DIFF
--- a/Exec/unit_tests/diffusion_test/Problem_Derive.cpp
+++ b/Exec/unit_tests/diffusion_test/Problem_Derive.cpp
@@ -24,29 +24,19 @@ void deranalytic(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
     amrex::ParallelFor(bx,
     [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {
-
-        Real r[3] = {0.0};
-        r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt) - problem::center[0];
+        Real r[3] = {0.0_rt};
+        r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
 #if AMREX_SPACEDIM >= 2
-        r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt) - problem::center[1];
+        r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt);
 #endif
 #if AMREX_SPACEDIM == 3
-        r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt) - problem::center[2];
+        r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt);
 #endif
-
-// #if AMREX_SPACEDIM == 2
-//         // Deal with 2D spherical special case.
-//         if (coord_type == 2) {
-//             Real r_sph = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
-//             Real theta = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt);
-
-//             // This is Cylindrical R = rsin(theta) - R_0
-//             r[0] = r_sph * std::sin(theta) - problem::center[0];
-
-//             // This is Z = rcos(theta) - Z_0
-//             r[1] = r_sph * std::cos(theta) - problem::center[1];
-//         }
-// #endif
+        if (coord_type <= 1) {
+            for (int i; i < AMREX_SPACEDIM; ++i) {
+                r[i] -= problem::center[i];
+            }
+        }
 
         der(i,j,k,0) = analytic(r, time, coord_type);
 

--- a/Exec/unit_tests/diffusion_test/Problem_Derive.cpp
+++ b/Exec/unit_tests/diffusion_test/Problem_Derive.cpp
@@ -34,6 +34,20 @@ void deranalytic(const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
         r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt) - problem::center[2];
 #endif
 
+// #if AMREX_SPACEDIM == 2
+//         // Deal with 2D spherical special case.
+//         if (coord_type == 2) {
+//             Real r_sph = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
+//             Real theta = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt);
+
+//             // This is Cylindrical R = rsin(theta) - R_0
+//             r[0] = r_sph * std::sin(theta) - problem::center[0];
+
+//             // This is Z = rcos(theta) - Z_0
+//             r[1] = r_sph * std::cos(theta) - problem::center[1];
+//         }
+// #endif
+
         der(i,j,k,0) = analytic(r, time, coord_type);
 
     });

--- a/Exec/unit_tests/diffusion_test/_prob_params
+++ b/Exec/unit_tests/diffusion_test/_prob_params
@@ -1,11 +1,12 @@
 
-diff_coeff    real     1.0_rt       y
+diff_coeff        real     1.0_rt       y
 
-T1            real     1.0_rt       y
+T1                real     1.0_rt       y
 
-T2            real     2.0_rt       y
+T2                real     2.0_rt       y
 
-rho0          real     0.0_rt
+rho0              real     0.0_rt
 
-t_0           real     0.001_rt     y
+t_0               real     0.001_rt     y
 
+gaussian_init     bool     1            y

--- a/Exec/unit_tests/diffusion_test/inputs.2d.axisymmetric
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.axisymmetric
@@ -14,7 +14,7 @@ amr.n_cell           = 64  128
 # 1 = Inflow             4 = SlipWall
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
-castro.lo_bc       =  1   2
+castro.lo_bc       =  3   2
 castro.hi_bc       =  2   2
 
 # WHICH PHYSICS

--- a/Exec/unit_tests/diffusion_test/inputs.2d.axisymmetric
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.axisymmetric
@@ -5,7 +5,7 @@ stop_time = 0.001
 # PROBLEM SIZE & GEOMETRY
 geometry.is_periodic = 0    0
 geometry.coord_sys   = 1    # 1 = RZ
-geometry.prob_lo     = 0.0  0.0 
+geometry.prob_lo     = 0.0  0.0
 geometry.prob_hi     = 0.5  1.0
 amr.n_cell           = 64  128
 
@@ -14,10 +14,10 @@ amr.n_cell           = 64  128
 # 1 = Inflow             4 = SlipWall
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
-castro.lo_bc       =  3   2
+castro.lo_bc       =  1   2
 castro.hi_bc       =  2   2
 
-# WHICH PHYSICS 
+# WHICH PHYSICS
 castro.do_hydro = 0
 castro.diffuse_temp = 1
 castro.do_react = 0

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph
@@ -17,7 +17,7 @@ castro.allow_non_unit_aspect_zones = 1
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 castro.lo_bc       =  1   3
-castro.hi_bc       =  2   3
+castro.hi_bc       =  1   3
 
 # WHICH PHYSICS
 castro.do_hydro = 0
@@ -65,6 +65,7 @@ amr.derive_plot_vars=ALL
 
 # PROBLEM PARAMETERS
 problem.diff_coeff = 1.0
+#problem.center = 0.5 0 0
 
 # CONDUCTIVITY
 conductivity.const_conductivity = 10.0

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph
@@ -79,12 +79,13 @@ problem.diff_coeff = 1.0
 # i.e. problem.gaussian_init=1
 # Put gaussian in the center of the domain, and use outflow condition in r-dir
 # Make sure the Gaussian diffuses quickly before reaching the boundary.
-problem.center = 0.5 0 0
+
+# problem.center = 0.5 0 0
 
 # Setting problem.gaussian_init=0 initializes problem with initial condition
 # that is oscillatory in r, but has theta variations.
 # Use Dirichlet boundary in r-dir for this
-#problem.gaussian_init = 0
+problem.gaussian_init = 0
 
 # CONDUCTIVITY
 conductivity.const_conductivity = 10.0

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph
@@ -16,8 +16,8 @@ castro.allow_non_unit_aspect_zones = 1
 # 1 = Inflow             4 = SlipWall
 # 2 = Outflow            5 = NoSlipWall
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
-castro.lo_bc       =  1   3
-castro.hi_bc       =  1   3
+castro.lo_bc       =  2   3
+castro.hi_bc       =  2   3
 
 # WHICH PHYSICS
 castro.do_hydro = 0
@@ -65,7 +65,26 @@ amr.derive_plot_vars=ALL
 
 # PROBLEM PARAMETERS
 problem.diff_coeff = 1.0
-#problem.center = 0.5 0 0
+
+# To test the theta-dependence of the spherical 2D diffusion solver, either
+# 1. Set a nonzero problem center for gaussian initial condition via problem.center
+#    This requires resolution convergence test
+# 2. Initialize problem with theta-dependent initial condition via gaussian_init=0.
+#    There is an analytic solution for this.
+
+# For spherical 2D, manually setting problem center corresponds to change it
+# in the cylindrical direction, i.e. center[0] refers to cylindrical r-direction
+# and center[1] refers to z-direction.
+# Note that changing problem::center only works with gaussian initial condition,
+# i.e. problem.gaussian_init=1
+# Put gaussian in the center of the domain, and use outflow condition in r-dir
+# Make sure the Gaussian diffuses quickly before reaching the boundary.
+problem.center = 0.5 0 0
+
+# Setting problem.gaussian_init=0 initializes problem with initial condition
+# that is oscillatory in r, but has theta variations.
+# Use Dirichlet boundary in r-dir for this
+#problem.gaussian_init = 0
 
 # CONDUCTIVITY
 conductivity.const_conductivity = 10.0

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph.bessel
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph.bessel
@@ -1,0 +1,95 @@
+#------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 50000
+stop_time = 0.001
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic = 0    0
+geometry.coord_sys   = 2    # 2 = SPHERICAL
+geometry.prob_lo     = 0.1       0.0
+geometry.prob_hi     = 1.0       3.141592653589793238
+amr.n_cell           = 64        64
+
+castro.allow_non_unit_aspect_zones = 1
+
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+# 0 = Interior           3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+castro.lo_bc       =  1   3
+castro.hi_bc       =  1   3
+
+# WHICH PHYSICS
+castro.do_hydro = 0
+castro.diffuse_temp = 1
+castro.do_react = 0
+
+# TIME STEP CONTROL
+
+castro.cfl            = 0.5     # cfl number for hyperbolic system
+castro.init_shrink    = 0.1    # scale back initial timestep
+castro.change_max     = 1.1     # maximum increase in dt over successive steps
+
+# DIAGNOSTICS & VERBOSITY
+castro.sum_interval   = 1       # timesteps between computing mass
+castro.v              = 1       # verbosity in Castro.cpp
+amr.v                 = 1       # verbosity in Amr.cpp
+#amr.grid_log         = grdlog  # name of grid logging file
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2       # how often to regrid
+amr.blocking_factor = 8       # block factor in grid generation
+amr.max_grid_size   = 32
+
+amr.refinement_indicators = temperr tempgrad
+
+amr.refine.temperr.value_greater = 1.1
+amr.refine.temperr.field_name = Temp
+amr.refine.temperr.max_level = 3
+
+amr.refine.tempgrad.gradient = 0.1
+amr.refine.tempgrad.field_name = Temp
+amr.refine.tempgrad.max_level = 3
+
+# CHECKPOINT FILES
+amr.check_file      = diffuse_chk     # root name of checkpoint file
+amr.check_int       = 1000     # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_file       = diffuse_plt
+#amr.plot_int        = 10
+amr.plot_per        = 0.0001
+amr.derive_plot_vars=ALL
+
+# PROBLEM PARAMETERS
+problem.diff_coeff = 1.0
+
+# To test the theta-dependence of the spherical 2D diffusion solver, either
+# 1. Set a nonzero problem center for gaussian initial condition via problem.center
+#    This requires resolution convergence test
+# 2. Initialize problem with theta-dependent initial condition via gaussian_init=0.
+#    There is an analytic solution for this.
+
+# For spherical 2D, manually setting problem center corresponds to change it
+# in the cylindrical direction, i.e. center[0] refers to cylindrical r-direction
+# and center[1] refers to z-direction.
+# Note that changing problem::center only works with gaussian initial condition,
+# i.e. problem.gaussian_init=1
+# Put gaussian in the center of the domain, and use outflow condition in r-dir
+# Make sure the Gaussian diffuses quickly before reaching the boundary.
+
+# problem.center = 0.5 0 0
+
+# Setting problem.gaussian_init=0 initializes problem with initial condition
+# that is oscillatory in r, but has theta variations.
+# Use Dirichlet boundary in r-dir for this
+problem.gaussian_init = 0
+
+# CONDUCTIVITY
+conductivity.const_conductivity = 10.0
+castro.diffuse_use_amrex_mlmg = 0
+
+# EOS
+eos.eos_assume_neutral = 1

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph.bessel
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph.bessel
@@ -72,19 +72,11 @@ problem.diff_coeff = 1.0
 # 2. Initialize problem with theta-dependent initial condition via gaussian_init=0.
 #    There is an analytic solution for this.
 
-# For spherical 2D, manually setting problem center corresponds to change it
-# in the cylindrical direction, i.e. center[0] refers to cylindrical r-direction
-# and center[1] refers to z-direction.
-# Note that changing problem::center only works with gaussian initial condition,
-# i.e. problem.gaussian_init=1
-# Put gaussian in the center of the domain, and use outflow condition in r-dir
-# Make sure the Gaussian diffuses quickly before reaching the boundary.
-
-# problem.center = 0.5 0 0
-
+# This input file is used to test option 2.
 # Setting problem.gaussian_init=0 initializes problem with initial condition
-# that is oscillatory in r, but has theta variations.
-# Use Dirichlet boundary in r-dir for this
+# that is oscillatory in r, but has a cos(theta) term for theta variation.
+# Dirichlet boundary in r-dir is needed for this.
+
 problem.gaussian_init = 0
 
 # CONDUCTIVITY

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph.gaussian
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph.gaussian
@@ -67,25 +67,19 @@ amr.derive_plot_vars=ALL
 problem.diff_coeff = 1.0
 
 # To test the theta-dependence of the spherical 2D diffusion solver, either
-# 1. Set a nonzero problem center for gaussian initial condition via problem.center
+# 1. Set a nonzero problem center for Gaussian initial condition via problem.center
 #    This requires resolution convergence test
 # 2. Initialize problem with theta-dependent initial condition via gaussian_init=0.
 #    There is an analytic solution for this.
 
-# For spherical 2D, manually setting problem center corresponds to change it
-# in the cylindrical direction, i.e. center[0] refers to cylindrical r-direction
-# and center[1] refers to z-direction.
+# This input file is used to test option 1.
+# This is meant to change the position of the Gaussian peak.
+# We use outflow condition in r-dir
+# and make sure the Gaussian diffuses quickly before reaching the boundary.
 # Note that changing problem::center only works with gaussian initial condition,
 # i.e. problem.gaussian_init=1
-# Put gaussian in the center of the domain, and use outflow condition in r-dir
-# Make sure the Gaussian diffuses quickly before reaching the boundary.
 
-problem.center = 0.5 0 0
-
-# Setting problem.gaussian_init=0 initializes problem with initial condition
-# that is oscillatory in r, but has theta variations.
-# Use Dirichlet boundary in r-dir for this
-# problem.gaussian_init = 0
+problem.center = 0.5 1.57079632679 0
 
 # CONDUCTIVITY
 conductivity.const_conductivity = 10.0

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph.gaussian
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph.gaussian
@@ -80,12 +80,12 @@ problem.diff_coeff = 1.0
 # Put gaussian in the center of the domain, and use outflow condition in r-dir
 # Make sure the Gaussian diffuses quickly before reaching the boundary.
 
-# problem.center = 0.5 0 0
+problem.center = 0.5 0 0
 
 # Setting problem.gaussian_init=0 initializes problem with initial condition
 # that is oscillatory in r, but has theta variations.
 # Use Dirichlet boundary in r-dir for this
-problem.gaussian_init = 0
+# problem.gaussian_init = 0
 
 # CONDUCTIVITY
 conductivity.const_conductivity = 10.0

--- a/Exec/unit_tests/diffusion_test/prob_util.H
+++ b/Exec/unit_tests/diffusion_test/prob_util.H
@@ -36,6 +36,7 @@ Real analytic(const Real* r, const Real time, const int coord_type) {
         if (coord_type == 2) {
             dist2 = r[0] * r[0];
 #if AMREX_SPACEDIM == 2
+            // Here problem::center is meant to be the peak position of the Gaussian initial condition
             // problem::center[0] = r_0 and problem::center[1] = theta_0
             // dist2 = r^2 + r_0^2 - 2 r r_0 cos(theta - theta_0)
             dist2 += problem::center[0]*problem::center[0] -

--- a/Exec/unit_tests/diffusion_test/prob_util.H
+++ b/Exec/unit_tests/diffusion_test/prob_util.H
@@ -16,17 +16,18 @@ Real analytic(const Real* r, const Real time, const int coord_type) {
     }
 
     Real dist2 = 0.0;
-    if (coord_type == 2) {
-        dist2 = r[0]*r[0];
-    } else {
-        for (int d = 0; d < AMREX_SPACEDIM; d++) {
-            dist2 += r[d] * r[d];
-        }
+    for (int d = 0; d < AMREX_SPACEDIM; d++) {
+        dist2 += r[d] * r[d];
     }
 
+    // Real temp = problem::T1 + (problem::T2 - problem::T1) *
+    //     std::pow(problem::t_0 / (time + problem::t_0), exponent) *
+    //     std::exp(-0.25_rt * dist2 / (problem::diff_coeff * (time + problem::t_0)));
+
+    Real kr = std::sqrt(1.0_rt / (problem::diff_coeff * problem::t_0)) * r[0];
     Real temp = problem::T1 + (problem::T2 - problem::T1) *
-        std::pow(problem::t_0 / (time + problem::t_0), exponent) *
-        std::exp(-0.25_rt * dist2 / (problem::diff_coeff * (time + problem::t_0)));
+        (std::sin(kr) / (kr * kr) - std::cos(kr) / kr) * std::cos(r[1]) *
+        std::exp(-1.0_rt * time / problem::t_0);
 
     return temp;
 }

--- a/Exec/unit_tests/diffusion_test/prob_util.H
+++ b/Exec/unit_tests/diffusion_test/prob_util.H
@@ -4,30 +4,55 @@
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 Real analytic(const Real* r, const Real time, const int coord_type) {
 
-    Real exponent;
-    if (coord_type == 2) {
-        // Handle spherical coordinates
-        exponent = 3.0_rt / 2.0_rt;
-    } else if (AMREX_SPACEDIM == 2 && coord_type == 1) {
-        // Handle cylindrical coordinates
-        exponent = 3.0_rt / 2.0_rt;
-    } else {
-        exponent = AMREX_SPACEDIM / 2.0_rt;
+    Real temp = 0.0_rt;
+
+#if AMREX_SPACEDIM == 2
+    if ((!problem::gaussian_init) && (coord_type == 2)) {
+        // For spherical geometry with azimuthal symmetry,
+        // diffusion equation has analytic form of:
+        // T(r, theta, t) = A_l j_l(kr) P_l(cos(theta)) exp(-t/t_0)
+        // where k^2 = 1/(D*t_0)
+        // Here we initialize problem to a single mode, l = 1.
+
+        Real kr = std::sqrt(1.0_rt / (problem::diff_coeff * problem::t_0)) * r[0];
+        temp = problem::T1 + (problem::T2 - problem::T1) *
+            (std::sin(kr) / (kr * kr) - std::cos(kr) / kr) * std::cos(r[1]) *
+            std::exp(-1.0_rt * time / problem::t_0);
+    } else
+#endif
+    {
+        Real exponent;
+        if (coord_type == 2) {
+            // Handle spherical coordinates
+            exponent = 3.0_rt / 2.0_rt;
+        } else if (AMREX_SPACEDIM == 2 && coord_type == 1) {
+            // Handle cylindrical coordinates
+            exponent = 3.0_rt / 2.0_rt;
+        } else {
+            exponent = AMREX_SPACEDIM / 2.0_rt;
+        }
+
+        Real dist2 = 0.0;
+        if (coord_type == 2) {
+            dist2 = r[0] * r[0];
+#if AMREX_SPACEDIM == 2
+            // Note r[0] = r, r[1] = theta,
+            // problem::center[0] = cylindrical r-center, problem::center[1] = z-center
+            dist2 += -2.0_rt * problem::center[0] * r[0] * std::sin(r[1]) -
+                2.0_rt * problem::center[1] * r[0] * std::cos(r[1]) +
+                problem::center[0] * problem::center[0] +
+                problem::center[1] * problem::center[1];
+#endif
+        } else {
+            for (int d = 0; d < AMREX_SPACEDIM; d++) {
+                dist2 += r[d] * r[d];
+            }
+        }
+
+        temp = problem::T1 + (problem::T2 - problem::T1) *
+            std::pow(problem::t_0 / (time + problem::t_0), exponent) *
+            std::exp(-0.25_rt * dist2 / (problem::diff_coeff * (time + problem::t_0)));
     }
-
-    Real dist2 = 0.0;
-    for (int d = 0; d < AMREX_SPACEDIM; d++) {
-        dist2 += r[d] * r[d];
-    }
-
-    // Real temp = problem::T1 + (problem::T2 - problem::T1) *
-    //     std::pow(problem::t_0 / (time + problem::t_0), exponent) *
-    //     std::exp(-0.25_rt * dist2 / (problem::diff_coeff * (time + problem::t_0)));
-
-    Real kr = std::sqrt(1.0_rt / (problem::diff_coeff * problem::t_0)) * r[0];
-    Real temp = problem::T1 + (problem::T2 - problem::T1) *
-        (std::sin(kr) / (kr * kr) - std::cos(kr) / kr) * std::cos(r[1]) *
-        std::exp(-1.0_rt * time / problem::t_0);
 
     return temp;
 }

--- a/Exec/unit_tests/diffusion_test/prob_util.H
+++ b/Exec/unit_tests/diffusion_test/prob_util.H
@@ -36,12 +36,10 @@ Real analytic(const Real* r, const Real time, const int coord_type) {
         if (coord_type == 2) {
             dist2 = r[0] * r[0];
 #if AMREX_SPACEDIM == 2
-            // Note r[0] = r, r[1] = theta,
-            // problem::center[0] = cylindrical r-center, problem::center[1] = z-center
-            dist2 += -2.0_rt * problem::center[0] * r[0] * std::sin(r[1]) -
-                2.0_rt * problem::center[1] * r[0] * std::cos(r[1]) +
-                problem::center[0] * problem::center[0] +
-                problem::center[1] * problem::center[1];
+            // problem::center[0] = r_0 and problem::center[1] = theta_0
+            // dist2 = r^2 + r_0^2 - 2 r r_0 cos(theta - theta_0)
+            dist2 += problem::center[0]*problem::center[0] -
+                2.0_rt * r[0] * problem::center[0] * std::cos(r[1] - problem::center[1]);
 #endif
         } else {
             for (int d = 0; d < AMREX_SPACEDIM; d++) {

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -46,6 +46,9 @@ void problem_bc_fill(int i, int j, int k,
         }
     }
 
+    // If MLMG is used to evaluate diffusion term, then the Dirichlet boundary condition
+    // for MLMG needs to be face-centered. This is done via mlabec.setLevelBC(0, &Temperature)
+    // in Diffusion.cpp. Here add another 0.5*dx to accomplish that.
     if (diffuse_use_amrex_mlmg) {
         if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
             || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))) {

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -43,6 +43,25 @@ void problem_bc_fill(int i, int j, int k,
     r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt) - problem::center[2];
 #endif
 
+    if (diffuse_use_amrex_mlmg) {
+        if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
+            || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))) {
+            r[0] += dx[0] * 0.5_rt;
+        }
+#if AMREX_SPACEDIM >= 2
+        if (   ((bcs(UTEMP).lo(1) == amrex::BCType::ext_dir) && (j < domlo[1]))
+            || ((bcs(UTEMP).hi(1) == amrex::BCType::ext_dir) && (j > domhi[1]))) {
+            r[1] += dx[1] * 0.5_rt;
+        }
+#endif
+#if AMREX_SPACEDIM == 3
+        if (   ((bcs(UTEMP).lo(2) == amrex::BCType::ext_dir) && (k < domlo[2]))
+            || ((bcs(UTEMP).hi(2) == amrex::BCType::ext_dir) && (k > domhi[2]))) {
+            r[2] += dx[2] * 0.5_rt;
+        }
+#endif
+    }
+
     if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
         || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))
 #if AMREX_SPACEDIM >= 2

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -40,7 +40,7 @@ void problem_bc_fill(int i, int j, int k,
 #if AMREX_SPACEDIM == 3
     r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt);
 #endif
-    if (coord_type <= 1) {
+    if (coord <= 1) {
         for (int i; i < AMREX_SPACEDIM; ++i) {
             r[i] -= problem::center[i];
         }

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -33,34 +33,34 @@ void problem_bc_fill(int i, int j, int k,
     const Real* problo = geomdata.ProbLo();
 
     Real r[3] = {0.0_rt};
-    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt) - problem::center[0];
+    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 1.0_rt) - problem::center[0];
 
 #if AMREX_SPACEDIM >= 2
-    r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt) - problem::center[1];
+    r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 1.0_rt) - problem::center[1];
 #endif
 
 #if AMREX_SPACEDIM == 3
     r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt) - problem::center[2];
 #endif
 
-    if (diffuse_use_amrex_mlmg) {
-        if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
-            || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))) {
-            r[0] += dx[0] * 0.5_rt;
-        }
-#if AMREX_SPACEDIM >= 2
-        if (   ((bcs(UTEMP).lo(1) == amrex::BCType::ext_dir) && (j < domlo[1]))
-            || ((bcs(UTEMP).hi(1) == amrex::BCType::ext_dir) && (j > domhi[1]))) {
-            r[1] += dx[1] * 0.5_rt;
-        }
-#endif
-#if AMREX_SPACEDIM == 3
-        if (   ((bcs(UTEMP).lo(2) == amrex::BCType::ext_dir) && (k < domlo[2]))
-            || ((bcs(UTEMP).hi(2) == amrex::BCType::ext_dir) && (k > domhi[2]))) {
-            r[2] += dx[2] * 0.5_rt;
-        }
-#endif
-    }
+//     if (diffuse_use_amrex_mlmg) {
+//         if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
+//             || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))) {
+//             r[0] += dx[0] * 0.5_rt;
+//         }
+// #if AMREX_SPACEDIM >= 2
+//         if (   ((bcs(UTEMP).lo(1) == amrex::BCType::ext_dir) && (j < domlo[1]))
+//             || ((bcs(UTEMP).hi(1) == amrex::BCType::ext_dir) && (j > domhi[1]))) {
+//             r[1] += dx[1] * 0.5_rt;
+//         }
+// #endif
+// #if AMREX_SPACEDIM == 3
+//         if (   ((bcs(UTEMP).lo(2) == amrex::BCType::ext_dir) && (k < domlo[2]))
+//             || ((bcs(UTEMP).hi(2) == amrex::BCType::ext_dir) && (k > domhi[2]))) {
+//             r[2] += dx[2] * 0.5_rt;
+//         }
+// #endif
+//     }
 
     if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
         || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -33,34 +33,37 @@ void problem_bc_fill(int i, int j, int k,
     const Real* problo = geomdata.ProbLo();
 
     Real r[3] = {0.0_rt};
-    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 1.0_rt) - problem::center[0];
-
+    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
 #if AMREX_SPACEDIM >= 2
-    r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 1.0_rt) - problem::center[1];
+    r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt);
 #endif
-
 #if AMREX_SPACEDIM == 3
-    r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt) - problem::center[2];
+    r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt);
 #endif
+    if (coord_type <= 1) {
+        for (int i; i < AMREX_SPACEDIM; ++i) {
+            r[i] -= problem::center[i];
+        }
+    }
 
-//     if (diffuse_use_amrex_mlmg) {
-//         if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
-//             || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))) {
-//             r[0] += dx[0] * 0.5_rt;
-//         }
-// #if AMREX_SPACEDIM >= 2
-//         if (   ((bcs(UTEMP).lo(1) == amrex::BCType::ext_dir) && (j < domlo[1]))
-//             || ((bcs(UTEMP).hi(1) == amrex::BCType::ext_dir) && (j > domhi[1]))) {
-//             r[1] += dx[1] * 0.5_rt;
-//         }
-// #endif
-// #if AMREX_SPACEDIM == 3
-//         if (   ((bcs(UTEMP).lo(2) == amrex::BCType::ext_dir) && (k < domlo[2]))
-//             || ((bcs(UTEMP).hi(2) == amrex::BCType::ext_dir) && (k > domhi[2]))) {
-//             r[2] += dx[2] * 0.5_rt;
-//         }
-// #endif
-//     }
+    if (diffuse_use_amrex_mlmg) {
+        if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
+            || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))) {
+            r[0] += dx[0] * 0.5_rt;
+        }
+#if AMREX_SPACEDIM >= 2
+        if (   ((bcs(UTEMP).lo(1) == amrex::BCType::ext_dir) && (j < domlo[1]))
+            || ((bcs(UTEMP).hi(1) == amrex::BCType::ext_dir) && (j > domhi[1]))) {
+            r[1] += dx[1] * 0.5_rt;
+        }
+#endif
+#if AMREX_SPACEDIM == 3
+        if (   ((bcs(UTEMP).lo(2) == amrex::BCType::ext_dir) && (k < domlo[2]))
+            || ((bcs(UTEMP).hi(2) == amrex::BCType::ext_dir) && (k > domhi[2]))) {
+            r[2] += dx[2] * 0.5_rt;
+        }
+#endif
+    }
 
     if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
         || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))

--- a/Exec/unit_tests/diffusion_test/problem_bc_fill.H
+++ b/Exec/unit_tests/diffusion_test/problem_bc_fill.H
@@ -46,9 +46,11 @@ void problem_bc_fill(int i, int j, int k,
         }
     }
 
+    // If we evaluate diffusion within castro, then boundary condition needs to be cell-centered.
     // If MLMG is used to evaluate diffusion term, then the Dirichlet boundary condition
     // for MLMG needs to be face-centered. This is done via mlabec.setLevelBC(0, &Temperature)
-    // in Diffusion.cpp. Here add another 0.5*dx to accomplish that.
+    // in Diffusion.cpp. Here add another 0.5 * dx to convert from cell-centered to face-centered.
+
     if (diffuse_use_amrex_mlmg) {
         if (   ((bcs(UTEMP).lo(0) == amrex::BCType::ext_dir) && (i < domlo[0]))
             || ((bcs(UTEMP).hi(0) == amrex::BCType::ext_dir) && (i > domhi[0]))) {

--- a/Exec/unit_tests/diffusion_test/problem_initialize.H
+++ b/Exec/unit_tests/diffusion_test/problem_initialize.H
@@ -18,15 +18,14 @@ void problem_initialize ()
 
     // set center variable
 
-    // Note for spherical 2D, here we assume problem::center is for [R,Z,0]
-    // where R is the cylindrical radial direction.
+    // Note that 2D spherical is a special case here.
+    // Here problem::center = 0 by default for 2d spherical geometry.
+    // If user manually sets a nonzero center,
+    // then it is assumed that center[0] is to offset in the cylindrical radial-direction
+    // and center[1] is to offset in the z-direction.
 
-    if (problem::center[0] == 0.0_rt) {
-        if (coord_type == 0) {
-            problem::center[0] = 0.5_rt * (problo[0] + probhi[0]);
-        } else if (coord_type >= 1) {
-            problem::center[0] = 0.0;
-        }
+    if ((problem::center[0] == 0.0_rt) &&(coord_type == 0)) {
+        problem::center[0] = 0.5_rt * (problo[0] + probhi[0]);
     }
 #if AMREX_SPACEDIM >= 2
     if ((problem::center[1] == 0.0_rt) && (coord_type <= 1)) {

--- a/Exec/unit_tests/diffusion_test/problem_initialize.H
+++ b/Exec/unit_tests/diffusion_test/problem_initialize.H
@@ -18,16 +18,25 @@ void problem_initialize ()
 
     // set center variable
 
-    if (coord_type == 0) {
-        problem::center[0] = 0.5_rt * (problo[0] + probhi[0]);
-    } else if (coord_type >= 1) {
-        problem::center[0] = 0.0;
+    // Note for spherical 2D, here we assume problem::center is for [R,Z,0]
+    // where R is the cylindrical radial direction.
+
+    if (problem::center[0] == 0.0_rt) {
+        if (coord_type == 0) {
+            problem::center[0] = 0.5_rt * (problo[0] + probhi[0]);
+        } else if (coord_type >= 1) {
+            problem::center[0] = 0.0;
+        }
     }
 #if AMREX_SPACEDIM >= 2
-    problem::center[1] = 0.5_rt * (problo[1] + probhi[1]);
+    if ((problem::center[1] == 0.0_rt) && (coord_type <= 1)) {
+        problem::center[1] = 0.5_rt * (problo[1] + probhi[1]);
+    }
 #endif
 #if AMREX_SPACEDIM == 3
-    problem::center[2] = 0.5_rt * (problo[2] + probhi[2]);
+    if (problem::center[2] == 0.0_rt) {
+        problem::center[2] = 0.5_rt * (problo[2] + probhi[2]);
+    }
 #endif
 
     // the conductivity is the physical quantity that appears in the

--- a/Exec/unit_tests/diffusion_test/problem_initialize.H
+++ b/Exec/unit_tests/diffusion_test/problem_initialize.H
@@ -18,12 +18,7 @@ void problem_initialize ()
 
     // set center variable
 
-    // Note that 2D spherical is a special case here.
-    // Here problem::center = 0 by default for 2d spherical geometry.
-    // If user manually sets a nonzero center,
-    // then it is assumed that center[0] is to offset in the cylindrical radial-direction
-    // and center[1] is to offset in the z-direction.
-
+    // Note problem::center = 0 by default for 2d spherical geometry.
     if ((problem::center[0] == 0.0_rt) && (coord_type == 0)) {
         problem::center[0] = 0.5_rt * (problo[0] + probhi[0]);
     }

--- a/Exec/unit_tests/diffusion_test/problem_initialize.H
+++ b/Exec/unit_tests/diffusion_test/problem_initialize.H
@@ -24,7 +24,7 @@ void problem_initialize ()
     // then it is assumed that center[0] is to offset in the cylindrical radial-direction
     // and center[1] is to offset in the z-direction.
 
-    if ((problem::center[0] == 0.0_rt) &&(coord_type == 0)) {
+    if ((problem::center[0] == 0.0_rt) && (coord_type == 0)) {
         problem::center[0] = 0.5_rt * (problo[0] + probhi[0]);
     }
 #if AMREX_SPACEDIM >= 2

--- a/Exec/unit_tests/diffusion_test/problem_initialize_state_data.H
+++ b/Exec/unit_tests/diffusion_test/problem_initialize_state_data.H
@@ -28,6 +28,20 @@ void problem_initialize_state_data (int i, int j, int k,
     r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt) - problem::center[2];
 #endif
 
+// #if AMREX_SPACEDIM == 2
+//     // Deal with 2D spherical special case.
+//     if (coord_type == 2) {
+//         Real r_sph = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
+//         Real theta = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt);
+
+//         // This is Cylindrical R = rsin(theta) - R_0
+//         r[0] = r_sph * std::sin(theta) - problem::center[0];
+
+//         // This is Z = rcos(theta) - Z_0
+//         r[1] = r_sph * std::cos(theta) - problem::center[1];
+//     }
+// #endif
+
     // set the composition
 
     Real X[NumSpec] = {0.0_rt};

--- a/Exec/unit_tests/diffusion_test/problem_initialize_state_data.H
+++ b/Exec/unit_tests/diffusion_test/problem_initialize_state_data.H
@@ -17,30 +17,18 @@ void problem_initialize_state_data (int i, int j, int k,
     int coord_type = geomdata.Coord();
 
     Real r[3] = {0.0_rt};
-
-    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt) - problem::center[0];
-
+    r[0] = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
 #if AMREX_SPACEDIM >= 2
-    r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt) - problem::center[1];
+    r[1] = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt);
 #endif
-
 #if AMREX_SPACEDIM == 3
-    r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt) - problem::center[2];
+    r[2] = problo[2] + dx[2] * (static_cast<Real>(k) + 0.5_rt);
 #endif
-
-// #if AMREX_SPACEDIM == 2
-//     // Deal with 2D spherical special case.
-//     if (coord_type == 2) {
-//         Real r_sph = problo[0] + dx[0] * (static_cast<Real>(i) + 0.5_rt);
-//         Real theta = problo[1] + dx[1] * (static_cast<Real>(j) + 0.5_rt);
-
-//         // This is Cylindrical R = rsin(theta) - R_0
-//         r[0] = r_sph * std::sin(theta) - problem::center[0];
-
-//         // This is Z = rcos(theta) - Z_0
-//         r[1] = r_sph * std::cos(theta) - problem::center[1];
-//     }
-// #endif
+    if (coord_type <= 1) {
+        for (int i; i < AMREX_SPACEDIM; ++i) {
+            r[i] -= problem::center[i];
+        }
+    }
 
     // set the composition
 

--- a/Source/diffusion/Diffusion.cpp
+++ b/Source/diffusion/Diffusion.cpp
@@ -119,7 +119,8 @@ Diffusion::make_mg_bc ()
     }
 
     // Set Neumann bc at r=0.
-    if (geom.IsSPHERICAL() || geom.IsRZ() ) {
+    const auto problo = geom.ProbLo();
+    if ((geom.IsSPHERICAL() || geom.IsRZ()) && problo[0] == 0.0_rt) {
         mlmg_lobc[0] = MLLinOp::BCType::Neumann;
     }
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary
1) Updates problem_bc_fill to do either face-centered or cell centered depending on where
`castro.diffuse_use_amrex_mlmg` is used.

I can get 2nd order accuracy (with L-inf error) with `max_level=0` for 2d spherical with AMReX-Codes/amrex/pull/4258

Again, amrex refers to `diffuse_use_amrex_mlmg=1` and castro refers to `diffuse_use_amrex_mlmg=0`
```
|    <c>     |        <c>        |        <c>        |        <c>         |        <c>         |
| resolution | L-\infin Error (amrex) | L-2 Error (amrex) | L-\infin Error (castro) | L-2 Error (castro) |
|------------+-------------------+-------------------+--------------------+--------------------|
|  (64, 64)  |     1.084e-4      |     1.498e-3      |      1.903e-4      |      2.479e-3      |
| (128, 128) |     3.173e-5      |     8.361e-4      |      3.999e-5      |      1.048e-3      |
| (256, 256) |     8.240e-6      |     4.344e-4      |      9.210e-6      |      4.809e-4      |
```

2) To test theta dependence, the analytic solution of spherical-bessel function and legendre polynomial is used.
Currently only castro evaluation works.

```
|    <c>     |        <c>         |        <c>         |
| resolution | L-\infin Error (castro) | L-2 Error (castro) |
|------------+--------------------+--------------------|
|  (64, 64)  |      8.168e-4      |      1.420e-2      |
| (128, 128) |      2.036e-4      |      7.031e-3      |
| (256, 256) |      5.110e-5      |      3.506e-3      |
```

3) Also added an 2d spherical input file for noncenter Gaussian, a convergence test for this still needs to be done in the future.

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
