### PR TITLE
Remove some SIMPLIFIED_SDC ifdefs

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -67,10 +67,8 @@ enum StateType { State_Type = 0,
                Mag_Type_y,
                Mag_Type_z,
 #endif
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
                  Simplified_SDC_React_Type
-#endif
 #endif
 };
 

--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -937,14 +937,15 @@ Castro::initMFs()
 
 #ifdef REACTIONS
     if (store_burn_weights) {
-#ifdef STRANG
-        // we have 2 components: first half and second half
-        burn_weights.define(grids, dmap, 2, 0);
-#endif
-#ifdef SIMPLIFIED_SDC
-        // we have a component for each sdc iteration + 1 extra for retries
-        burn_weights.define(grids, dmap, sdc_iters+1, 0);
-#endif
+        if (castro::time_integration_method == CornerTransportUpwind) {
+            // we have 2 components: first half and second half
+            burn_weights.define(grids, dmap, 2, 0);
+        }
+        else if (castro::time_integration_method == SimplifiedSpectralDeferredCorrections) {
+            // we have a component for each sdc iteration + 1 extra for retries
+            burn_weights.define(grids, dmap, sdc_iters+1, 0);
+        }
+
         burn_weights.setVal(0.0);
     }
 #endif
@@ -1077,13 +1078,11 @@ Castro::initData ()
     React_new.setVal(0.);
 #endif
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
    if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
        MultiFab& react_src_new = get_new_data(Simplified_SDC_React_Type);
        react_src_new.setVal(0.0, react_src_new.nGrow());
    }
-#endif
 #endif
 
 #ifdef MAESTRO_INIT
@@ -4233,14 +4232,12 @@ Castro::swap_state_time_levels(const Real dt)
         // this because we never need the old data, so we
         // don't want to allocate memory for it.
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
         if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
             if (k == Simplified_SDC_React_Type) {
                 state[k].swapTimeLevels(0.0);
             }
         }
-#endif
 #endif
 
 #ifdef TRUE_SDC

--- a/Source/driver/Castro_advance_ctu.cpp
+++ b/Source/driver/Castro_advance_ctu.cpp
@@ -227,11 +227,9 @@ Castro::retry_advance_ctu(Real dt, const advance_status& status)
             if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
                 getLevel(lev).source_corrector.setVal(0.0, getLevel(lev).source_corrector.nGrow());
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
                 MultiFab& SDC_react_new = getLevel(lev).get_new_data(Simplified_SDC_React_Type);
                 SDC_react_new.setVal(0.0, SDC_react_new.nGrow());
-#endif
 #endif
             }
 

--- a/Source/driver/Castro_io.cpp
+++ b/Source/driver/Castro_io.cpp
@@ -522,14 +522,12 @@ Castro::setPlotVariables ()
     parent->deleteStatePlotVar(desc_lst[Source_Type].name(i));
   }
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
   if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
       for (int i = 0; i < desc_lst[Simplified_SDC_React_Type].nComp(); i++) {
           parent->deleteStatePlotVar(desc_lst[Simplified_SDC_React_Type].name(i));
       }
   }
-#endif
 #endif
 
 }

--- a/Source/driver/Castro_setup.cpp
+++ b/Source/driver/Castro_setup.cpp
@@ -425,7 +425,6 @@ Castro::variableSetUp ()
                          interp, state_data_extrap, store_in_checkpoint);
 #endif
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
   // For simplified SDC, we want to store the reactions source.
   // these are not traced, so we only need a single ghost cell
@@ -441,7 +440,6 @@ Castro::variableSetUp ()
                              interp, state_data_extrap, store_in_checkpoint);
 
   }
-#endif
 #endif
 
   Vector<BCRec>       bcs(NUM_STATE);
@@ -639,19 +637,18 @@ Castro::variableSetUp ()
 
   if (store_burn_weights) {
 
-#ifdef STRANG
-      burn_weight_names.emplace_back("burn_weights_firsthalf");
-      burn_weight_names.emplace_back("burn_weights_secondhalf");
-#endif
-#ifdef SIMPLIFIED_SDC
-      for (int n = 0; n < sdc_iters+1; n++) {
-          burn_weight_names.emplace_back("burn_weights_iter_" + std::to_string(n+1));
+      if (castro::time_integration_method == CornerTransportUpwind) {
+          burn_weight_names.emplace_back("burn_weights_firsthalf");
+          burn_weight_names.emplace_back("burn_weights_secondhalf");
       }
-#endif
+      else if (castro::time_integration_method == SimplifiedSpectralDeferredCorrections) {
+          for (int n = 0; n < sdc_iters+1; n++) {
+              burn_weight_names.emplace_back("burn_weights_iter_" + std::to_string(n+1));
+          }
+      }
   }
 #endif
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
   if (time_integration_method == SimplifiedSpectralDeferredCorrections) {
       for (int i = 0; i < NQ; ++i) {
@@ -663,7 +660,6 @@ Castro::variableSetUp ()
           desc_lst.setComponent(Simplified_SDC_React_Type,i,std::string(buf),bc,genericBndryFunc);
       }
   }
-#endif
 #endif
 
 #ifdef RADIATION

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -53,7 +53,9 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)  // NOLINT(readability-co
   MultiFab& S_new = get_new_data(State_Type);
 
 #ifdef REACTIONS
-  MultiFab& SDC_react_source = get_new_data(Simplified_SDC_React_Type);
+  MultiFab tmp_SDC_mf;
+  MultiFab& SDC_react_source = castro::time_integration_method == SimplifiedSpectralDeferredCorrections ?
+                               get_new_data(Simplified_SDC_React_Type) : tmp_SDC_mf;
 #endif
 
   // we will treat the hydro source as any other source term

