### PR TITLE
Timestep estimator interfaces accept MultiFabs

### DIFF
--- a/Source/driver/Castro.H
+++ b/Source/driver/Castro.H
@@ -8,6 +8,7 @@
 #include <prob_parameters.H>
 #include <Castro_io.H>
 #include <Castro_util.H>
+#include <timestep.H>
 
 using namespace castro;
 
@@ -536,39 +537,6 @@ public:
 /// Estimate time step.
 ///
     amrex::Real estTimeStep (int is_new = 1);
-
-
-///
-/// Compute the CFL timestep
-///
-    ValLocPair<amrex::Real, IntVect> estdt_cfl (int is_new = 1);
-
-
-#ifdef MHD
-///
-/// Compute the CFL timestep
-///
-    ValLocPair<amrex::Real, IntVect>  estdt_mhd (int is_new = 1);
-#endif
-
-///
-/// Diffusion-limited timestep
-///
-    ValLocPair<amrex::Real, IntVect> estdt_temp_diffusion (int is_new = 1);
-
-#ifdef REACTIONS
-///
-/// Reactions-limited timestep
-///
-    ValLocPair<amrex::Real, IntVect> estdt_burning (int is_new = 1);
-#endif
-
-#ifdef RADIATION
-///
-/// Radiation hydro timestep
-///
-    amrex::Real estdt_rad (int is_new = 1);
-#endif
 
 ///
 /// Compute initial time step.

--- a/Source/driver/Make.package
+++ b/Source/driver/Make.package
@@ -47,4 +47,5 @@ ifdef NEED_MGUTIL
   CEXE_headers += MGutils.H
 endif
 
+CEXE_headers += timestep.H
 CEXE_sources += timestep.cpp

--- a/Source/driver/timestep.H
+++ b/Source/driver/timestep.H
@@ -1,0 +1,53 @@
+#ifndef TIMESTEP_H
+#define TIMESTEP_H
+
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Reduce.H>
+#include <AMReX_MultiFab.H>
+
+namespace timestep {
+
+    ///
+    /// Compute the CFL timestep
+    ///
+    amrex::ValLocPair<amrex::Real, amrex::IntVect> estdt_cfl (const amrex::MultiFab& stateMF,
+                                                              const amrex::GeometryData& geomdata);
+
+
+#ifdef MHD
+    ///
+    /// Compute the CFL timestep
+    ///
+    amrex::ValLocPair<amrex::Real, amrex::IntVect>  estdt_mhd (const amrex::MultiFab& stateMF, const amrex::MultiFab& bx,
+                                                               const amrex::MultiFab& by, const amrex::MultiFab& bz,
+                                                               const amrex::GeometryData& geomdata);
+#endif
+
+    ///
+    /// Diffusion-limited timestep
+    ///
+    amrex::ValLocPair<amrex::Real, amrex::IntVect> estdt_temp_diffusion (const amrex::MultiFab& stateMF,
+                                                                         const amrex::GeometryData& geomdata);
+
+#ifdef REACTIONS
+    ///
+    /// Reactions-limited timestep
+    ///
+    amrex::ValLocPair<amrex::Real, amrex::IntVect> estdt_burning (const amrex::MultiFab& stateMF,
+                                                                  const amrex::MultiFab& maskMF,
+                                                                  const amrex::GeometryData& geomdata);
+#endif
+
+#ifdef RADIATION
+    ///
+    /// Radiation hydro timestep
+    ///
+    amrex::Real estdt_rad (const amrex::MultiFab& stateMF, const amrex::MultiFab& radMF,
+                           const amrex::GeometryData& geomdata);
+#endif
+
+}
+
+#endif // TIMESTEP_H

--- a/Source/driver/timestep.cpp
+++ b/Source/driver/timestep.cpp
@@ -1,4 +1,5 @@
 #include <Castro.H>
+#include <timestep.H>
 
 #ifdef DIFFUSION
 #include <conductivity.H>
@@ -29,17 +30,15 @@
 using namespace amrex;
 
 ValLocPair<Real, IntVect>
