### PR TITLE
remove obsolete comment in 4th order averaging about unit aspect cells

### DIFF
--- a/Source/hydro/fourth_center_average.cpp
+++ b/Source/hydro/fourth_center_average.cpp
@@ -3,9 +3,6 @@
 
 using namespace amrex;
 
-// Note: pretty much all of these routines below assume that dx(1) = dx(2) = dx(3)
-
-
 void
 Castro::make_cell_center(const Box& bx,
                          Array4<Real const> const& U,


### PR DESCRIPTION
all of the 4th order Laplacian routines work for dx != dy != dz

<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
