### PR TITLE
clarify test_composite_phi coarse level

### DIFF
--- a/Source/gravity/Gravity.cpp
+++ b/Source/gravity/Gravity.cpp
@@ -1266,6 +1266,9 @@ Gravity::test_composite_phi (int crse_level)
 {
     BL_PROFILE("Gravity::test_composite_phi()");
 
+    // the lhas only really been tested with crse_level = 0
+    AMREX_ALWAYS_ASSERT(crse_level == 0);
+
     if (gravity::verbose > 1 && ParallelDescriptor::IOProcessor()) {
         std::cout << "   " << '\n';
         std::cout << "... test_composite_phi at base level " << crse_level << '\n';
@@ -1306,7 +1309,7 @@ Gravity::test_composite_phi (int crse_level)
                         time);
 
     // Average residual from fine to coarse level before printing the norm
-    for (int amr_lev = finest_level_local-1; amr_lev >= 0; --amr_lev)
+    for (int amr_lev = finest_level_local-1; amr_lev >= crse_level; --amr_lev)
     {
         const IntVect& ratio = parent->refRatio(amr_lev);
         int ilev = amr_lev - crse_level;
@@ -1315,7 +1318,8 @@ Gravity::test_composite_phi (int crse_level)
     }
 
     for (int amr_lev = crse_level; amr_lev <= finest_level_local; ++amr_lev) {
-        Real resnorm = res[amr_lev]->norm0();
+        int ilev = amr_lev - crse_level;
+        Real resnorm = res[ilev]->norm0();
         amrex::Print() << "      ... norm of composite residual at level "
                        << amr_lev << "  " << resnorm << '\n';
     }


### PR DESCRIPTION
this adds an assert that we only call this with crse_level = 0 but also fixes some loop bounds to use crse_level in case we change things in the future (we will need further testing then)

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