-Castro::estdt_cfl (int is_new)
+timestep::estdt_cfl (const MultiFab& stateMF, const GeometryData& geomdata)
 {
 
   // Courant-condition limited timestep
 
-  const auto dx = geom.CellSizeArray();
-  const auto problo = geom.ProbLoArray();
-  const auto coord = geom.Coord();
+  const auto dx = geomdata.CellSize();
+  const auto problo = geomdata.ProbLo();
+  const auto coord = geomdata.Coord();
   amrex::ignore_unused(problo, coord);
-
-  const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
   auto const& ua = stateMF.const_arrays();
 
@@ -130,20 +129,16 @@ Castro::estdt_cfl (int is_new)
 
 #ifdef MHD
 ValLocPair<Real, IntVect>
-Castro::estdt_mhd (int is_new)
+timestep::estdt_mhd (const MultiFab& U_state, const MultiFab& bx,
+                     const MultiFab& by, const MultiFab& bz,
+                     const GeometryData& geomdata)
 {
 
   // MHD timestep limiter
-  const auto dx = geom.CellSizeArray();
-  const auto problo = geom.ProbLoArray();
-  const auto coord = geom.Coord();
+  const auto dx = geomdata.CellSize();
+  const auto problo = geomdata.ProbLo();
+  const auto coord = geomdata.Coord();
   amrex::ignore_unused(problo, coord);
-
-  const MultiFab& U_state = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
-
-  const MultiFab& bx = is_new ? get_new_data(Mag_Type_x) : get_old_data(Mag_Type_x);
-  const MultiFab& by = is_new ? get_new_data(Mag_Type_y) : get_old_data(Mag_Type_y);
-  const MultiFab& bz = is_new ? get_new_data(Mag_Type_z) : get_old_data(Mag_Type_z);
 
   auto const& ua = U_state.const_arrays();
 
@@ -243,7 +238,7 @@ Castro::estdt_mhd (int is_new)
 #ifdef DIFFUSION
 
 ValLocPair<Real, IntVect>
-Castro::estdt_temp_diffusion (int is_new)
+timestep::estdt_temp_diffusion (const MultiFab& stateMF, const GeometryData& geomdata)
 {
 
   // Diffusion-limited timestep
@@ -251,12 +246,10 @@ Castro::estdt_temp_diffusion (int is_new)
   // dt < 0.5 dx**2 / D
   // where D = k/(rho c_v), and k is the conductivity
 
-  const auto dx = geom.CellSizeArray();
-  const auto problo = geom.ProbLoArray();
-  const auto coord = geom.Coord();
+  const auto dx = geomdata.CellSize();
+  const auto problo = geomdata.ProbLo();
+  const auto coord = geomdata.Coord();
   amrex::ignore_unused(problo, coord);
-
-  const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
   const Real ldiffuse_cutoff_density = diffuse_cutoff_density;
   const Real lmax_dt = max_dt;
@@ -332,7 +325,7 @@ Castro::estdt_temp_diffusion (int is_new)
 
 #ifdef REACTIONS
 ValLocPair<Real, IntVect>
-Castro::estdt_burning (int is_new)
+timestep::estdt_burning (const MultiFab& stateMF, const MultiFab& maskMF, const GeometryData& geomdata)
 {
 
     if (castro::dtnuc_e > 1.e199_rt && castro::dtnuc_X > 1.e199_rt) {
@@ -340,28 +333,17 @@ Castro::estdt_burning (int is_new)
         return {ValLocPair<Real, IntVect>{1.e200_rt, idx}};
     }
 
-    const auto dx = geom.CellSizeArray();
-    const auto problo = geom.ProbLoArray();
-    const auto coord = geom.Coord();
+    const auto dx = geomdata.CellSize();
+    const auto problo = geomdata.ProbLo();
+    const auto coord = geomdata.Coord();
     amrex::ignore_unused(problo, coord);
-
-    MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
 
     auto const& ua = stateMF.const_arrays();
 
-    // If we're not subcycling, we only need to do the burn on leaf cells.
-
-    bool mask_covered_zones = false;
-
-    if (level < parent->finestLevel() && parent->subcyclingMode() == "None") {
-        mask_covered_zones = true;
-    }
-
-    MultiFab tmp_mask_mf;
-    const MultiFab& mask_mf = mask_covered_zones ? getLevel(level+1).build_fine_mask() : tmp_mask_mf;
+    bool mask_covered_zones = maskMF.isDefined();
 
     MultiArray4<Real const> empty_arr{};
-    const auto& ma = mask_covered_zones ? mask_mf.const_arrays() : empty_arr;
+    const auto& ma = mask_covered_zones ? maskMF.const_arrays() : empty_arr;
 
     auto r = amrex::ParReduce(TypeList<ReduceOpMin>{}, TypeList<ValLocPair<Real, IntVect>>{}, stateMF,
     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) -> GpuTuple<ValLocPair<Real, IntVect>>
@@ -515,15 +497,12 @@ Castro::estdt_burning (int is_new)
 
 #ifdef RADIATION
 Real
-Castro::estdt_rad (int is_new)
+timestep::estdt_rad (const MultiFab& stateMF, const MultiFab& radMF, const GeometryData& geomdata)
 {
-    auto dx = geom.CellSizeArray();
-    const auto problo = geom.ProbLoArray();
-    const auto coord = geom.Coord();
+    auto dx = geomdata.CellSize();
+    const auto problo = geomdata.ProbLo();
+    const auto coord = geomdata.Coord();
     amrex::ignore_unused(problo, coord);
-
-    const MultiFab& stateMF = is_new ? get_new_data(State_Type) : get_old_data(State_Type);
-    const MultiFab& radMF = is_new ? get_new_data(Rad_Type) : get_old_data(Rad_Type);
 
     // Compute radiation + hydro limited timestep.
 


### PR DESCRIPTION

## PR summary

The estdt functions now take the MultiFab state they're working with rather than the is_new parameter. This enables a potential future change where we could estimate the timestep on some states that are different from the old and new time data. While doing this change, we also move the declarations to a separate header and update the namespace accordingly.

## PR checklist

- [x] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
