### PR TITLE
use r_vec instead of r for rotational_potential in 2d spherical geometry

### DIFF
--- a/Source/rotation/Rotation.H
+++ b/Source/rotation/Rotation.H
@@ -143,7 +143,7 @@ rotational_potential(const GpuArray<Real, 3>& r, const GpuArray<Real, 3>& omega,
   if (castro::rotation_include_centrifugal == 1) {
 
       GpuArray<Real, 3> omega_cross_r;
-      cross_product(omega, r, omega_cross_r);
+      cross_product(omega, r_vec, omega_cross_r);
 
       for (int idir = 0; idir < 3; idir++) {
           phi -= 0.5_rt * omega_cross_r[idir] * omega_cross_r[idir];


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary
pointed out by #3231 
<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
