### PR TITLE
Fix double-counting of refined zones in perf stats when no subcycling

### DIFF
--- a/Source/driver/Castro_advance.cpp
+++ b/Source/driver/Castro_advance.cpp
@@ -649,7 +649,12 @@ Castro::finalize_advance()
     }
 #endif
 
-    // Record how many zones we have advanced.
+    // Each level is finalized separately, even when advanced together.
+    // Count only this level's zones in the cumulative performance statistic.
+
+    num_zones_advanced += static_cast<Real>(grids.numPts()) / static_cast<Real>(getLevel(0).grids.numPts());
+
+    // For the per-advance timing report, count all levels advanced together.
 
     int max_level_to_advance = level;
 
@@ -662,8 +667,6 @@ Castro::finalize_advance()
     for (int lev = level; lev <= max_level_to_advance; ++lev) {
         num_pts_advanced += getLevel(lev).grids.numPts();
     }
-
-    num_zones_advanced += static_cast<Real>(num_pts_advanced) / static_cast<Real>(getLevel(0).grids.numPts());
 
     Real wall_time = ParallelDescriptor::second() - wall_time_start;
 


### PR DESCRIPTION
<!-- Thank you for your PR!  Please provide a descriptive title above
and fill in the following fields as best you can. -->

<!-- Note: your PR should:

    * Target the development branch
    * Follow the style conventions here:
      https://amrex-astro.github.io/Castro/docs/coding_conventions.html  -->

## PR summary

<!-- Please summarize your PR here. We will squash merge this PR, so
     this summary should be suitable as the commit message. If the
     PR addresses any issues, reference them by issue # here as well. -->

## PR motivation

<!-- Please describe here the motivation for the PR, if appropriate.
     This section will not be included in the commit message, and can
     be used to communicate with the developers about why the PR should
     be accepted. This section is optional and can be deleted. -->

## PR checklist

- [ ] test suite needs to be run on this PR
- [ ] this PR will change answers in the test suite to more than roundoff level
- [ ] all newly-added functions have docstrings as per the coding conventions
- [ ] the `CHANGES` file has been updated, if appropriate
- [ ] if appropriate, this change is described in the docs
