### PR TITLE
Set the background color for enuc in flame_wave slice plots

### DIFF
--- a/Exec/science/flame_wave/analysis/overview.py
+++ b/Exec/science/flame_wave/analysis/overview.py
@@ -47,6 +47,8 @@ for i, f in enumerate(fields):
         sp.set_cmap(f, "magma_r")
     elif f == "enuc":
         sp.set_zlim(f, 1.e18, 1.e20)
+        # set the background color to the bottom value of the colormap
+        sp.set_background_color("enuc", None)
     elif f == "density":
         sp.set_zlim(f, 1.e-3, 5.e8)
     elif f == "z_velocity":

--- a/Exec/science/flame_wave/analysis/slice.py
+++ b/Exec/science/flame_wave/analysis/slice.py
@@ -31,6 +31,8 @@ for f in fields:
         sp.set_zlim(f, 5.e7, 1.5e9)
     elif f == "enuc":
         sp.set_zlim(f, 1.e18, 1.e20)
+        # set the background color to the bottom value of the colormap
+        sp.set_background_color("enuc", None)
     elif f == "density":
         sp.set_zlim(f, 1.e-3, 5.e8)
     elif f == "z_velocity":

--- a/Exec/science/flame_wave/analysis/slice_multi.py
+++ b/Exec/science/flame_wave/analysis/slice_multi.py
@@ -43,6 +43,8 @@ for i, f in enumerate(fields):
         sp.set_cmap(f, "magma_r")
     elif f == "enuc":
         sp.set_zlim(f, 1.e18, 1.e20)
+        # set the background color to the bottom value of the colormap
+        sp.set_background_color("enuc", None)
     elif f == "density":
         sp.set_zlim(f, 1.e-3, 5.e8)
     elif f == "z_velocity":

--- a/Exec/science/flame_wave/analysis/slice_multi_crop.py
+++ b/Exec/science/flame_wave/analysis/slice_multi_crop.py
@@ -51,6 +51,8 @@ for i, f in enumerate(fields):
         sp.set_cmap(f, "magma_r")
     elif f == "enuc":
         sp.set_zlim(f, 1.e18, 1.e20)
+        # set the background color to the bottom value of the colormap
+        sp.set_background_color("enuc", None)
     elif f == "density":
         sp.set_zlim(f, 1.e-3, 5.e8)
     elif f == "z_velocity":

--- a/Exec/science/flame_wave/analysis/slice_multi_crop_H_He.py
+++ b/Exec/science/flame_wave/analysis/slice_multi_crop_H_He.py
@@ -51,6 +51,8 @@ for i, f in enumerate(fields):
         sp.set_cmap(f, "magma_r")
     elif f == "enuc":
         sp.set_zlim(f, 1.e14, 3.e17)
+        # set the background color to the bottom value of the colormap
+        sp.set_background_color("enuc", None)
     elif f == "density":
         sp.set_zlim(f, 1.e-3, 5.e8)
     elif f == "z_velocity":


### PR DESCRIPTION
## PR summary

This colors the regions where enuc is invalid (i.e. <= 0) with the minimum value of the colormap, instead of white.

## PR motivation

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
