### PR TITLE
Updated profiles.py and snapshot.py to use symlog

### DIFF
--- a/Exec/science/Detonation/analysis/profiles.py
+++ b/Exec/science/Detonation/analysis/profiles.py
@@ -135,12 +135,15 @@ def plot_Te(prefix, nums, skip, limitlabels, xmin, xmax, plot_in_nse=False):
         if plot_in_nse:
             ax_nse.set_xlim(xmin, xmax)
 
-    ax_e.set_yscale("log")
+
+    max_enuc = np.abs(enuc).max()
+
+    ax_e.set_yscale("symlog", linthresh=1.e-6 * max_enuc)
     ax_e.set_ylabel(r"$S_\mathrm{nuc}$ (erg/g/s)")
     ax_e.set_xlabel("x (cm)")
 
-    cur_lims = ax_e.get_ylim()
-    ax_e.set_ylim(1.e-10*cur_lims[-1], cur_lims[-1])
+    #cur_lims = ax_e.get_ylim()
+    #ax_e.set_ylim(1.e-10*cur_lims[-1], cur_lims[-1])
 
     if plot_in_nse:
         ax_nse.set_ylabel("IN NSE")

--- a/Exec/science/Detonation/analysis/snapshot.py
+++ b/Exec/science/Detonation/analysis/snapshot.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 
+
 import matplotlib
 import matplotlib.ticker as mticker
 
@@ -113,10 +114,11 @@ def doit(pf, xmin, xmax, nuc_thresh):
         ax_e.set_xlim(xmin, xmax)
         ax_X.set_xlim(xmin, xmax)
 
-    ax_e.set_yscale("log")
+    max_enuc = np.abs(enuc).max()
+    ax_e.set_yscale("symlog", linthresh=1.e-6 * max_enuc)
     ax_e.set_ylabel(r"$S_\mathrm{nuc}$ (erg/g/s)")
-    cur_lims = ax_e.get_ylim()
-    ax_e.set_ylim(1.e-10*cur_lims[-1], cur_lims[-1])
+    #cur_lims = ax_e.get_ylim()
+    #ax_e.set_ylim(1.e-10*cur_lims[-1], cur_lims[-1])
     ax_e.xaxis.set_major_formatter(mticker.ScalarFormatter(useMathText=True))
 
     ax_X.set_yscale("log")


### PR DESCRIPTION

## PR summary

Changed profiles.py and snapshot.py to use symlog when creating a plot in order to avoid issues with negative values. 

Without symlog: 

<img width="700" height="1000" alt="oldsnapshot" src="https://github.com/user-attachments/assets/bf87e155-2ba3-40b6-b616-53e51534d722" />

<img width="700" height="900" alt="profilesold" src="https://github.com/user-attachments/assets/8444e5a0-c5f5-4eec-991f-e66450cc40d9" />

With symlog:

<img width="700" height="1000" alt="newsnapshot" src="https://github.com/user-attachments/assets/9ed0e5e7-0c03-4441-8faa-ae076dca1a8e" />

<img width="700" height="900" alt="profilesnew" src="https://github.com/user-attachments/assets/f2da69dd-150a-4b12-ae26-4c30bd997ee3" />


## PR motivation


## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
