### PR TITLE
we were never allowing the maximum number of subdivisions in SDC loop

### DIFF
--- a/Source/sdc/sdc_newton_solve.H
+++ b/Source/sdc/sdc_newton_solve.H
@@ -267,7 +267,7 @@ sdc_newton_subdivide(const Real dt_m,
         U_begin[n] = U_old[n];
     }
 
-    while (nsub < MAX_NSUB && ierr != newton::NEWTON_SUCCESS) {
+    while (nsub <= MAX_NSUB && ierr != newton::NEWTON_SUCCESS) {
         if (nsub > 1) {
             for (int n = 0; n < NUM_STATE; ++n) {
                 U_new[n] = U_old[n];


### PR DESCRIPTION
we started at 1 and tested on nsub < MAX_NSUB instead of <= MAX_NSUB

closes #3258 

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
