### PR TITLE
Always display estdt_burn

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -1717,7 +1717,7 @@ Castro::estTimeStep (int is_new)
         ParallelAllReduce::Min(burn_dt, MPI_COMM_WORLD);
         estdt_burn = amrex::min(estdt_burn, burn_dt.value);
 
-        if (verbose && estdt_burn < max_dt) {
+        if (verbose) {
             amrex::Print() << "...estimated burning-limited timestep at level " << level << ": " << estdt_burn << std::endl;
             std::string idx_str = "(i";
 #if AMREX_SPACEDIM >= 2


### PR DESCRIPTION


## PR summary

The burning timestep limiter had different behavior where it didn't always display its value. (Though there is still a separate issue to fix where if this dt is larger than max_dt, it will display as max_dt; the hydro dt has the same issue, and this should probably be improved in a separate PR.)

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
