### PR TITLE
change the conditions that trigger some CI tests

### DIFF
--- a/.github/workflows/check-ifdefs.yml
+++ b/.github/workflows/check-ifdefs.yml
@@ -1,13 +1,6 @@
 name: check ifdefs
 
-on:
-  push:
-    branches:
-      - development
-      - main
-  pull_request:
-    branches:
-      - development
+on: [push, pull_request]
 
 jobs:
   check-ifdefs:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,13 +1,6 @@
 name: codespell
 
-on:
-  push:
-    branches:
-      - development
-      - main
-  pull_request:
-    branches:
-      - development
+on: [push, pull_request]
 
 jobs:
   codespell:

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -1,13 +1,6 @@
 name: docs build
 
-on:
-  push:
-    branches:
-      - development
-      - main
-  pull_request:
-    branches:
-      - development
+on: [push, pull_request]
 
 env:
   # enable color output from Sphinx


### PR DESCRIPTION
if we mistakenly target "main" and then switch to "development", then check-ifdefs, codespell, and docs never run.  This changes the action to look like the others so these should hopefully run.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
