### PR TITLE
Set a maximum tagging radius for the SCF test

### DIFF
--- a/Exec/scf_tests/single_star/inputs_helm_nonrotating
+++ b/Exec/scf_tests/single_star/inputs_helm_nonrotating
@@ -27,6 +27,8 @@ amr.n_error_buf      = 2 2 2 2 2 0 0 0 0 0 0
 amr.blocking_factor  = 16
 amr.max_grid_size    = 32
 
+castro.max_tagging_radius = 0.6
+
 # WHICH PHYSICS
 castro.do_hydro = 1
 castro.do_grav  = 1

--- a/Exec/scf_tests/single_star/inputs_helm_nonrotating.test
+++ b/Exec/scf_tests/single_star/inputs_helm_nonrotating.test
@@ -27,6 +27,8 @@ amr.n_error_buf      = 2 2 2 2 2
 amr.blocking_factor  = 16
 amr.max_grid_size    = 32
 
+castro.max_tagging_radius = 0.6
+
 # WHICH PHYSICS
 castro.do_hydro = 1
 castro.do_grav  = 1

--- a/Exec/scf_tests/single_star/inputs_helm_rotating
+++ b/Exec/scf_tests/single_star/inputs_helm_rotating
@@ -1,12 +1,25 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
 max_step = 0
 
-# PROBLEM SIZE & GEOMETRY
+#if AMREX_SPACEDIM == 2
+
+geometry.coord_sys   =  1
+geometry.prob_lo     =  0.0   -1.6e9
+geometry.prob_hi     =  1.6e9  1.6e9
+amr.n_cell           =  64     128
+castro.lo_bc         =  3      2
+castro.hi_bc         =  2      2
+
+#elif AMREX_SPACEDIM == 3
+
 geometry.coord_sys   =  0
-geometry.is_periodic =  0 0 0
 geometry.prob_lo     = -1.6e9 -1.6e9 -1.6e9
 geometry.prob_hi     =  1.6e9  1.6e9  1.6e9
-amr.n_cell           =  128 128 128
+amr.n_cell           =  128    128    128
+castro.lo_bc         =  2      2      2
+castro.hi_bc         =  2      2      2
+
+#endif
 
 amr.max_level        = 0
 amr.ref_ratio        = 2 2 2 2 2 2 2 2 2 2 2
@@ -14,14 +27,7 @@ amr.n_error_buf      = 2 2 2 2 2 0 0 0 0 0 0
 amr.blocking_factor  = 16
 amr.max_grid_size    = 64
 
-# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
-# 0 = Interior           3 = Symmetry
-# 1 = Inflow             4 = SlipWall
-# 2 = Outflow            5 = NoSlipWall
-# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
-
-castro.lo_bc       =  2   2   2
-castro.hi_bc       =  2   2   2
+castro.max_tagging_radius = 0.6
 
 # WHICH PHYSICS
 castro.do_hydro = 1


### PR DESCRIPTION

## PR summary

Sets a maximum tagging radius for the SCF single star test so that the refined levels don't hit the ground boundary.

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
