### PR TITLE
add 2d spherical results to diffusion unit test readme

### DIFF
--- a/Exec/unit_tests/diffusion_test/README.md
+++ b/Exec/unit_tests/diffusion_test/README.md
@@ -76,7 +76,7 @@ Run with:
 ./Castro2d.gnu.MPI.ex inputs.2d.sph.bessel amr.n_cell=256 256
 ```
 
-After each run, the norm of the errror against the analytic solution
+After each run, the norm of the error against the analytic solution
 shows 2nd order accuracy:
 
 ```

--- a/Exec/unit_tests/diffusion_test/README.md
+++ b/Exec/unit_tests/diffusion_test/README.md
@@ -324,7 +324,7 @@ Level  L1 norm of Error in Each Component
                diff_term        2.631251e-01       1.915835   6.973300e-02
 ```
 
-For the higher resolution run, e.g. `convergence_diffusion.2d.hi.out`:
+For the higher resolution runs, e.g. `convergence_diffusion.2d.hi.out`:
 
 ```
 Level  L1 norm of Error in Each Component

--- a/Exec/unit_tests/diffusion_test/README.md
+++ b/Exec/unit_tests/diffusion_test/README.md
@@ -63,6 +63,29 @@ analytic solution, giving:
  (256, 512)          2.437072009e-05
 ```
 
+## 2-d Spherical Geometry
+
+An analytic convergence test with 2D spherical geometry is done
+using the initial condition constructed with spherical-bessel function
+and legendre polynomial, which tests both radial and theta dependence.
+Run with:
+
+```
+./Castro2d.gnu.MPI.ex inputs.2d.sph.bessel amr.n_cell=64 64
+./Castro2d.gnu.MPI.ex inputs.2d.sph.bessel amr.n_cell=128 128
+./Castro2d.gnu.MPI.ex inputs.2d.sph.bessel amr.n_cell=256 256
+```
+
+After each run, the norm of the errror against the analytic solution
+shows 2nd order accuracy:
+
+```
+ base resolution      L-inf error
+ (64 ,  64)          0.0008168088258
+ (128, 128)          0.0002035772451
+ (256, 256)          5.109916938e-05
+```
+
 
 ## SDC-4 in 1-d
 
@@ -252,3 +275,72 @@ Temp&         1.770452e-06 & 3.966033724 & 1.132894e-07 \\
 ```
 
 e.g. we see fourth-order convergence in the temperature
+
+
+## 2-d spherical geometry (with AMR)
+
+We use a non-center Gaussian initial condition to test
+resolution convergence and AMR for 2D spherical geometry.
+
+First compile with power law conductivity:
+
+```
+make DIM=2 CONDUCTIVITY_DIR=powerlaw -j 20
+```
+
+Now run using:
+
+```
+./Castro2d.gnu.MPI.ex inputs.2d.sph.gaussian amr.plot_per = 0.001 amr.n_cell=32 32 castro.fixed_dt=3.2e-6
+mv diffuse_plt00314 diffuse_sph_32
+./Castro2d.gnu.MPI.ex inputs.2d.sph.gaussian amr.plot_per = 0.001 amr.n_cell=64 64 castro.fixed_dt=1.6e-6
+mv diffuse_plt00626 diffuse_sph_64
+./Castro2d.gnu.MPI.ex inputs.2d.sph.gaussian amr.plot_per = 0.001 amr.n_cell=128 128 castro.fixed_dt=8.e-7
+mv diffuse_plt01251 diffuse_sph_128
+./Castro2d.gnu.MPI.ex inputs.2d.sph.gaussian amr.plot_per = 0.001 amr.n_cell=256 256 castro.fixed_dt=4.e-7
+mv diffuse_plt02501 diffuse_sph_256
+```
+
+Now use the RichardsonConvergence Script:
+
+```
+./RichardsonConvergenceTest2d.gnu.ex coarFile=diffuse_sph_32 mediFile=diffuse_sph_64  fineFile=diffuse_sph_128 > convergence_diffusion.2d.lo.out
+./RichardsonConvergenceTest2d.gnu.ex coarFile=diffuse_sph_64 mediFile=diffuse_sph_128 fineFile=diffuse_sph_256 > convergence_diffusion.2d.hi.out
+```
+
+For the lower resolution runs, e.g. `convergence_diffusion.2d.lo.out`:
+
+```
+Level  L1 norm of Error in Each Component
+-----------------------------------------------
+                   rho_E        2.681136e-04       1.811933   7.636120e-05
+                   rho_e        2.681136e-04       1.811933   7.636120e-05
+                    Temp        2.681136e-04       1.811933   7.636120e-05
+                pressure        1.787424e-04       1.811933   5.090747e-05
+              soundspeed        1.458607e+00       1.797880   4.194908e-01
+                 entropy        2.867059e+04       1.786225   8.312456e+03
+            thermal_cond        6.322558e-04       1.841497   1.764196e-04
+              diff_coeff        6.322558e-04       1.841497   1.764196e-04
+               diff_term        2.631251e-01       1.915835   6.973300e-02
+```
+
+For the higher resolution run, e.g. `convergence_diffusion.2d.hi.out`:
+
+```
+Level  L1 norm of Error in Each Component
+-----------------------------------------------
+Warning: BoxArray lengths are not the same at level 0
+level: 0
+Warning: BoxArray lengths are not the same at level 1
+level: 1
+Warning: BoxArray lengths are not the same at level 0
+                   rho_E        7.636120e-05       2.046783   1.848118e-05
+                   rho_e        7.636120e-05       2.046783   1.848118e-05
+                    Temp        7.636120e-05       2.046783   1.848118e-05
+                pressure        5.090747e-05       2.046783   1.232079e-05
+              soundspeed        4.194908e-01       2.034310   1.024081e-01
+                 entropy        8.312456e+03       2.020431   2.048891e+03
+            thermal_cond        1.764196e-04       2.066769   4.211021e-05
+              diff_coeff        1.764196e-04       2.066769   4.211021e-05
+               diff_term        6.973300e-02       1.903361   1.864102e-02
+```

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph.bessel
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph.bessel
@@ -23,6 +23,7 @@ castro.hi_bc       =  1   3
 castro.do_hydro = 0
 castro.diffuse_temp = 1
 castro.do_react = 0
