### PR TITLE
make the flame analysis scripts more robust to enuc = 0 at t = 0

### DIFF
--- a/Exec/science/flame/analysis/profiles.py
+++ b/Exec/science/flame/analysis/profiles.py
@@ -108,7 +108,8 @@ def doit(pfiles, limitlabels, xmin, xmax):
         ax_T.set_xlim(xmin, xmax)
 
     max_enuc = np.abs(enuc).max()
-    ax_e.set_yscale("symlog", linthresh=1.e-6 * max_enuc)
+    if max_enuc > 0:
+        ax_e.set_yscale("symlog", linthresh=1.e-6 * max_enuc)
     ax_e.set_ylabel(r"$S_\mathrm{nuc}$ (erg/g/s)")
 
     if xmax > 0:

--- a/Exec/science/flame/analysis/snapshot.py
+++ b/Exec/science/flame/analysis/snapshot.py
@@ -5,16 +5,13 @@
 import argparse
 import os
 import re
-import sys
 
 import matplotlib
 import matplotlib.ticker as mticker
 
 import numpy as np
-from cycler import cycler
 
 matplotlib.use('agg')
-import math
 
 import matplotlib.pyplot as plt
 import yt
@@ -57,6 +54,7 @@ def get_rTe_profile(plotfile):
     temp = np.array(ad['Temp'][srt])
     enuc = np.array(ad['enuc'][srt])
     return time, x_coord, density, temp, enuc
+
 
 def get_nuc_profile(plotfile):
 
@@ -124,10 +122,11 @@ def doit(pf, xmin, xmax, nuc_thresh):
         ax_e.set_xlim(xmin, xmax)
         ax_X.set_xlim(xmin, xmax)
 
-    ax_e.set_yscale("log")
+    if np.abs(enuc).max() > 0:
+        ax_e.set_yscale("log")
+        cur_lims = ax_e.get_ylim()
+        ax_e.set_ylim(1.e-10*cur_lims[-1], cur_lims[-1])
     ax_e.set_ylabel(r"$S_\mathrm{nuc}$ (erg/g/s)")
-    cur_lims = ax_e.get_ylim()
-    ax_e.set_ylim(1.e-10*cur_lims[-1], cur_lims[-1])
     ax_e.xaxis.set_major_formatter(mticker.ScalarFormatter(useMathText=True))
 
     ax_X.set_yscale("log")
@@ -153,7 +152,14 @@ def doit(pf, xmin, xmax, nuc_thresh):
     f.text(0.02, 0.005, f"t = {float(time):8.3f} s", transform=f.transFigure)
 
     prefix = os.getcwd().split("/")[-1]
-    time_str = f"{time:05.3f}s"
+    if time < 1.e-9:
+        time_str = f"{time/1.e-9:05.3f}ns"
+    elif time < 1.e-6:
+        time_str = f"{time/1.e-6:05.3f}us"
+    elif time < 1.e-3:
+        time_str = f"{time/1.e-3:05.3f}ms"
+    else:
+        time_str = f"{time:05.3f}s"
     f.savefig(f"snapshot_{prefix}_{pf}_{time_str}.png")
 
 


### PR DESCRIPTION
now we don't take the log if enuc = 0
also change the output filename for snapshot to use better units for small times

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
