### PR TITLE
Remove stub EstTimeStep from Radiation

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1740,10 +1740,6 @@ Castro::estTimeStep (int is_new)
     }
 #endif
 
-#ifdef RADIATION
-    if (do_radiation) radiation->EstTimeStep(estdt, level);
-#endif
-
     if (verbose) {
         amrex::Print() << "Castro::estTimeStep (" << limiter << "-limited) at level " << level << ":  estdt = " << estdt << '\n' << std::endl;
     }

--- a/Source/radiation/Radiation.H
+++ b/Source/radiation/Radiation.H
@@ -296,13 +296,6 @@ public:
 
 
 ///
-/// @param estdt
-/// @param level
-///
-  void EstTimeStep(amrex::Real& estdt, int level);
-
-
-///
 /// @param level
 /// @param State
 ///

--- a/Source/radiation/Radiation.cpp
+++ b/Source/radiation/Radiation.cpp
@@ -2669,13 +2669,6 @@ void Radiation::update_dcf(MultiFab& dcf, MultiFab& etainv, MultiFab& kp, MultiF
     dcf.FillBoundary(geom.periodicity());
 }
 
-void Radiation::EstTimeStep(Real & estdt, int level)
-{
-  Castro *castro        = dynamic_cast<Castro*>(&parent->getLevel(level));
-  const Geometry& geom = parent->Geom(level);
-  Real time = castro->get_state_data(Rad_Type).curTime();
-}
-
 void Radiation::set_current_group(int igroup)
 {
   current_group_number = igroup;


### PR DESCRIPTION

## PR summary

This radiation-specific timestep function previously had two special cases; one was for neutrino problems (which were removed a long time ago) and another for the thermal wave radiation problem, which was removed from this function during the major radiation restructure in commit 3728c987783268a7fcc6b0d893374e1d4827db31. But now it does nothing.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
