### PR TITLE
for post-step regrid, using the correct time in the error estimators

### DIFF
--- a/Source/driver/Castro.cpp
+++ b/Source/driver/Castro.cpp
@@ -3513,9 +3513,9 @@ Castro::errorEst (TagBoxArray& tags,
     for (const auto & etag : error_tags) {
         std::unique_ptr<MultiFab> mf;
         if (! etag.Field().empty()) {
-            mf = derive(etag.Field(), time, etag.NGrow());
+            mf = derive(etag.Field(), ltime, etag.NGrow());
         }
-        etag(tags, mf.get(), TagBox::CLEAR, TagBox::SET, time, level, geom);
+        etag(tags, mf.get(), TagBox::CLEAR, TagBox::SET, ltime, level, geom);
     }
 
     // Now we'll tag any user-specified zones using the full state array.


### PR DESCRIPTION
we should use ltime, which is correctly set depending on the value of `post_step_regrid`

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
