### PR TITLE
add check to make sure hydrostatic pressure at interface is also positive for HSE methods

### DIFF
--- a/Source/hydro/ppm.H
+++ b/Source/hydro/ppm.H
@@ -186,12 +186,19 @@ ppm_reconstruct_pslope(const amrex::Real* rho, const amrex::Real* p, const amrex
     amrex::Real pm1_hse = p0_hse - 0.25_rt*dx * (rho[i0] + rho[im1]) * (src[i0] + src[im1]);
     amrex::Real pm2_hse = pm1_hse - 0.25_rt*dx * (rho[im1] + rho[im2]) * (src[im1] + src[im2]);
 
+    // compute hydrostatic pressure at the interface
+
+    amrex::Real p_p_hse = p0_hse + 0.5_rt*dx * rho[i0] * src[i0];
+    amrex::Real p_m_hse = p0_hse - 0.5_rt*dx * rho[i0] * src[i0];
+
     // this only makes sense if the pressures are positive
-    bool ptest = p0_hse < 0.0 ||
+    bool ptest =  p0_hse < 0.0 ||
                  pp1_hse < 0.0 ||
                  pp2_hse < 0.0 ||
                  pm1_hse < 0.0 ||
-                 pm2_hse < 0.0;
+                 pm2_hse < 0.0 ||
+                 p_p_hse < 0.0 ||
+                 p_m_hse < 0.0;
 
 
     bool do_hse = !ptest && rho[i0] >= pslope_cutoff_density;


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary
This fixes the issue where hydrostatic pressure at the interface could be negative due to external source terms.
<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
