### PR TITLE
fix loc center correction for hybrid momentum in old grav source

### DIFF
--- a/Source/gravity/Castro_gravity.cpp
+++ b/Source/gravity/Castro_gravity.cpp
@@ -375,8 +375,8 @@ void Castro::construct_old_gravity_source(MultiFab& source, MultiFab& state_in, 
 
 #ifdef HYBRID_MOMENTUM
             GpuArray<Real, 3> loc;
+            position(i, j, k, geomdata, loc);
             for (int n = 0; n < 3; ++n) {
-                position(i, j, k, geomdata, loc);
                 loc[n] -= problem::center[n];
             }
 


### PR DESCRIPTION
we were resetting it each loop iteration.  The new-gravity version was already done correctly.

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
