### PR TITLE
Update deprecated call to `mlmg.setAlwaysUseBNorm`

### DIFF
--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -3774,7 +3774,7 @@ Gravity::actual_solve_with_mlmg (int crse_level, int fine_level,
     if (!grad_phi.empty())
     {
         if (!gmv[0].isAllPeriodic()) {
-            mlmg.setAlwaysUseBNorm(true);
+            mlmg.setConvergenceNormType(MLMGNormType::bnorm);
         }
 
         mlmg.setNSolve(gravity::mlmg_nsolve);


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

This was recently deprecated in AMReX-Codes/amrex#4495.

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