--- a/Source/hydro/Castro_ctu_hydro.cpp
+++ b/Source/hydro/Castro_ctu_hydro.cpp
@@ -52,10 +52,8 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)  // NOLINT(readability-co
 
   MultiFab& S_new = get_new_data(State_Type);
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
   MultiFab& SDC_react_source = get_new_data(Simplified_SDC_React_Type);
-#endif
 #endif
 
   // we will treat the hydro source as any other source term
@@ -456,19 +454,18 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)  // NOLINT(readability-co
       fab_size += pradial.nBytes();
 #endif
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
-      Array4<Real> const sdc_src_arr = SDC_react_source.array(mfi);
-#endif
+      auto sdc_src_arr = castro::time_integration_method == SimplifiedSpectralDeferredCorrections ?
+                         SDC_react_source.array(mfi) : Array4<Real const>{};
 #endif
 
 #if AMREX_SPACEDIM == 1
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
-      add_sdc_source_to_states(xbx, 0, dt,
-                               qxm_arr, qxp_arr, sdc_src_arr);
-#endif
+      if (castro::time_integration_method == SimplifiedSpectralDeferredCorrections) {
+          add_sdc_source_to_states(xbx, 0, dt,
+                                   qxm_arr, qxp_arr, sdc_src_arr);
+      }
 #endif
 
       // compute the fluxes through the x-interface
@@ -591,12 +588,11 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)  // NOLINT(readability-co
 
       // solve the final Riemann problem axross the x-interfaces
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
-      add_sdc_source_to_states(xbx, 0, dt,
-                               ql_arr, qr_arr, sdc_src_arr);
-#endif
-
+      if (castro::time_integration_method == SimplifiedSpectralDeferredCorrections) {
+          add_sdc_source_to_states(xbx, 0, dt,
+                                   ql_arr, qr_arr, sdc_src_arr);
+      }
 #endif
 
       cmpflx_plus_godunov(xbx,
@@ -636,11 +632,11 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)  // NOLINT(readability-co
 
       // solve the final Riemann problem axross the y-interfaces
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
-      add_sdc_source_to_states(ybx, 1, dt,
-                               ql_arr, qr_arr, sdc_src_arr);
-#endif
+      if (castro::time_integration_method == SimplifiedSpectralDeferredCorrections) {
+          add_sdc_source_to_states(ybx, 1, dt,
+                                   ql_arr, qr_arr, sdc_src_arr);
+      }
 #endif
 
       cmpflx_plus_godunov(ybx,
@@ -954,11 +950,11 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)  // NOLINT(readability-co
 
       reset_edge_state_thermo(xbx, qr_arr);
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
-      add_sdc_source_to_states(xbx, 0, dt,
-                               ql_arr, qr_arr, sdc_src_arr);
-#endif
+      if (castro::time_integration_method == SimplifiedSpectralDeferredCorrections) {
+          add_sdc_source_to_states(xbx, 0, dt,
+                                   ql_arr, qr_arr, sdc_src_arr);
+      }
 #endif
 
 
@@ -1033,11 +1029,11 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)  // NOLINT(readability-co
 
       reset_edge_state_thermo(ybx, qr_arr);
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
-      add_sdc_source_to_states(ybx, 1, dt,
-                               ql_arr, qr_arr, sdc_src_arr);
-#endif
+      if (castro::time_integration_method == SimplifiedSpectralDeferredCorrections) {
+          add_sdc_source_to_states(ybx, 1, dt,
+                                   ql_arr, qr_arr, sdc_src_arr);
+      }
 #endif
 
 
@@ -1114,11 +1110,11 @@ Castro::construct_ctu_hydro_source(Real time, Real dt)  // NOLINT(readability-co
 
       reset_edge_state_thermo(zbx, qr_arr);
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
-      add_sdc_source_to_states(zbx, 2, dt,
-                               ql_arr, qr_arr, sdc_src_arr);
-#endif
+      if (castro::time_integration_method == SimplifiedSpectralDeferredCorrections) {
+          add_sdc_source_to_states(zbx, 2, dt,
+                                   ql_arr, qr_arr, sdc_src_arr);
+      }
 #endif
 
       // compute the final z fluxes F^z

--- a/Source/sources/Castro_sources.cpp
+++ b/Source/sources/Castro_sources.cpp
@@ -640,15 +640,15 @@ Castro::pre_hydro_operators (Real time, Real dt)  // NOLINT(readability-convert-
 
     advance_status status {};
 
-#ifdef SIMPLIFIED_SDC
 #ifdef REACTIONS
     // The SDC reactive source ghost cells on coarse levels might not
     // be in sync due to any average down done, so fill them here.
 
-    MultiFab& react_src = get_new_data(Simplified_SDC_React_Type);
+    if (castro::time_integration_method == SimplifiedSpectralDeferredCorrections) {
+        MultiFab& react_src = get_new_data(Simplified_SDC_React_Type);
 
-    AmrLevel::FillPatch(*this, react_src, react_src.nGrow(), time + dt, Simplified_SDC_React_Type, 0, react_src.nComp());
-#endif
+        AmrLevel::FillPatch(*this, react_src, react_src.nGrow(), time + dt, Simplified_SDC_React_Type, 0, react_src.nComp());
+    }
 #endif
 
     return status;


### PR DESCRIPTION

## PR summary

If we always define the Simplified_SDC_React_Type in the State_Type enum, then we can make runtime decisions based on `castro.time_integration_method` about whether to use that slot. For Strang runs this will be unused but it should not cause harm.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
