### PR TITLE
add disable shock burning to reaction timestep limiter

### DIFF
--- a/Source/driver/timestep.H
+++ b/Source/driver/timestep.H
@@ -442,6 +442,14 @@ namespace timestep {
                     return {ValLocPair<Real, IntVect>{dt_tmp, idx}};
                 }
 
+                // Don't consider zones with shocks if we disabled
+                // burning in shocks
+#ifdef SHOCK_VAR
+                if (S(i,j,k,USHK) > 0.0_rt && disable_shock_burning == 1) {
+                    return {ValLocPair<Real, IntVect>{dt_tmp, idx}};
+                }
+#endif
+
                 Real e = burn_state.e;
                 Real X[NumSpec];
                 for (int n = 0; n < NumSpec; ++n) {

--- a/Source/driver/timestep.H
+++ b/Source/driver/timestep.H
@@ -445,7 +445,7 @@ namespace timestep {
                 // Don't consider zones with shocks if we disabled
                 // burning in shocks
 #ifdef SHOCK_VAR
-                if (S(i,j,k,USHK) > 0.0_rt && disable_shock_burning == 1) {
+                if (S(i,j,k,USHK) > 0.0_rt && castro::disable_shock_burning == 1) {
                     return {ValLocPair<Real, IntVect>{dt_tmp, idx}};
                 }
 #endif


### PR DESCRIPTION
we were not considering the fact that we are not burning in zones with a shock (if the shock variable is defined and disable_shock_burning is true).

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
