### PR TITLE
when we "make" without a "clean", ensure that the same net is used

### DIFF
--- a/Exec/Make.Castro
+++ b/Exec/Make.Castro
@@ -146,13 +146,21 @@ endif
 CASTRO_AUTO_SOURCE_DIR := $(TmpBuildDir)/castro_sources/$(optionsSuffix).EXE
 
 
-all: build_status $(executable)
+all: build_status check_network $(executable)
 	@echo SUCCESS
 
 build_status:
 	$(AMREX_HOME)/Tools/C_scripts/describe_sources.py \
           --git_names "Castro AMReX Microphysics" \
           --git_dirs "$(TOP) $(AMREX_HOME) $(MICROPHYSICS_HOME)"
+
+# If we make and then make again with a different network, undefined
+# behavior may result.  One should always do a `make clean` before
+# changing networks.  This tries to check if there is an inconsistency.
+check_network:
+	$(CASTRO_HOME)/Util/scripts/check_network.py $(NETWORK_DIR) $(CASTRO_AUTO_SOURCE_DIR)
+	@if [ ! -d $(CASTRO_AUTO_SOURCE_DIR) ]; then mkdir -p $(CASTRO_AUTO_SOURCE_DIR); fi
+	echo $(NETWORK_DIR) > $(CASTRO_AUTO_SOURCE_DIR)/NETWORK_USED
 
 # The default is to include the sponge functionality
 DEFINES += -DSPONGE

--- a/Util/scripts/check_network.py
+++ b/Util/scripts/check_network.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+
+def doit():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("network", type=str, nargs=1)
+    parser.add_argument("auto_source_dir", type=str, nargs=1)
+
+    args = parser.parse_args()
+
+    net = args.network[0]
+    auto_dir = args.auto_source_dir[0]
+
+    try:
+        with open(f"{auto_dir}/NETWORK_USED") as f:
+            stored_net = f.readlines()[0].strip()
+            if stored_net != net:
+                sys.exit("network inconsistent.  do 'make clean' and retry")
+
+    except OSError:
+        pass
+
+
+if __name__ == "__main__":
+    doit()


### PR DESCRIPTION
a common error is to build the executable, do a run, and then change the network by building with NETWORK_DIR set, without a "make clean". This leads to an undefined behavior.  This adds a check to ensure that when we make we are using the same network as done originally, and if not, aborts with a message saying to do "make clean"

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