+castro.diffuse_use_amrex_mlmg = 0
 
 # TIME STEP CONTROL
 
@@ -42,16 +43,6 @@ amr.ref_ratio       = 2 2 2 2 # refinement ratio
 amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 32
-
-amr.refinement_indicators = temperr tempgrad
-
-amr.refine.temperr.value_greater = 1.1
-amr.refine.temperr.field_name = Temp
-amr.refine.temperr.max_level = 3
-
-amr.refine.tempgrad.gradient = 0.1
-amr.refine.tempgrad.field_name = Temp
-amr.refine.tempgrad.max_level = 3
 
 # CHECKPOINT FILES
 amr.check_file      = diffuse_chk     # root name of checkpoint file
@@ -81,7 +72,6 @@ problem.gaussian_init = 0
 
 # CONDUCTIVITY
 conductivity.const_conductivity = 10.0
-castro.diffuse_use_amrex_mlmg = 0
 
 # EOS
 eos.eos_assume_neutral = 1

--- a/Exec/unit_tests/diffusion_test/inputs.2d.sph.gaussian
+++ b/Exec/unit_tests/diffusion_test/inputs.2d.sph.gaussian
@@ -5,9 +5,9 @@ stop_time = 0.001
 # PROBLEM SIZE & GEOMETRY
 geometry.is_periodic = 0    0
 geometry.coord_sys   = 2    # 2 = SPHERICAL
-geometry.prob_lo     = 0.1       0.0
+geometry.prob_lo     = 0.2       0.0
 geometry.prob_hi     = 1.0       3.141592653589793238
-amr.n_cell           = 64        64
+amr.n_cell           = 32        32
 
 castro.allow_non_unit_aspect_zones = 1
 
@@ -23,6 +23,7 @@ castro.hi_bc       =  2   3
 castro.do_hydro = 0
 castro.diffuse_temp = 1
 castro.do_react = 0
+castro.diffuse_use_amrex_mlmg = 0
 
 # TIME STEP CONTROL
 
@@ -37,7 +38,7 @@ amr.v                 = 1       # verbosity in Amr.cpp
 #amr.grid_log         = grdlog  # name of grid logging file
 
 # REFINEMENT / REGRIDDING
-amr.max_level       = 0       # maximum level number allowed
+amr.max_level       = 1       # maximum level number allowed
 amr.ref_ratio       = 2 2 2 2 # refinement ratio
 amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8       # block factor in grid generation
@@ -59,8 +60,8 @@ amr.check_int       = 1000     # number of timesteps between checkpoints
 
 # PLOTFILES
 amr.plot_file       = diffuse_plt
-#amr.plot_int        = 10
-amr.plot_per        = 0.0001
+amr.plot_int        = -1
+amr.plot_per        = 0.001
 amr.derive_plot_vars=ALL
 
 # PROBLEM PARAMETERS
@@ -79,11 +80,13 @@ problem.diff_coeff = 1.0
 # Note that changing problem::center only works with gaussian initial condition,
 # i.e. problem.gaussian_init=1
 
-problem.center = 0.5 1.57079632679 0
+problem.center = 0.6 1.57079632679 0
 
 # CONDUCTIVITY
 conductivity.const_conductivity = 10.0
-castro.diffuse_use_amrex_mlmg = 0
 
+# For powerlaw conductivity of form k_th = k_th0 T^v
+conductivity.cond_coeff=1
+conductivity.cond_exponent=2
 # EOS
 eos.eos_assume_neutral = 1


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary
Mainly adds the convergence results, both analytic and resolution-wise, to the readme. 

When using the richardsonconvergence script, I have a modified version in this [branch](https://github.com/AMReX-Codes/amrex/compare/development...zhichen3:amrex:sph_convergence), where I switch to use volume weighted average down from fine to coarse resolution and normalize the norm with `dV_{i,j,k}` directly instead of `dx dy dz`. But it didn't make a big difference. 

Here I'm using the non-center gaussian with power law conductivity for testing. It's basically 2nd order with 1 AMR level.

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
